### PR TITLE
Use valid_data instead of instance_state [10078]

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg
@@ -127,7 +127,7 @@ void $ctx.filename$Subscriber::SubListener::on_data_available(
 
     if (reader->take_next_sample(&st, &info) == ReturnCode_t::RETCODE_OK)
     {
-        if (info.instance_state == ALIVE)
+        if (info.valid_data)
         {
             // Print your structure data here.
             ++samples;


### PR DESCRIPTION
This PR makes the subscriber example code check for `valid_data` instead of `instance_state == ALIVE`.

This way, the example code follows the way suggested by the DDS standard.
