### PR TITLE
Make <>PubSubType::deserialize safer [13941]

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -119,21 +119,21 @@ bool $if (parent.IsInterface)$$parent.name$_$endif$$struct.name$PubSubType::dese
         SerializedPayload_t* payload,
         void* data)
 {
-    //Convert DATA to pointer of your type
-    $if (parent.IsInterface)$$struct.scopedname$$else$$struct.name$$endif$* p_type = static_cast<$if (parent.IsInterface)$$struct.scopedname$$else$$struct.name$$endif$*>(data);
-
-    // Object that manages the raw buffer.
-    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->length);
-
-    // Object that deserializes the data.
-    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
-
-    // Deserialize encapsulation.
-    deser.read_encapsulation();
-    payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-
     try
     {
+        //Convert DATA to pointer of your type
+        $if (parent.IsInterface)$$struct.scopedname$$else$$struct.name$$endif$* p_type = static_cast<$if (parent.IsInterface)$$struct.scopedname$$else$$struct.name$$endif$*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
         // Deserialize the object.
         p_type->deserialize(deser);
     }


### PR DESCRIPTION
This PR makes the generated `<>PubSubType::deserialize` safer by catching the `NotEnoughMemoryException` that `Cdr::read_encapsulation()` may throw

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>