### PR TITLE
[14671] Fix generated code for bounded strings

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -94,8 +94,21 @@ $else$
     scdr << temp_$object.name$;
 }
 $endif$
+$elseif(object.typecode.contentTypeCode.isBounded)$
+{
+$if(object.typecode.isType_e)$
+    scdr << static_cast<uint32_t>($preffix$$object.name$.size());
+$endif$
+
+    for (const auto& item : $preffix$$object.name$)
+    {
+        scdr << item.c_str();
+    }
+}
+
 $else$
 scdr << $serializeCasting(typecode=object.typecode)$$preffix$$object.name$;
+
 $endif$
 >>
 

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -50,7 +50,7 @@ $elseif(object.typecode.isType_e)$
 $object_map_seq_serialization(ctx=ctx, object=object, preffix=preffix)$
 
 $else$
-scdr << $serializeCasting(typecode=object.typecode)$$preffix$$object.name$;
+scdr << $serializeCasting(typecode=object.typecode)$$preffix$$object.name$$if(object.typecode.isType_d)$.c_str()$endif$;
 
 $endif$
 >>
@@ -511,6 +511,16 @@ $if(typecode.isStringType)$
     free($preffix$$name$);
     $preffix$$name$ = (char*)malloc(aux.size() + 1);
     strncpy($preffix$$name$, aux.c_str(), aux.size() + 1);
+}
+$else$
+dcdr \>> $if(typecode.forwarded)$*$endif$$preffix$$name$;
+$endif$
+$elseif(typecode.isStringType)$
+$if(typecode.isBounded)$
+{
+    std::string aux;
+    dcdr \>> aux;
+    $if(typecode.forwarded)$*$endif$$preffix$$name$ = aux.c_str();
 }
 $else$
 dcdr \>> $if(typecode.forwarded)$*$endif$$preffix$$name$;

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -198,6 +198,22 @@ $else$
     }
 }
 $endif$
+$elseif(object.typecode.contentTypeCode.isBounded)$
+{
+$if(object.typecode.isType_e)$
+    uint32_t sequence_size = 0;
+    dcdr \>> sequence_size;
+    $preffix$$object.name$$if(object.typecode.forwarded)$->$else$.$endif$resize(sequence_size);
+$endif$
+
+    for (auto& item : $if(object.typecode.forwarded)$*$endif$$preffix$$object.name$)
+    {
+        std::string s;
+        dcdr \>> s;
+        item = s.c_str();
+    }
+}
+
 $else$
 dcdr \>> $preffix$$object.name$;
 $endif$

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -77,10 +77,10 @@ $endif$
 >>
 
 string_collection_serialization(ctx, object, preffix, array) ::= <<
-$if(ctx.generateTypesC)$
 $if(object.typecode.isType_f)$
-$recursive_string_array_serialization(ctx=ctx, name=cdrMemberName(name=object.name, preffix=preffix),  loopvar=ctx.nextLoopVarName, dims=object.typecode.dimensions)$
-$elseif(object.typecode.isType_e)$
+$recursive_string_array_serialization(ctx=ctx, name=cdrMemberName(name=object.name, preffix=preffix),  loopvar=ctx.nextLoopVarName, dims=object.typecode.dimensions, object=object)$
+$elseif(ctx.generateTypesC)$
+$if(object.typecode.isType_e)$
 {
     scdr << $preffix$$object.name$;
 }
@@ -94,6 +94,7 @@ $else$
     scdr << temp_$object.name$;
 }
 $endif$
+
 $elseif(object.typecode.contentTypeCode.isStringType)$
 $if(object.typecode.contentTypeCode.isBounded)$
 {
@@ -117,17 +118,23 @@ scdr << $serializeCasting(typecode=object.typecode)$$preffix$$object.name$;
 $endif$
 >>
 
-recursive_string_array_serialization(ctx, name, loopvar, dims) ::= <<
+recursive_string_array_serialization(ctx, name, loopvar, dims, object) ::= <<
 $if(rest(dims))$
 for (uint32_t $loopvar$ = 0; $loopvar$ < $name$.size(); ++$loopvar$)
 {
-    $recursive_string_array_serialization(ctx=ctx, name=cdrIndexName(name=name,loopvar=loopvar),  loopvar=ctx.nextLoopVarName, dims=rest(dims))$
+    $recursive_string_array_serialization(ctx=ctx, name=cdrIndexName(name=name,loopvar=loopvar),  loopvar=ctx.nextLoopVarName, dims=rest(dims), object=object)$
 }
-$else$
+$elseif(ctx.generateTypesC)$
 for (char* str : $name$)
 {
     scdr << std::string(str != nullptr ? str : "");
 }
+$else$
+for (const auto& str : $name$)
+{
+    scdr << str$if(object.typecode.contentTypeCode.isStringType)$.c_str()$endif$;
+}
+
 $endif$
 >>
 

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -185,10 +185,10 @@ $endif$
 >>
 
 string_collection_deserialization(ctx, object, preffix) ::= <<
-$if(ctx.generateTypesC)$
 $if(object.typecode.isType_f)$
-$recursive_string_array_deserialization(ctx=ctx, name=cdrMemberName(name=object.name, preffix=preffix),  loopvar=ctx.nextLoopVarName, dims=object.typecode.dimensions)$
-$elseif(object.typecode.isType_e)$
+$recursive_string_array_deserialization(ctx=ctx, name=cdrMemberName(name=object.name, preffix=preffix),  loopvar=ctx.nextLoopVarName, dims=object.typecode.dimensions, object=object)$
+$elseif(ctx.generateTypesC)$
+$if(object.typecode.isType_e)$
 {
     dcdr \>> $preffix$$object.name$;
 }
@@ -235,13 +235,13 @@ dcdr \>> $preffix$$object.name$;
 $endif$
 >>
 
-recursive_string_array_deserialization(ctx, name, loopvar, dims) ::= <<
+recursive_string_array_deserialization(ctx, name, loopvar, dims, object) ::= <<
 $if(rest(dims))$
 for (uint32_t $loopvar$ = 0; $loopvar$ < $name$.size(); ++$loopvar$)
 {
-    $recursive_string_array_deserialization(ctx=ctx, name=cdrIndexName(name=name,loopvar=loopvar),  loopvar=ctx.nextLoopVarName, dims=rest(dims))$
+    $recursive_string_array_deserialization(ctx=ctx, name=cdrIndexName(name=name,loopvar=loopvar),  loopvar=ctx.nextLoopVarName, dims=rest(dims), object=object)$
 }
-$else$
+$elseif(ctx.generateTypesC)$
 // Free old memory allocation
 for (char* str : $name$)
 {
@@ -256,7 +256,27 @@ for (uint32_t index = 0; index < $name$.size(); ++index)
     strncpy(aux, str.c_str(), str.size() + 1);
     $name$[index] = aux;
 }
-$endif$>>
+$else$
+for (auto& str : $name$)
+{
+$if(object.typecode.contentTypeCode.isStringType)$
+$if(object.typecode.contentTypeCode.isBounded)$
+    {
+        std::string aux_str;
+        dcdr \>> aux_str;
+        str = aux_str.c_str();
+    }
+
+$else$
+    dcdr \>> str;
+$endif$
+$else$
+    dcdr \>> str;
+$endif$
+}
+
+$endif$
+>>
 
 bitfield_deserialization(ctx, object) ::= <<$if(member.name)$$member.spec.cppTypename$ aux_$member.name$;
 dcdr \>> aux_$member.name$;

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -50,7 +50,7 @@ $elseif(object.typecode.isType_e)$
 $object_map_seq_serialization(ctx=ctx, object=object, preffix=preffix)$
 
 $else$
-scdr << $serializeCasting(typecode=object.typecode)$$preffix$$object.name$$if(object.typecode.isType_d)$.c_str()$endif$;
+scdr << $serializeCasting(typecode=object.typecode)$$preffix$$object.name$$if(object.typecode.isStringType)$.c_str()$endif$;
 
 $endif$
 >>
@@ -94,7 +94,8 @@ $else$
     scdr << temp_$object.name$;
 }
 $endif$
-$elseif(object.typecode.contentTypeCode.isBounded)$
+$elseif(object.typecode.contentTypeCode.isStringType)$
+$if(object.typecode.contentTypeCode.isBounded)$
 {
 $if(object.typecode.isType_e)$
     scdr << static_cast<uint32_t>($preffix$$object.name$.size());
@@ -106,6 +107,10 @@ $endif$
     }
 }
 
+$else$
+scdr << $serializeCasting(typecode=object.typecode)$$preffix$$object.name$;
+
+$endif$
 $else$
 scdr << $serializeCasting(typecode=object.typecode)$$preffix$$object.name$;
 
@@ -198,7 +203,8 @@ $else$
     }
 }
 $endif$
-$elseif(object.typecode.contentTypeCode.isBounded)$
+$elseif(object.typecode.contentTypeCode.isStringType)$
+$if(object.typecode.contentTypeCode.isBounded)$
 {
 $if(object.typecode.isType_e)$
     uint32_t sequence_size = 0;
@@ -214,6 +220,9 @@ $endif$
     }
 }
 
+$else$
+dcdr \>> $preffix$$object.name$;
+$endif$
 $else$
 dcdr \>> $preffix$$object.name$;
 $endif$

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -26,6 +26,8 @@ $endif$
 
 $ctx.directIncludeDependencies : {include | #include "$include$.h"}; separator="\n"$
 
+#include <fastrtps/utils/fixed_size_string.hpp>
+
 #include <stdint.h>
 #include <array>
 #include <string>


### PR DESCRIPTION
This PR changes the generated code for bounded strings, so `eprosima::fastrtps::fixed_string<N>` is used instead of `std::string`

Depends on eProsima/IDL-Parser#53