### PR TITLE
[13333] Modified Compilation guards and comparison operator generation

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectHeader.stg
@@ -17,8 +17,8 @@ group TypeObjectHeader;
 main(ctx, definitions) ::= <<
 $fileHeader(file=[ctx.filename, "TypeObject.h"], description=["This header file contains the declaration of the described types in the IDL file."])$
 
-#ifndef _$ctx.headerGuardName$_TYPE_OBJECT_H_
-#define _$ctx.headerGuardName$_TYPE_OBJECT_H_
+#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_TYPE_OBJECT_H_
+#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_TYPE_OBJECT_H_
 
 $ctx.directIncludeDependencies : {include | #include "$include$TypeObject.h"}; separator="\n"$
 
@@ -55,7 +55,7 @@ eProsima_user_DllExport void register$ctx.filename$Types();
 
 $definitions; separator="\n"$
 
-#endif // _$ctx.headerGuardName$_TYPE_OBJECT_H_
+#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_TYPE_OBJECT_H_
 >>
 
 typedef_decl(ctx, parent, typedefs) ::= <<

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -17,8 +17,8 @@ group TypesHeader;
 main(ctx, definitions) ::= <<
 $fileHeader(file=[ctx.filename, ".h"], description=["This header file contains the declaration of the described types in the IDL file."])$
 
-#ifndef _$ctx.headerGuardName$_H_
-#define _$ctx.headerGuardName$_H_
+#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_H_
+#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_H_
 
 $if(ctx.printexception)$
 #include <$ctx.product$/exceptions/UserException.h>
@@ -84,7 +84,7 @@ $endif$
 
 $definitions; separator="\n"$
 
-#endif // _$ctx.headerGuardName$_H_
+#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_H_
 >>
 
 // TODO name -> module
@@ -267,14 +267,14 @@ public:
      * @param x $struct.scopedname$ object to compare.
      */
     eProsima_user_DllExport bool operator ==(
-            const $struct.name$& x);
+            const $struct.name$& x) const;
 
     /*!
      * @brief Comparison operator.
      * @param x $struct.scopedname$ object to compare.
      */
     eProsima_user_DllExport bool operator !=(
-            const $struct.name$& x);
+            const $struct.name$& x) const;
 
     $struct.members:{$public_member_declaration(it)$}; separator="\n"$
 
@@ -342,14 +342,14 @@ public:
      * @param x $union.scopedname$ object to compare.
      */
     eProsima_user_DllExport bool operator ==(
-            const $union.name$& x);
+            const $union.name$& x) const;
 
     /*!
      * @brief Comparison operator.
      * @param x $union.scopedname$ object to compare.
      */
     eProsima_user_DllExport bool operator !=(
-            const $union.name$& x);
+            const $union.name$& x) const;
 
     /*!
      * @brief This function sets the discriminator value.
@@ -439,14 +439,14 @@ public:
      * @param x $bitset.scopedname$ object to compare.
      */
     eProsima_user_DllExport bool operator ==(
-            const $bitset.name$& x);
+            const $bitset.name$& x) const;
 
     /*!
      * @brief Comparison operator.
      * @param x $bitset.scopedname$ object to compare.
      */
     eProsima_user_DllExport bool operator !=(
-            const $bitset.name$& x);
+            const $bitset.name$& x) const;
 
     $bitset.bitfields:{$public_bitfield_declaration(it)$}; separator="\n"$
 

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -261,7 +261,7 @@ $struct.scopedname$& $struct.scopedname$::operator =(
 }
 
 bool $struct.scopedname$::operator ==(
-        const $struct.name$& x)
+        const $struct.name$& x) const
 {
     $if(struct.inheritances)$    $struct.inheritances : { if ($it.scopedname$::operator !=(x)) return false;}; separator="\n"$ $endif$
 
@@ -269,7 +269,7 @@ bool $struct.scopedname$::operator ==(
 }
 
 bool $struct.scopedname$::operator !=(
-        const $struct.name$& x)
+        const $struct.name$& x) const
 {
     return !(*this == x);
 }
@@ -395,7 +395,7 @@ $bitset.scopedname$& $bitset.scopedname$::operator =(
 }
 
 bool $bitset.scopedname$::operator ==(
-        const $bitset.name$& x)
+        const $bitset.name$& x) const
 {
     $if(bitset.parents)$    $bitset.parents : { if ($it.scopedname$::operator !=(x)) return false;}; separator="\n"$ $endif$
 
@@ -403,7 +403,7 @@ bool $bitset.scopedname$::operator ==(
 }
 
 bool $bitset.scopedname$::operator !=(
-        const $bitset.name$& x)
+        const $bitset.name$& x) const
 {
     return !(*this == x);
 }
@@ -586,7 +586,7 @@ $union.scopedname$& $union.scopedname$::operator =(
 }
 
 bool $union.scopedname$::operator ==(
-        const $union.name$& x)
+        const $union.name$& x) const
 {
     if (m__d != x.m__d)
     {
@@ -602,7 +602,7 @@ bool $union.scopedname$::operator ==(
 }
 
 bool $union.scopedname$::operator !=(
-        const $union.name$& x)
+        const $union.name$& x) const
 {
     return !(*this == x);
 }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -18,8 +18,8 @@ main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.h"], description=["This header file contains the declaration of the serialization functions."])$
 
 
-#ifndef _$ctx.headerGuardName$_PUBSUBTYPES_H_
-#define _$ctx.headerGuardName$_PUBSUBTYPES_H_
+#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBSUBTYPES_H_
+#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBSUBTYPES_H_
 
 #include <fastdds/dds/topic/TopicDataType.hpp>
 #include <fastrtps/utils/md5.h>
@@ -27,12 +27,13 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.h"], description=["This h
 #include "$ctx.filename$.h"
 
 #if !defined(GEN_API_VER) || (GEN_API_VER != 1)
-#error Generated $ctx.filename$ is not compatible with current installed Fast DDS. Please, regenerate it with fastddsgen.
+#error \
+    Generated $ctx.filename$ is not compatible with current installed Fast DDS. Please, regenerate it with fastddsgen.
 #endif  // GEN_API_VER
 
 $definitions; separator="\n"$
 
-#endif // _$ctx.headerGuardName$_PUBSUBTYPES_H_
+#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBSUBTYPES_H_
 >>
 
 // TODO name -> module

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg
@@ -18,8 +18,8 @@ main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Publisher.h"], description=["This header file contains the declaration of the publisher functions."])$
 
 
-#ifndef _$ctx.headerGuardName$_PUBLISHER_H_
-#define _$ctx.headerGuardName$_PUBLISHER_H_
+#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBLISHER_H_
+#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBLISHER_H_
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
@@ -64,7 +64,7 @@ private:
     listener_;
 };
 
-#endif // _$ctx.headerGuardName$_PUBLISHER_H_
+#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBLISHER_H_
 >>
 
 module(ctx, parent, module, definition_list) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg
@@ -18,8 +18,8 @@ main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Subscriber.h"], description=["This header file contains the declaration of the subscriber functions."])$
 
 
-#ifndef _$ctx.headerGuardName$_SUBSCRIBER_H_
-#define _$ctx.headerGuardName$_SUBSCRIBER_H_
+#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_SUBSCRIBER_H_
+#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_SUBSCRIBER_H_
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
@@ -67,7 +67,7 @@ private:
     listener_;
 };
 
-#endif // _$ctx.headerGuardName$_SUBSCRIBER_H_
+#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_SUBSCRIBER_H_
 >>
 
 module(ctx, parent, module, definition_list) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationHeader.stg
@@ -17,14 +17,14 @@ group ProtocolHeader;
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Serialization.h"], description=["This file contains serialization definitions."])$
 
-#ifndef _$ctx.headerGuardName$_SERIALIZATION_H_
-#define _$ctx.headerGuardName$_SERIALIZATION_H_
+#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_SERIALIZATION_H_
+#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_SERIALIZATION_H_
 
 #include "$ctx.filename$.h"
 
 $definitions; separator="\n"$
 
-#endif //_$ctx.headerGuardName$_SERIALIZATION_H_
+#endif //_FAST_DDS_GENERATED_$ctx.headerGuardName$_SERIALIZATION_H_
 >>
 
 struct_type(ctx, parent, struct) ::= <<


### PR DESCRIPTION
Added _FAST_DDS_GENERATED_ to prevent guards overlapping for some common types and words.

Added const keyword to equality and non-equality operators