### PR TITLE
Basic Python bindings [12206]

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -17,39 +17,73 @@ group TypesSwigInterface;
 main(ctx, definitions) ::= <<
 $fileHeader(file=[ctx.filename, ".i"], description=["This header file contains the SWIG interface of the described types in the IDL file."])$
 
+%module $ctx.filename$
+
+// SWIG helper modules
+%include "std_string.i"
+%include "typemaps.i"
+
+// Assignemt operators are ignored, as there is no such thing in Python.
+// Trying to export them issues a warning
+%ignore *::operator=;
+
+$internal_types()$
+
+$fast_macro_declarations()$
+
 %{
 #include "$ctx.filename$.h"
 %}
 
-// Not sure if this must be AFTER the ignores and BEFORE the extends
-#include "$ctx.filename$.h"
-
 $definitions; separator="\n"$
+
+// Include the class interfaces
+%include "$ctx.filename$.h"
+
+// Include the corresponding TopicDataType
+%include "$ctx.filename$PubSubTypes.i"
 
 >>
 
 struct_type(ctx, parent, struct, extensions) ::= <<
+////////////////////////////////////////////////////////
+// Binding for class $struct.name$
+////////////////////////////////////////////////////////
+
 // Ignore overloaded methods that have no application on Python
 // Otherwise they will issue a warning
 %ignore $struct.name$::$struct.name$($struct.name$&&);
 
-// Field getter-setter methods do not map correctly to target languages
-// We better ignore it and extend to make the getter and setter methods explicit and break the overload
-$struct.members:{%ignore $struct.name$::$it.name$;}; separator="\n"$
+// Overloaded getter methods shadow each other and are equivalent in python
+// Avoid a warning ignoring all but one
+$struct.members : {$member_getters(struct_name=struct.name, member=it)$}; separator="\n"$
 
-// Add the explicit getter and setters
-%extend $struct.name$ {
-$struct.members:{$create_getter_setter(it)$}; separator="\n"$
-}
 >>
 
-create_getter_setter(member) ::= <<
-    $member.typecode.cppTypename$ get_$member.name$() const {
-        return \$self->$member.name$();
-    }
+member_getters(struct_name, member) ::= <<
+%ignore $struct_name$::$member.name$();
+%rename("%s") $struct_name$::$member.name$() const;
 
-    set_$member.name$($member.typecode.cppTypename$ _$member.name$) {
-        return \$self->$member.name$(_$member.name$);
-    }
+>>
+
+fast_macro_declarations() ::= <<
+// Macro delcarations
+// Any macro used on the Fast DDS header files will give an error if it is not redefined here
+#define RTPS_DllAPI
+#define eProsima_user_DllExport
+>>
+
+internal_types() ::= <<
+// Definition of internal types
+
+typedef char int8_t;
+typedef short int16_t;
+typedef long int32_t;
+typedef long long int64_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned long uint32_t;
+typedef unsigned long long uint64_t;
 
 >>

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -1,0 +1,55 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group TypesSwigInterface;
+
+main(ctx, definitions) ::= <<
+$fileHeader(file=[ctx.filename, ".i"], description=["This header file contains the SWIG interface of the described types in the IDL file."])$
+
+%{
+#include "$ctx.filename$.h"
+%}
+
+// Not sure if this must be AFTER the ignores and BEFORE the extends
+#include "$ctx.filename$.h"
+
+$definitions; separator="\n"$
+
+>>
+
+struct_type(ctx, parent, struct, extensions) ::= <<
+// Ignore overloaded methods that have no application on Python
+// Otherwise they will issue a warning
+%ignore $struct.name$::$struct.name$($struct.name$&&);
+
+// Field getter-setter methods do not map correctly to target languages
+// We better ignore it and extend to make the getter and setter methods explicit and break the overload
+$struct.members:{%ignore $struct.name$::$it.name$;}; separator="\n"$
+
+// Add the explicit getter and setters
+%extend $struct.name$ {
+$struct.members:{$create_getter_setter(it)$}; separator="\n"$
+}
+>>
+
+create_getter_setter(member) ::= <<
+    $member.typecode.cppTypename$ get_$member.name$() const {
+        return \$self->$member.name$();
+    }
+
+    set_$member.name$($member.typecode.cppTypename$ _$member.name$) {
+        return \$self->$member.name$(_$member.name$);
+    }
+
+>>

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -677,6 +677,11 @@ public class fastddsgen
                 ctx.setPackage(m_package);
             }
 
+            if (m_python)
+            {
+                tmanager.addGroup("TypesSwigInterface");
+            }
+
             // Create main template
             TemplateGroup maintemplates = tmanager.createTemplateGroup("main");
             maintemplates.setAttribute("ctx", ctx);
@@ -735,6 +740,12 @@ public class fastddsgen
                                     project.addCommonIncludeFile(ctx.getFilename() + "TypeObject.h");
                                     project.addCommonSrcFile(ctx.getFilename() + "TypeObject.cxx");
                                 }
+                            }
+                        }
+                        if(m_python) {
+                            System.out.println("Generating Swig interface files...");
+                            if (returnedValue = Utils.writeFile(m_outputDir + onlyFileName + ".i", maintemplates.getTemplate("TypesSwigInterface"), m_replace)) {
+
                             }
                         }
                     }

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -85,12 +85,6 @@ public class fastddsgen
     protected static String m_localAppProduct = "fastrtps";
     private ArrayList<String> m_includePaths = new ArrayList<String>();
 
-    private String m_command = null;
-    private String m_extra_command = null;
-    private ArrayList m_lineCommand = null;
-    private ArrayList m_lineCommandForWorkDirSet = null;
-    private String m_spTemplate = "main";
-
     private static VSConfiguration m_vsconfigurations[] = {
         new VSConfiguration("Debug DLL", "Win32", true, true),
         new VSConfiguration("Release DLL", "Win32", false, true),
@@ -99,7 +93,6 @@ public class fastddsgen
     };
 
     private String m_os = null;
-    private boolean m_local = false;
     private boolean fusion_ = false;
 
     //! Default package used in Java files.
@@ -256,10 +249,6 @@ public class fastddsgen
             {
                 printHelp();
                 System.exit(0);
-            }
-            else if (arg.equals("-local"))
-            {
-                m_local = true;
             }
             else if (arg.equals("-fusion"))
             {
@@ -536,7 +525,6 @@ public class fastddsgen
 
     public boolean globalInit()
     {
-        String dds_root = null, tao_root = null, fastrtps_root = null;
 
         // Set the temporary folder
         if (m_tempDir == null)
@@ -562,9 +550,6 @@ public class fastddsgen
         {
             m_tempDir += File.separator;
         }
-
-        // Set the line command
-        m_lineCommand = new ArrayList();
 
         return true;
     }

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -680,6 +680,7 @@ public class fastddsgen
             if (m_python)
             {
                 tmanager.addGroup("TypesSwigInterface");
+                tmanager.addGroup("DDSPubSubTypeSwigInterface");
             }
 
             // Create main template
@@ -786,6 +787,11 @@ public class fastddsgen
                         {
                             project.addProjectIncludeFile(ctx.getFilename() + "PubSubTypes.h");
                             project.addProjectSrcFile(ctx.getFilename() + "PubSubTypes.cxx");
+                            if(m_python)
+                            {
+                                System.out.println("Generating Swig interface files...");
+                                returnedValue = Utils.writeFile(m_outputDir + ctx.getFilename() + "PubSubTypes.i", maintemplates.getTemplate("DDSPubSubTypeSwigInterface"), m_replace);
+                            }
                         }
                     }
 

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -107,6 +107,9 @@ public class fastddsgen
     // Generate string and sequence types compatible with C?
     private boolean m_typesc = false;
 
+    // Generate python binding files
+    private boolean m_python = false;
+
     private boolean m_case_sensitive = false;
 
     // Testing
@@ -265,6 +268,10 @@ public class fastddsgen
             else if (arg.equals("-typesc"))
             {
                 m_typesc = true;
+            }
+            else if (arg.equals("-python"))
+            {
+                m_python = true;
             }
             else if (arg.equals("-test"))
             {
@@ -518,6 +525,7 @@ public class fastddsgen
         System.out.println(" dynamic.");
         System.out.println("\t\t-cs: IDL grammar apply case sensitive matching.");
         System.out.println("\t\t-test: executes FastDDSGen tests.");
+        System.out.println("\t\t-python: generates python bindings for the generated types.");
         System.out.println("\tand the supported input files are:");
         System.out.println("\t* IDL files.");
 

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -429,6 +429,10 @@ public class fastddsgen
                 }
             }
 
+            if (returnedValue && m_python) {
+                returnedValue = genSwigCMake(solution);
+            }
+
 
             // Generate solution
             if (returnedValue && (m_exampleOption != null) || m_test)
@@ -1186,9 +1190,24 @@ public class fastddsgen
             cmake.setAttribute("test", m_test);
 
             returnedValue = Utils.writeFile(m_outputDir + "CMakeLists.txt", cmake, m_replace);
+        }
+        return returnedValue;
+    }
+
+    private boolean genSwigCMake(Solution solution) {
+
+        boolean returnedValue = false;
+        StringTemplate swig = null;
+
+        StringTemplateGroup swigTemplates = StringTemplateGroup.loadGroup("SwigCMake", DefaultTemplateLexer.class, null);
+        if (swigTemplates != null) {
+            swig = swigTemplates.getInstanceOf("swig_cmake");
+
+            swig.setAttribute("solution", solution);
+
+            returnedValue = Utils.writeFile(m_outputDir + "CMakeLists.txt", swig, m_replace);
 
         }
-
         return returnedValue;
     }
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg
@@ -1,0 +1,31 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group ProtocolHeader;
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.i"], description=["This header file contains the SWIG interface of the serialization functions."])$
+
+%import(module="fastdds_wrapper") "fastdds/dds/topic/TopicDataType.hpp";
+
+%{
+#include "$ctx.filename$PubSubTypes.h"
+%}
+
+%include "$ctx.filename$PubSubTypes.h"
+
+>>
+
+struct_type(ctx, parent, struct) ::= <<
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -1,0 +1,109 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group SwigCMake;
+
+swig_cmake(solution) ::= <<
+
+cmake_minimum_required(VERSION 2.8.12)
+
+if(NOT CMAKE_VERSION VERSION_LESS 3.0)
+    cmake_policy(SET CMP0048 NEW)
+endif()
+
+# SWIG: use standard target name.
+if(POLICY CMP0078)
+  cmake_policy(SET CMP0078 NEW)
+endif()
+
+# SWIG: use SWIG_MODULE_NAME property.
+if(POLICY CMP0086)
+  cmake_policy(SET CMP0086 NEW)
+endif()
+
+$solution.projects : {$subproject_compiler(project=it)$}; separator="\n"$
+
+>>
+
+subproject_compiler(project) ::= <<
+###############################################################################
+# Library for types defined in $it.name$ IDL
+###############################################################################
+
+message(STATUS "Configuring python wrapper for types in $it.name$...")
+
+###############################################################################
+# Type library on C++
+
+project($it.name$)
+
+FIND_PACKAGE(fastcdr REQUIRED)
+FIND_PACKAGE(fastrtps REQUIRED)
+
+
+set(\${PROJECT_NAME}_FILES
+    $it.name$.cxx
+    $it.name$PubSubTypes.cxx
+    )
+
+INCLUDE_DIRECTORIES()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+#Create library for C++ types
+add_library(\${PROJECT_NAME} \${\${PROJECT_NAME}_FILES})
+target_link_libraries(\${PROJECT_NAME} PUBLIC fastcdr fastrtps)
+
+###############################################################################
+# Python bindings for type
+
+project($it.name$Wrapper)
+
+FIND_PACKAGE(SWIG REQUIRED)
+INCLUDE(\${SWIG_USE_FILE})
+SET(CMAKE_SWIG_FLAGS "")
+
+FIND_PACKAGE(PythonLibs REQUIRED)
+INCLUDE_DIRECTORIES(\${PYTHON_INCLUDE_PATH})
+
+FIND_PACKAGE(fastcdr REQUIRED)
+FIND_PACKAGE(fastrtps REQUIRED)
+
+set(\${PROJECT_NAME}_FILES
+    $it.name$.i
+    )
+
+SET_SOURCE_FILES_PROPERTIES(
+    \${\${PROJECT_NAME}_FILES}
+    PROPERTIES CPLUSPLUS ON
+    USE_TARGET_INCLUDE_DIRECTORIES TRUE
+    )
+
+INCLUDE_DIRECTORIES(
+    \${PROJECT_SOURCE_DIR}
+    )
+
+SWIG_ADD_LIBRARY(\${PROJECT_NAME} 
+    TYPE SHARED
+    LANGUAGE python 
+    SOURCES \${\${PROJECT_NAME}_FILES})
+
+SWIG_LINK_LIBRARIES(\${PROJECT_NAME}
+    \${PYTHON_LIBRARIES}
+    fastrtps
+    $it.name$
+    )
+
+>>
+

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -62,7 +62,7 @@ INCLUDE_DIRECTORIES()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #Create library for C++ types
-add_library(\${PROJECT_NAME} \${\${PROJECT_NAME}_FILES})
+add_library(\${PROJECT_NAME} SHARED \${\${PROJECT_NAME}_FILES})
 target_link_libraries(\${PROJECT_NAME} PUBLIC fastcdr fastrtps)
 
 ###############################################################################


### PR DESCRIPTION
This pull request adds support to generate Python binding files for the generated data types.
- Adds a new option '-python' that enables the generation of python binding files
- Each IDL file will result in a new python module that will contain all the data types defined in that IDL
- Creates a CMake file that enables the compilation and the generation of the binding using SWIG
- Only simple Structs with basic types are supported (no nested structs, no arrays or maps)
