### PR TITLE
[14455] Support ROS2 compatible topic naming (#111)

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -527,7 +527,7 @@ public class fastddsgen
         System.out.println("\t\t-replace: replaces existing generated files.");
         System.out.println("\t\t-ppDisable: disables the preprocessor.");
         System.out.println("\t\t-ppPath: specifies the preprocessor path.");
-        System.out.println("\t\t-typeros2: generates type naming compatible with ROS2.");
+        System.out.println("\t\t-typeros2: generates type naming and topics compatible with ROS2.");
         System.out.println("\t\t-I <path>: add directory to preprocessor include paths.");
         System.out.println("\t\t-d <path>: sets an output directory for generated files.");
         System.out.println("\t\t-t <temp dir>: sets a specific directory as a temporary directory.");

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherSource.stg
@@ -83,7 +83,7 @@ bool $ctx.filename$Publisher::init()
 
     //CREATE THE TOPIC
     topic_ = participant_->create_topic(
-        "$ctx.filename$Topic",
+        "$if (ctx.GenerateTypesROS2)$rt/$endif$$ctx.filename$Topic",
         type_.get_type_name(),
         TOPIC_QOS_DEFAULT);
     if (topic_ == nullptr)

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg
@@ -77,7 +77,7 @@ bool $ctx.filename$Subscriber::init()
 
     //CREATE THE TOPIC
     topic_ = participant_->create_topic(
-        "$ctx.filename$Topic",
+        "$if (ctx.GenerateTypesROS2)$rt/$endif$$ctx.filename$Topic",
         type_.get_type_name(),
         TOPIC_QOS_DEFAULT);
     if (topic_ == nullptr)


### PR DESCRIPTION
This adds the prefixes to topic names such the topics can communicate with a ROS2 node; it will also show up in a command line call of `ros2 topic list`