### PR TITLE
Use pragma once instead of not always unique header guards

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectHeader.stg
@@ -17,8 +17,7 @@ group TypeObjectHeader;
 main(ctx, definitions) ::= <<
 $fileHeader(file=[ctx.filename, "TypeObject.h"], description=["This header file contains the declaration of the described types in the IDL file."])$
 
-#ifndef _$ctx.headerGuardName$_TYPE_OBJECT_H_
-#define _$ctx.headerGuardName$_TYPE_OBJECT_H_
+#pragma once
 
 $ctx.directIncludeDependencies : {include | #include "$include$TypeObject.h"}; separator="\n"$
 
@@ -54,8 +53,6 @@ using namespace eprosima::fastrtps::types;
 eProsima_user_DllExport void register$ctx.filename$Types();
 
 $definitions; separator="\n"$
-
-#endif // _$ctx.headerGuardName$_TYPE_OBJECT_H_
 >>
 
 typedef_decl(ctx, parent, typedefs) ::= <<

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -17,8 +17,7 @@ group TypesHeader;
 main(ctx, definitions) ::= <<
 $fileHeader(file=[ctx.filename, ".h"], description=["This header file contains the declaration of the described types in the IDL file."])$
 
-#ifndef _$ctx.headerGuardName$_H_
-#define _$ctx.headerGuardName$_H_
+#pragma once
 
 $if(ctx.printexception)$
 #include <$ctx.product$/exceptions/UserException.h>
@@ -83,8 +82,6 @@ $endif$
 
 
 $definitions; separator="\n"$
-
-#endif // _$ctx.headerGuardName$_H_
 >>
 
 // TODO name -> module

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -18,8 +18,7 @@ main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.h"], description=["This header file contains the declaration of the serialization functions."])$
 
 
-#ifndef _$ctx.headerGuardName$_PUBSUBTYPES_H_
-#define _$ctx.headerGuardName$_PUBSUBTYPES_H_
+#pragma once
 
 #include <fastdds/dds/topic/TopicDataType.hpp>
 #include <fastrtps/utils/md5.h>
@@ -31,8 +30,6 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.h"], description=["This h
 #endif  // GEN_API_VER
 
 $definitions; separator="\n"$
-
-#endif // _$ctx.headerGuardName$_PUBSUBTYPES_H_
 >>
 
 // TODO name -> module

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg
@@ -18,8 +18,7 @@ main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Publisher.h"], description=["This header file contains the declaration of the publisher functions."])$
 
 
-#ifndef _$ctx.headerGuardName$_PUBLISHER_H_
-#define _$ctx.headerGuardName$_PUBLISHER_H_
+#pragma once
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
@@ -63,8 +62,6 @@ private:
     }
     listener_;
 };
-
-#endif // _$ctx.headerGuardName$_PUBLISHER_H_
 >>
 
 module(ctx, parent, module, definition_list) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg
@@ -18,8 +18,7 @@ main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Subscriber.h"], description=["This header file contains the declaration of the subscriber functions."])$
 
 
-#ifndef _$ctx.headerGuardName$_SUBSCRIBER_H_
-#define _$ctx.headerGuardName$_SUBSCRIBER_H_
+#pragma once
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
@@ -66,8 +65,6 @@ private:
     }
     listener_;
 };
-
-#endif // _$ctx.headerGuardName$_SUBSCRIBER_H_
 >>
 
 module(ctx, parent, module, definition_list) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationHeader.stg
@@ -17,14 +17,11 @@ group ProtocolHeader;
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Serialization.h"], description=["This file contains serialization definitions."])$
 
-#ifndef _$ctx.headerGuardName$_SERIALIZATION_H_
-#define _$ctx.headerGuardName$_SERIALIZATION_H_
+#pragma once
 
 #include "$ctx.filename$.h"
 
 $definitions; separator="\n"$
-
-#endif //_$ctx.headerGuardName$_SERIALIZATION_H_
 >>
 
 struct_type(ctx, parent, struct) ::= <<


### PR DESCRIPTION
Less standard, but far simpler solution to issues raised in issue #54.

Submitted as an alternate option for PR #65.