### PR TITLE
Added return statement to Union comparison operator

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -598,6 +598,7 @@ bool $union.scopedname$::operator ==(
         $union.members:{$unionmember_compare(it)$}; separator="\n"$
         $unionmemberdefault_compare(union.defaultMember)$
     }
+    return false;
 }
 
 bool $union.scopedname$::operator !=(


### PR DESCRIPTION
Prevents a _control reaches end of non-void function_ warning for Union equality comparisons.

Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>