### PR TITLE
comparison operators [12880]

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -262,6 +262,20 @@ public:
     eProsima_user_DllExport $struct.name$& operator =(
             $struct.name$&& x);
 
+    /*!
+     * @brief Comparison operator.
+     * @param x $struct.scopedname$ object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const $struct.name$& x);
+
+    /*!
+     * @brief Comparison operator.
+     * @param x $struct.scopedname$ object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const $struct.name$& x);
+
     $struct.members:{$public_member_declaration(it)$}; separator="\n"$
 
     $size_functions(struct)$
@@ -322,6 +336,20 @@ public:
      */
     eProsima_user_DllExport $union.name$& operator =(
             $union.name$&& x);
+
+    /*!
+     * @brief Comparison operator.
+     * @param x $union.scopedname$ object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const $union.name$& x);
+
+    /*!
+     * @brief Comparison operator.
+     * @param x $union.scopedname$ object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const $union.name$& x);
 
     /*!
      * @brief This function sets the discriminator value.
@@ -405,6 +433,20 @@ public:
      */
     eProsima_user_DllExport $bitset.name$& operator =(
             $bitset.name$&& x);
+
+    /*!
+     * @brief Comparison operator.
+     * @param x $bitset.scopedname$ object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const $bitset.name$& x);
+
+    /*!
+     * @brief Comparison operator.
+     * @param x $bitset.scopedname$ object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const $bitset.name$& x);
 
     $bitset.bitfields:{$public_bitfield_declaration(it)$}; separator="\n"$
 

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -260,6 +260,20 @@ $struct.scopedname$& $struct.scopedname$::operator =(
     return *this;
 }
 
+bool $struct.scopedname$::operator ==(
+        const $struct.name$& x)
+{
+    $if(struct.inheritances)$    $struct.inheritances : { if ($it.scopedname$::operator !=(x)) return false;}; separator="\n"$ $endif$
+
+    return ($struct.members:{m_$it.name$ == x.m_$it.name$}; separator=" && "$);
+}
+
+bool $struct.scopedname$::operator !=(
+        const $struct.name$& x)
+{
+    return !(*this == x);
+}
+
 $if(ctx.anyCdr)$
 size_t $struct.scopedname$::getMaxCdrSerializedSize(
         size_t current_alignment)
@@ -378,6 +392,20 @@ $bitset.scopedname$& $bitset.scopedname$::operator =(
     m_bitset = x.m_bitset;
 
     return *this;
+}
+
+bool $bitset.scopedname$::operator ==(
+        const $bitset.name$& x)
+{
+    $if(bitset.parents)$    $bitset.parents : { if ($it.scopedname$::operator !=(x)) return false;}; separator="\n"$ $endif$
+
+    return m_bitset == x.m_bitset;
+}
+
+bool $bitset.scopedname$::operator !=(
+        const $bitset.name$& x)
+{
+    return !(*this == x);
 }
 
 $if(ctx.anyCdr)$
@@ -555,6 +583,27 @@ $union.scopedname$& $union.scopedname$::operator =(
     }
 
     return *this;
+}
+
+bool $union.scopedname$::operator ==(
+        const $union.name$& x)
+{
+    if (m__d != x.m__d)
+    {
+        return false;
+    }
+
+    switch(m__d)
+    {
+        $union.members:{$unionmember_compare(it)$}; separator="\n"$
+        $unionmemberdefault_compare(union.defaultMember)$
+    }
+}
+
+bool $union.scopedname$::operator !=(
+        const $union.name$& x)
+{
+    return !(*this == x);
 }
 
 void $union.scopedname$::_d(
@@ -974,6 +1023,25 @@ m_$member.name$ = x.m_$member.name$;
 $else$
 m_$member.name$ = std::move(x.m_$member.name$);
 $endif$
+$endif$
+$endif$
+
+break;
+>>
+
+unionmember_compare(member) ::= <<
+$if(member.labels)$
+$member.labels:{case $it$:}; separator="\n"$
+    return (m_$it.name$ == x.m_$it.name$);
+    break;
+$endif$
+>>
+
+unionmemberdefault_compare(member) ::= <<
+default:
+$if(member)$
+$if(member.default)$
+return m_$member.name$ == x.m_$member.name$;
 $endif$
 $endif$
 


### PR DESCRIPTION
**IMPORTANT:** Merge after #75 
The only relevant changes are on the last commit (0ceb2d9), the rest is part of PR #75 

Adds comparison operators `operator==()` and `operator!=()` to the generated classes.
