### PR TITLE
Generated operator== not compiling for inherited structs with no members

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -265,7 +265,7 @@ bool $struct.scopedname$::operator ==(
 {
     $if(struct.inheritances)$    $struct.inheritances : { if ($it.scopedname$::operator !=(x)) return false;}; separator="\n"$ $endif$
 
-    return ($struct.members:{m_$it.name$ == x.m_$it.name$}; separator=" && "$);
+    $if(struct.members)$    return ($struct.members:{m_$it.name$ == x.m_$it.name$}; separator=" && "$); $else$    return true; $endif$
 }
 
 bool $struct.scopedname$::operator !=(


### PR DESCRIPTION
We have some structs in our IDL that inherit from base structs that have no members, eg:

```
struct Base
{
	long id; //@key
};		
		
struct Derived : Base
};
```

In this case the the operator== does not compile since the final return statement is invalid. I have proposed a modification in this will just return true if the derived struct does not have any members. Please note that non inheriting structs without members will still probably cause invalid syntax to be generated.

Of course, redo the grammar in your preferred style. Thanks.