### PR TITLE
Support for generating recursive structures [15347]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,11 @@ jar {
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     archiveBaseName = 'fastddsgen'
     manifest {
-        attributes("Created-By": "eProsima", "Main-Class": "com.eprosima.fastdds.fastddsgen")
+        attributes(
+            "Created-By": "eProsima",
+            "Main-Class": "com.eprosima.fastdds.fastddsgen",
+            "Class-Path": configurations.runtimeClasspath.collect { it.getName() }.join(' ')
+            )
     }
     doLast
     {

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -280,6 +280,17 @@ public:
 
     $struct.members:{$public_member_declaration(it)$}; separator="\n"$
 
+    $if(ctx.anyCdr)$
+    /*!
+    * @brief This function returns the maximum serialized size of an object
+    * depending on the buffer alignment.
+    * @param current_alignment Buffer alignment.
+    * @return Maximum serialized size.
+    */
+    eProsima_user_DllExport static size_t getMaxCdrSerializedSize(
+            size_t current_alignment = 0);
+    $endif$
+
     $size_functions(struct)$
 
     $serialization_functions(struct)$
@@ -289,6 +300,7 @@ public:
 private:
 
     $struct.members:{$private_member_declaration(member=it)$}; separator="\n"$
+
 };
 >>
 
@@ -698,15 +710,6 @@ $typecode.cppTypename$$if(typecode.forwarded)$*$endif$ m_$name$;
 
 size_functions(type) ::= <<
 $if(ctx.anyCdr)$
-/*!
- * @brief This function returns the maximum serialized size of an object
- * depending on the buffer alignment.
- * @param current_alignment Buffer alignment.
- * @return Maximum serialized size.
- */
-eProsima_user_DllExport static size_t getMaxCdrSerializedSize(
-        size_t current_alignment = 0);
-
 /*!
  * @brief This function returns the serialized size of a data depending on the buffer alignment.
  * @param data Data which is calculated its serialized size.

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -14,7 +14,7 @@
 
 group TypesSource;
 
-main(ctx, definitions) ::= <<
+main(ctx, definitions, extensions) ::= <<
 $fileHeader(file=[ctx.filename, ".cpp"], description=["This source file contains the definition of the described types in the IDL file."])$
 
 #ifdef _WIN32
@@ -48,6 +48,7 @@ $if(ctx.anyCdr)$
 $ctx.types:{ type | $if(type.typeCode.isStructType)$#define $type.typeCode.cScopedname$_max_cdr_typesize $type.typeCode.maxSerializedSize$ULL;$endif$}; separator="\n"$
 $endif$
 
+$extensions : {$it$}; separator="\n"$
 
 $if(ctx.generateTypesC)$
 $ctx.typeCodesToDefine : {

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -44,6 +44,11 @@ using namespace eprosima::fastcdr::exception;
 
 #include <utility>
 
+$if(ctx.anyCdr)$
+$ctx.types:{ type | $if(type.typeCode.isStructType)$#define $type.typeCode.cScopedname$_max_cdr_typesize $type.typeCode.maxSerializedSize$ULL;$endif$}; separator="\n"$
+$endif$
+
+
 $if(ctx.generateTypesC)$
 $ctx.typeCodesToDefine : {
 $sequences_definition(it.value)$
@@ -98,17 +103,17 @@ $exception.scopedname$::$exception.name$(
 $exception.scopedname$& $exception.scopedname$::operator =(
         const $exception.name$& x)
 {
-	UserException::operator =(x);
+    UserException::operator =(x);
     $exception.members : { member |$member_copy(ctx=ctx, member=member)$}; separator="\n"$
-	return *this;
+    return *this;
 }
 
 $exception.scopedname$& $exception.scopedname$::operator =(
         $exception.name$&& x)
 {
-	UserException::operator =(std::move(x));
-	$exception.members : { member |$member_move(member=member)$}; separator="\n"$
-	return *this;
+    UserException::operator =(std::move(x));
+    $exception.members : { member |$member_move(member=member)$}; separator="\n"$
+    return *this;
 }
 
 $exception.scopedname$::~$exception.name$() throw()
@@ -118,20 +123,10 @@ $exception.scopedname$::~$exception.name$() throw()
 
 void $exception.scopedname$::raise() const
 {
-	throw *this;
+    throw *this;
 }
 
 $if(ctx.anyCdr)$
-size_t $exception.scopedname$::getMaxCdrSerializedSize(
-        size_t current_alignment)
-{
-    size_t initial_alignment = current_alignment;
-
-    $exception.members : { member |$max_serialized_size(ctx=ctx, typecode=member.typecode, var="current_alignment")$}; separator="\n"$
-
-    return current_alignment - initial_alignment;
-}
-
 size_t $exception.scopedname$::getCdrSerializedSize(
         const $exception.scopedname$& data,
         size_t current_alignment)
@@ -278,13 +273,7 @@ $if(ctx.anyCdr)$
 size_t $struct.scopedname$::getMaxCdrSerializedSize(
         size_t current_alignment)
 {
-    size_t initial_alignment = current_alignment;
-
-    $if(struct.inheritances)$    $struct.inheritances : {current_alignment += $it.scopedname$::getMaxCdrSerializedSize(current_alignment);}; separator="\n"$ $endif$
-
-    $struct.members : { member | $if(!member.annotationNonSerialized)$$max_serialized_size(ctx=ctx, typecode=member.typecode, var="current_alignment")$$endif$}; separator="\n"$
-
-    return current_alignment - initial_alignment;
+    return $struct.cScopedname$_max_cdr_typesize;
 }
 
 size_t $struct.scopedname$::getCdrSerializedSize(
@@ -409,18 +398,6 @@ bool $bitset.scopedname$::operator !=(
 }
 
 $if(ctx.anyCdr)$
-size_t $bitset.scopedname$::getMaxCdrSerializedSize(
-        size_t current_alignment)
-{
-    size_t initial_alignment = current_alignment;
-
-    $if(bitset.parents)$    $bitset.parents : {current_alignment += $it.scopedname$::getMaxCdrSerializedSize(current_alignment);}; separator="\n"$ $endif$
-
-    $bitset.bitfields : { member | $if(!member.annotationNonSerialized)$$if(member.name)$$max_serialized_size(ctx=ctx, typecode=member.spec.typecode, var="current_alignment")$$endif$$endif$}; separator="\n"$
-
-    return current_alignment - initial_alignment;
-}
-
 size_t $bitset.scopedname$::getCdrSerializedSize(
         const $bitset.scopedname$& $if(bitset.parents)$data$endif$,
         size_t current_alignment)
@@ -638,28 +615,6 @@ $union.discriminator.cppTypename$& $union.scopedname$::_d()
 $union.members:{$public_unionmember_declaration(class=union.scopedname, member=it, defaultvalue=union.defaultvalue, totallabels=union.totallabels)$}; separator="\n"$
 
 $if(ctx.anyCdr)$
-size_t $union.scopedname$::getMaxCdrSerializedSize(
-        size_t current_alignment)
-{
-    size_t initial_alignment = current_alignment;
-    size_t reset_alignment = 0;
-    size_t union_max_size_serialized = 0;
-
-    $max_serialized_size(ctx=ctx, typecode=union.discriminator, var="current_alignment")$
-
-    $union.members : { member |
-    reset_alignment = current_alignment;
-
-    $max_serialized_size(ctx=ctx, typecode=member.typecode, var="reset_alignment")$
-
-    if(union_max_size_serialized < reset_alignment)
-        union_max_size_serialized = reset_alignment;
-
-    }; separator="\n"$
-
-    return union_max_size_serialized - initial_alignment;
-}
-
 // TODO(Ricardo) Review
 size_t $union.scopedname$::getCdrSerializedSize(
         const $union.scopedname$& data,
@@ -1465,16 +1420,6 @@ bool& $scopedtypename$::release()
 }
 
 $if(ctx.anyCdr)$
-size_t $scopedtypename$::getMaxCdrSerializedSize(
-        size_t current_alignment)
-{
-    size_t initial_alignment = current_alignment;
-
-    $max_serialized_size(ctx=ctx, typecode=typecode, var="current_alignment")$
-
-    return current_alignment - initial_alignment;
-}
-
 size_t $scopedtypename$::getCdrSerializedSize(
         const $scopedtypename$& data,
         size_t current_alignment)

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -273,6 +273,7 @@ $if(ctx.anyCdr)$
 size_t $struct.scopedname$::getMaxCdrSerializedSize(
         size_t current_alignment)
 {
+    static_cast<void>(current_alignment);
     return $struct.cScopedname$_max_cdr_typesize;
 }
 

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -638,6 +638,7 @@ public class fastddsgen
             List<TemplateExtension> extensions = new ArrayList<TemplateExtension>();
 
             // Load common types template
+            /// Add extension for @key related function definitions for each struct_type.
             extensions.add(new TemplateExtension("struct_type", "keyFunctionHeadersStruct"));
             tmanager.addGroup("TypesHeader", extensions);
             if (m_type_object_files)
@@ -645,12 +646,17 @@ public class fastddsgen
                 tmanager.addGroup("TypeObjectHeader", extensions);
             }
             extensions.clear();
+            /// Add extension for @key related function declarations for each struct_type.
             extensions.add(new TemplateExtension("struct_type", "keyFunctionSourcesStruct"));
             tmanager.addGroup("TypesSource", extensions);
             if (m_type_object_files)
             {
                 tmanager.addGroup("TypeObjectSource", extensions);
             }
+            extensions.clear();
+            /// Add extension for @key related preprocessor definitions in main for each struct typecode.
+            extensions.add(new TemplateExtension("main", "keyFunctionSourcesMain"));
+            tmanager.addGroup("TypesSource", extensions);
 
             // Load Types common templates
             tmanager.addGroup("DDSPubSubTypeHeader");

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -14,17 +14,25 @@
 
 package com.eprosima.fastdds.idl.grammar;
 
+import com.eprosima.fastdds.idl.parser.typecode.AliasTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.ArrayTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.BitmaskTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.BitsetTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.EnumTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.MapTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.PrimitiveTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.SequenceTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.SetTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.StringTypeCode;
 import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.UnionTypeCode;
 import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.tree.Interface;
 import com.eprosima.idl.parser.tree.TypeDeclaration;
 import com.eprosima.idl.parser.typecode.Kind;
 import com.eprosima.idl.parser.typecode.TypeCode;
 import com.eprosima.idl.parser.typecode.Member;
-import com.eprosima.idl.parser.typecode.MapTypeCode;
 import com.eprosima.idl.parser.typecode.MemberedTypeCode;
-import com.eprosima.idl.parser.typecode.SequenceTypeCode;
-import com.eprosima.idl.parser.typecode.EnumTypeCode;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map.Entry;
@@ -74,10 +82,101 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     }
 
     @Override
+    public AliasTypeCode createAliasTypeCode(
+            String scope,
+            String name)
+    {
+        return new AliasTypeCode(scope, name);
+    }
+
+    @Override
+    public ArrayTypeCode createArrayTypeCode()
+    {
+        return new ArrayTypeCode();
+    }
+
+    @Override
+    public BitsetTypeCode createBitsetTypeCode(
+            String scope,
+            String name)
+    {
+        return new BitsetTypeCode(scope, name);
+    }
+
+    @Override
+    public BitmaskTypeCode createBitmaskTypeCode(
+            String scope,
+            String name)
+    {
+        return new BitmaskTypeCode(scope, name);
+    }
+
+    @Override
+    public EnumTypeCode createEnumTypeCode(
+            String scope,
+            String name)
+    {
+        return new EnumTypeCode(scope, name);
+    }
+
+    @Override
+    public MapTypeCode createMapTypeCode(
+            String maxsize)
+    {
+        return new MapTypeCode(maxsize);
+    }
+
+    @Override
+    public PrimitiveTypeCode createPrimitiveTypeCode(
+            int kind)
+    {
+        return new PrimitiveTypeCode(kind);
+    }
+
+    @Override
+    public SequenceTypeCode createSequenceTypeCode(
+            String maxsize)
+    {
+        return new SequenceTypeCode(maxsize);
+    }
+
+    @Override
+    public SetTypeCode createSetTypeCode(
+            String maxsize)
+    {
+        return new SetTypeCode(maxsize);
+    }
+
+    @Override
+    public StringTypeCode createStringTypeCode(
+            int kind,
+            String maxsize)
+    {
+        return new StringTypeCode(kind, maxsize);
+    }
+
+    @Override
     public StructTypeCode createStructTypeCode(
             String name)
     {
         return new StructTypeCode(getScope(), name);
+    }
+
+    @Override
+    public UnionTypeCode createUnionTypeCode(
+            String scope,
+            String name)
+    {
+        return new UnionTypeCode(scope, name);
+    }
+
+    @Override
+    public UnionTypeCode createUnionTypeCode(
+            String scope,
+            String name,
+            TypeCode discriminatorTypeCode)
+    {
+        return new UnionTypeCode(scope, name, discriminatorTypeCode);
     }
 
     @Override

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/AliasTypeCode.java
@@ -1,0 +1,33 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public class AliasTypeCode extends com.eprosima.idl.parser.typecode.AliasTypeCode
+    implements TypeCode
+{
+    public AliasTypeCode(
+            String scope,
+            String name)
+    {
+        super(scope, name);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        return ((TypeCode) getTypedefContentTypeCode()).maxSerializedSize(current_alignment);
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/ArrayTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/ArrayTypeCode.java
@@ -1,0 +1,39 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public class ArrayTypeCode extends com.eprosima.idl.parser.typecode.ArrayTypeCode
+    implements TypeCode
+{
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+        long size = 1;
+        for (int count = 0; count < getDimensions().size(); ++count)
+        {
+            size += Long.parseLong(getDimensions().get(count), 10);
+        }
+
+        for (long count = 0; count < size; ++count)
+        {
+            current_alignment += ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitmaskTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitmaskTypeCode.java
@@ -1,0 +1,46 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public class BitmaskTypeCode extends com.eprosima.idl.parser.typecode.BitmaskTypeCode
+    implements TypeCode
+{
+    public BitmaskTypeCode(
+            String scope,
+            String name)
+    {
+        super(scope, name);
+    }
+
+    public BitmaskTypeCode(
+            String scope,
+            String name,
+            Integer bit_bound)
+    {
+        super(scope, name, bit_bound);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+        long size = Long.parseLong(getSize(), 10);
+
+        current_alignment += size + TypeCode.cdr_alignment(current_alignment, size);
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitsetTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitsetTypeCode.java
@@ -1,0 +1,46 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+import com.eprosima.idl.parser.typecode.Bitfield;
+
+public class BitsetTypeCode extends com.eprosima.idl.parser.typecode.BitsetTypeCode
+    implements TypeCode
+{
+
+    public BitsetTypeCode(
+            String scope,
+            String name)
+    {
+        super(scope, name);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+
+        for (Bitfield member : getBitfields(true))
+        {
+            if (!member.isAnnotationNonSerialized())
+            {
+                current_alignment += ((TypeCode)member.getSpec().getTypecode()).maxSerializedSize(current_alignment);
+            }
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/EnumTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/EnumTypeCode.java
@@ -1,0 +1,37 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public class EnumTypeCode extends com.eprosima.idl.parser.typecode.EnumTypeCode
+    implements TypeCode
+{
+    public EnumTypeCode(
+            String scope,
+            String name)
+    {
+        super(scope, name);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+
+        current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/MapTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/MapTypeCode.java
@@ -1,0 +1,43 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public class MapTypeCode extends com.eprosima.idl.parser.typecode.MapTypeCode
+    implements TypeCode
+{
+    public MapTypeCode(
+            String maxsize)
+    {
+        super(maxsize);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+        long maxsize = Long.parseLong(getMaxsize(), 10);
+
+        current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
+
+        for (long count = 0; count < maxsize; ++count)
+        {
+            current_alignment += ((TypeCode)getKeyTypeCode()).maxSerializedSize(current_alignment);
+            current_alignment += ((TypeCode)getValueTypeCode()).maxSerializedSize(current_alignment);
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/PrimitiveTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/PrimitiveTypeCode.java
@@ -1,0 +1,64 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public class PrimitiveTypeCode extends com.eprosima.idl.parser.typecode.PrimitiveTypeCode
+    implements TypeCode
+{
+
+    public PrimitiveTypeCode(
+            int kind)
+    {
+        super(kind);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+
+        switch (getKind())
+        {
+            case com.eprosima.idl.parser.typecode.Kind.KIND_LONGDOUBLE:
+                current_alignment += 16 + TypeCode.cdr_alignment(current_alignment, 8);
+                break;
+            case com.eprosima.idl.parser.typecode.Kind.KIND_DOUBLE:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_LONGLONG:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_ULONGLONG:
+                current_alignment += 8 + TypeCode.cdr_alignment(current_alignment, 8);
+                break;
+            case com.eprosima.idl.parser.typecode.Kind.KIND_LONG:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_ULONG:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_FLOAT:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_WCHAR:
+                current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
+                break;
+            case com.eprosima.idl.parser.typecode.Kind.KIND_SHORT:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_USHORT:
+                current_alignment += 2 + TypeCode.cdr_alignment(current_alignment, 2);
+                break;
+            case com.eprosima.idl.parser.typecode.Kind.KIND_BOOLEAN:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_CHAR:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_OCTET:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_INT8:
+            case com.eprosima.idl.parser.typecode.Kind.KIND_UINT8:
+                current_alignment += 1;
+                break;
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SequenceTypeCode.java
@@ -27,11 +27,11 @@ public class SequenceTypeCode extends com.eprosima.idl.parser.typecode.SequenceT
             long current_alignment)
     {
         long initial_alignment = current_alignment;
-        long maxsize = !(getContentTypeCode().isForwarded() && detect_recursive_)
+        long maxsize = !detect_recursive_
             ? Long.parseLong(getMaxsize(), 10)
             : 0;
 
-        boolean should_set_and_unset = getContentTypeCode().isForwarded() && !detect_recursive_;
+        boolean should_set_and_unset = !detect_recursive_;
 
         if (should_set_and_unset)
         {

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SequenceTypeCode.java
@@ -1,0 +1,56 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public class SequenceTypeCode extends com.eprosima.idl.parser.typecode.SequenceTypeCode
+    implements TypeCode
+{
+    public SequenceTypeCode(
+            String maxsize)
+    {
+        super(maxsize);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+        long maxsize = !(getContentTypeCode().isForwarded() && detect_recursive_)
+            ? Long.parseLong(getMaxsize(), 10)
+            : 0;
+
+        boolean should_set_and_unset = getContentTypeCode().isForwarded() && !detect_recursive_;
+
+        if (should_set_and_unset)
+        {
+            detect_recursive_ = true;
+        }
+
+        current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
+
+        for (long count = 0; count < maxsize; ++count)
+        {
+            current_alignment += ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+        }
+
+        if (should_set_and_unset)
+        {
+            detect_recursive_ = false;
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SetTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SetTypeCode.java
@@ -1,0 +1,42 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public class SetTypeCode extends com.eprosima.idl.parser.typecode.SetTypeCode
+    implements TypeCode
+{
+    public SetTypeCode(
+            String maxsize)
+    {
+        super(maxsize);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+        long maxsize = Long.parseLong(getMaxsize(), 10);
+
+        current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
+
+        for (long count = 0; count < maxsize; ++count)
+        {
+            current_alignment += ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StringTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StringTypeCode.java
@@ -1,0 +1,49 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+import com.eprosima.idl.parser.typecode.Kind;
+
+public class StringTypeCode extends com.eprosima.idl.parser.typecode.StringTypeCode
+    implements TypeCode
+{
+    public StringTypeCode(
+            int kind,
+            String maxsize)
+    {
+        super(kind, maxsize);
+    }
+
+    @Override
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+        long maxsize = Long.parseLong(getMaxsize(), 10);
+
+        switch (getKind())
+        {
+            case Kind.KIND_STRING:
+                current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4) + (maxsize * 4);
+                break;
+            case Kind.KIND_WSTRING:
+                current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4) + maxsize + 1;
+                break;
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StringTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StringTypeCode.java
@@ -36,10 +36,10 @@ public class StringTypeCode extends com.eprosima.idl.parser.typecode.StringTypeC
         switch (getKind())
         {
             case Kind.KIND_STRING:
-                current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4) + (maxsize * 4);
+                current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4) + maxsize + 1;
                 break;
             case Kind.KIND_WSTRING:
-                current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4) + maxsize + 1;
+                current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4) + (maxsize * 4);
                 break;
         }
 

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StructTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StructTypeCode.java
@@ -20,8 +20,11 @@ import com.eprosima.idl.parser.tree.Annotation;
 import java.util.ArrayList;
 
 public class StructTypeCode extends com.eprosima.idl.parser.typecode.StructTypeCode
+    implements TypeCode
 {
-    public StructTypeCode(String scope, String name)
+    public StructTypeCode(
+            String scope,
+            String name)
     {
         super(scope, name);
     }
@@ -39,8 +42,10 @@ public class StructTypeCode extends com.eprosima.idl.parser.typecode.StructTypeC
             {
                 String value = key.getValue("value");
 
-                if(value != null && value.equals("true"))
+                if (value != null && value.equals("true"))
+                {
                     returnedValue = true;
+                }
             }
             else // Try with lower case
             {
@@ -49,7 +54,7 @@ public class StructTypeCode extends com.eprosima.idl.parser.typecode.StructTypeC
                 {
                     String value = key.getValue("value");
 
-                    if(value != null && value.equals("true"))
+                    if (value != null && value.equals("true"))
                     {
                         returnedValue = true;
                     }
@@ -60,7 +65,45 @@ public class StructTypeCode extends com.eprosima.idl.parser.typecode.StructTypeC
         return returnedValue;
     }
 
-    public void setIsTopic(boolean value)
+    public String getMaxSerializedSize()
+    {
+        return Long.toString(maxSerializedSize(0));
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+
+        for (com.eprosima.idl.parser.typecode.TypeCode parent : getInheritances())
+        {
+            current_alignment += ((TypeCode)parent).maxSerializedSize(current_alignment);
+        }
+
+        for (Member member : getMembers())
+        {
+            if (!member.isAnnotationNonSerialized())
+            {
+                current_alignment += ((TypeCode)member.getTypecode()).maxSerializedSize(current_alignment);
+            }
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+    public String getMaxKeySerializedSize()
+    {
+        return Long.toString(maxKeySerializedSize(0));
+    }
+
+    protected long maxKeySerializedSize(
+            long current_alignment)
+    {
+        return 0;
+    }
+
+    public void setIsTopic(
+            boolean value)
     {
         istopic_ = value;
     }
@@ -76,14 +119,14 @@ public class StructTypeCode extends com.eprosima.idl.parser.typecode.StructTypeC
         String scopes = getScope();
         int ch_pos = scopes.indexOf("::");
 
-        while(0 < ch_pos)
+        while (0 < ch_pos)
         {
             namespaces.add(scopes.substring(0, ch_pos));
             scopes = scopes.substring(ch_pos + 2);
             ch_pos = scopes.indexOf("::");
         }
 
-        if(!scopes.isEmpty())
+        if (!scopes.isEmpty())
         {
             namespaces.add(scopes);
         }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StructTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StructTypeCode.java
@@ -75,7 +75,7 @@ public class StructTypeCode extends com.eprosima.idl.parser.typecode.StructTypeC
                 if (member.getTypecode() instanceof StructTypeCode)
                 {
                     current_alignment +=
-                            ((StructTypeCode)member.getTypecode()).maxSerializedSize(current_alignment, only_keys);
+                            ((StructTypeCode)member.getTypecode()).maxSerializedSize(current_alignment, ser_only_keys);
                 }
                 else
                 {

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/TypeCode.java
@@ -1,0 +1,28 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+public interface TypeCode
+{
+    static long cdr_alignment(
+            long current_alignment,
+            long data_size)
+    {
+        return (data_size - (current_alignment % data_size)) & (data_size - 1);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment);
+}

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/UnionTypeCode.java
@@ -1,0 +1,59 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.parser.typecode;
+
+import com.eprosima.idl.parser.typecode.Member;
+
+public class UnionTypeCode extends com.eprosima.idl.parser.typecode.UnionTypeCode
+    implements TypeCode
+{
+    public UnionTypeCode(
+            String scope,
+            String name)
+    {
+        super(scope, name);
+    }
+
+    public UnionTypeCode(
+            String scope,
+            String name,
+            com.eprosima.idl.parser.typecode.TypeCode discriminatorTypeCode)
+    {
+        super(scope, name, discriminatorTypeCode);
+    }
+
+    public long maxSerializedSize(
+            long current_alignment)
+    {
+        long initial_alignment = current_alignment;
+        long reset_alignment = 0;
+        long union_max_size_serialized = 0;
+
+        current_alignment += ((TypeCode)getDiscriminator()).maxSerializedSize(current_alignment);
+
+        for (Member member : getMembers())
+        {
+            reset_alignment = current_alignment;
+            reset_alignment += ((TypeCode)member.getTypecode()).maxSerializedSize(reset_alignment);
+            if (union_max_size_serialized < reset_alignment)
+            {
+                union_max_size_serialized = reset_alignment;
+            }
+        }
+
+        return union_max_size_serialized - initial_alignment;
+    }
+
+}

--- a/src/main/java/com/eprosima/fastdds/idl/templates/Common.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/Common.stg
@@ -96,8 +96,6 @@ $keyFunctionHeaders(struct)$
 
 keyFunctionSourcesStruct(ctx, parent, struct) ::= <<
 
-#define $struct.cScopedname$_max_key_cdr_typesize $struct.maxKeySerializedSize$ULL;
-
 size_t $struct.scopedname$::getKeyMaxCdrSerializedSize(
         size_t current_alignment)
 {
@@ -118,6 +116,10 @@ void $struct.scopedname$::serializeKey(
     $struct.members : { member |$if(member.annotationKey)$ $object_serialization(ctx=ctx, object=member, preffix="m_")$ $endif$ }; separator=""$
 }
 
+>>
+
+keyFunctionSourcesMain(ctx, definitions) ::= <<
+$ctx.types:{ type | $if(type.typeCode.isStructType)$#define $type.typeCode.cScopedname$_max_key_cdr_typesize $type.typeCode.maxKeySerializedSize$ULL;$endif$}; separator="\n"$
 >>
 
 fwd_decl(ctx, parent, type) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/Common.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/Common.stg
@@ -113,7 +113,11 @@ void $struct.scopedname$::serializeKey(
 {
     (void) scdr;
     $if(struct.inheritances)$    $struct.inheritances : {$it.scopedname$::serializeKey(scdr);}; separator="\n"$ $endif$
-    $struct.members : { member |$if(member.annotationKey)$ $object_serialization(ctx=ctx, object=member, preffix="m_")$ $endif$ }; separator=""$
+    $if(struct.hasKey)$
+    $struct.members : { member |$if(member.annotationKey)$ $if(member.typecode.isStructType)$ m_$member.name$.serializeKey(scdr); $else$ $object_serialization(ctx=ctx, object=member, preffix="m_")$ $endif$ $endif$ }; separator=""$
+    $else$
+    $struct.members : { member |$object_serialization(ctx=ctx, object=member, preffix="m_")$ }; separator=""$
+    $endif$
 }
 
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/Common.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/Common.stg
@@ -95,16 +95,14 @@ $keyFunctionHeaders(struct)$
 >>
 
 keyFunctionSourcesStruct(ctx, parent, struct) ::= <<
+
+#define $struct.cScopedname$_max_key_cdr_typesize $struct.maxKeySerializedSize$ULL;
+
 size_t $struct.scopedname$::getKeyMaxCdrSerializedSize(
         size_t current_alignment)
 {
-    size_t current_align = current_alignment;
-
-    $if(struct.inheritances)$    $struct.inheritances : {current_align += $it.scopedname$::getKeyMaxCdrSerializedSize(current_align);}; separator="\n"$ $endif$
-
-    $struct.members : { member | $if(member.annotationKey)$ $max_serialized_size(ctx=ctx, typecode=member.typecode, var="current_align")$ $endif$}; separator="\n"$
-
-    return current_align;
+    static_cast<void>(current_alignment);
+    return $struct.cScopedname$_max_key_cdr_typesize;
 }
 
 bool $struct.scopedname$::isKeyDefined()

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
@@ -364,8 +364,17 @@ $endif$
 >>
 
 sequence_assigment(ctx, typecode, name, p, loopvar) ::= <<
-for(size_t $loopvar$ = 0; $loopvar$ < $if(typecode.unbound)$50$else$$typecode.maxsize$$endif$; ++$loopvar$)
+$if(typecode.contentTypeCode.forwarded)$
+static bool $name$_detect_recursive_ = false;
+
+$endif$
+
+for(size_t $loopvar$ = 0; $if(typecode.contentTypeCode.forwarded)$!$name$_detect_recursive_ && $endif$$loopvar$ < $if(typecode.unbound)$50$else$$typecode.maxsize$$endif$; ++$loopvar$)
 {
+    $if(typecode.contentTypeCode.forwarded)$
+    $name$_detect_recursive_ = true;
+    $endif$
+
     $if(typecode.contentTypeCode.isSequenceType)$
     topic->$name$$p$.emplace_back();
     $if(ctx.generateTypesC)$
@@ -377,6 +386,10 @@ for(size_t $loopvar$ = 0; $loopvar$ < $if(typecode.unbound)$50$else$$typecode.ma
     $sequence_member_assignment(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name, p=p, loopvar=loopvar), originName=name, p="", loopvar=ctx.nextLoopVarName, currentvar=loopvar)$
     $else$
     $sequence_member_assignment(ctx=ctx, typecode=typecode.contentTypeCode, name=name, originName=name, p=p, loopvar=ctx.nextLoopVarName, currentvar=loopvar)$
+    $endif$
+
+    $if(typecode.contentTypeCode.forwarded)$
+    $name$_detect_recursive_ = false;
     $endif$
 }
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
@@ -364,19 +364,10 @@ $endif$
 >>
 
 sequence_assigment(ctx, typecode, name, p, loopvar) ::= <<
-$if(ctx.generateTypesC)$
-$if(typecode.unbound)$
-topic->$name$$p$.size(50);
-for(int $loopvar$ = 0; $loopvar$ < topic->$name$$p$.size(); ++$loopvar$)
-$else$
-topic->$name$$p$.size($typecode.maxsize$);
-for(int $loopvar$ = 0; $loopvar$ < $typecode.maxsize$; ++$loopvar$)
-$endif$
-$else$
-for(int $loopvar$ = 0; $loopvar$ < $typecode.maxsize$; ++$loopvar$)
-$endif$
+for(size_t $loopvar$ = 0; $loopvar$ < $if(typecode.unbound)$50$else$$typecode.maxsize$$endif$; ++$loopvar$)
 {
     $if(typecode.contentTypeCode.isSequenceType)$
+    topic->$name$$p$.emplace_back();
     $if(ctx.generateTypesC)$
     $sequence_member_assignment(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name, p=[p, ".value()"], loopvar=loopvar), originName=name, p="", loopvar=ctx.nextLoopVarName, currentvar=loopvar)$
     $else$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
@@ -76,7 +76,6 @@ functions_to_run.emplace_back([]() -> bool
 
     uint32_t payloadOutSize = static_cast<uint32_t>(pst.getSerializedSizeProvider(&$struct.name$_deserialization_topic)());
 
-    //int topic_equal = memcmp(&$struct.name$_serialization_topic, &$struct.name$_deserialization_topic, sizeof(&$struct.name$)) == 0;
     int topic_equal = compare$struct.name$(&$struct.name$_serialization_topic, &$struct.name$_deserialization_topic);
     int size_equal = payloadOutSize == payloadSize;
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
@@ -22,48 +22,70 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "SerializationTest.cpp"], description=
 #include <fastcdr/Cdr.h>
 #include <fastrtps/rtps/common/SerializedPayload.h>
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <inttypes.h>
 #include <string.h>
+#include <functional>
+#include <vector>
 
-int test$ctx.lastStructure.name$()
+using TestLambda = std::function<bool()>;
+
+std::vector<TestLambda> functions_to_run;
+
+int main(void)
 {
+    srand((unsigned) time(NULL));
+    bool ret_value = true;
+
+    $definitions; separator="\n"$
+
+    for (auto& fc : functions_to_run)
+    {
+        ret_value &= fc();
+    }
+    return ret_value ? 0 : 1;
+}
+
+>>
+
+struct_type(ctx, parent, struct) ::= <<
+functions_to_run.emplace_back([]() -> bool
+{
+    printf("\n========================================Testing $struct.name$ ========================================\n");
     using eprosima::fastrtps::rtps::SerializedPayload_t;
-    $if(ctx.lastStructure.hasScope)$    using namespace $ctx.lastStructure.scope$;$endif$
+    $if(struct.hasScope)$    using namespace $struct.scope$;$endif$
 
-    $ctx.lastStructure.name$ $ctx.lastStructure.name$_serialization_topic;
-    $ctx.lastStructure.name$ $ctx.lastStructure.name$_deserialization_topic;
+    $struct.name$ $struct.name$_serialization_topic;
+    $struct.name$ $struct.name$_deserialization_topic;
 
-    initialize$ctx.lastStructure.name$(&$ctx.lastStructure.name$_serialization_topic);
+    initialize$struct.name$(&$struct.name$_serialization_topic);
 
-    $ctx.lastStructure.name$PubSubType pst;
-    uint32_t payloadSize = static_cast<uint32_t>(pst.getSerializedSizeProvider(&$ctx.lastStructure.name$_serialization_topic)());
+    $struct.name$PubSubType pst;
+    uint32_t payloadSize = static_cast<uint32_t>(pst.getSerializedSizeProvider(&$struct.name$_serialization_topic)());
 
     SerializedPayload_t payload(payloadSize);
-    if (pst.serialize(&$ctx.lastStructure.name$_serialization_topic, &payload) == 0)
+    if (pst.serialize(&$struct.name$_serialization_topic, &payload) == 0)
     {
-        return 0;
+        return false;
     }
 
-    if (pst.deserialize(&payload, &$ctx.lastStructure.name$_deserialization_topic) == 0)
+    if (pst.deserialize(&payload, &$struct.name$_deserialization_topic) == 0)
     {
-        return 0;
+        return false;
     }
 
-    uint32_t payloadOutSize = static_cast<uint32_t>(pst.getSerializedSizeProvider(&$ctx.lastStructure.name$_deserialization_topic)());
+    uint32_t payloadOutSize = static_cast<uint32_t>(pst.getSerializedSizeProvider(&$struct.name$_deserialization_topic)());
 
-    //int topic_equal = memcmp(&$ctx.lastStructure.name$_serialization_topic, &$ctx.lastStructure.name$_deserialization_topic, sizeof(&$ctx.lastStructure.name$)) == 0;
-    int topic_equal = compare$ctx.lastStructure.name$(&$ctx.lastStructure.name$_serialization_topic, &$ctx.lastStructure.name$_deserialization_topic);
+    //int topic_equal = memcmp(&$struct.name$_serialization_topic, &$struct.name$_deserialization_topic, sizeof(&$struct.name$)) == 0;
+    int topic_equal = compare$struct.name$(&$struct.name$_serialization_topic, &$struct.name$_deserialization_topic);
     int size_equal = payloadOutSize == payloadSize;
 
     printf("\n");
     printf("===== Before serialize: =====\n");
-    print$ctx.lastStructure.name$(&$ctx.lastStructure.name$_serialization_topic);
+    print$struct.name$(&$struct.name$_serialization_topic);
     printf("\n");
     printf("===== After deserialize: =====\n");
-    print$ctx.lastStructure.name$(&$ctx.lastStructure.name$_deserialization_topic);
+    print$struct.name$(&$struct.name$_deserialization_topic);
     printf("\n");
     printf("SerializedPayload_t: \n");
     printf("length: %d - %d\n", payloadSize, payload.length);
@@ -74,31 +96,22 @@ int test$ctx.lastStructure.name$()
     }
     printf("\n\n");
 
-    uint32_t type_size = sizeof($ctx.lastStructure.name$);
-    printf("Topic $ctx.lastStructure.name$ size: %s => payloadIn: %d, payloadOut: %d, type: %d\n", size_equal ? "OK" : "ERROR", payloadSize, payloadOutSize, type_size);
-    printf("Topic $ctx.lastStructure.name$ comparation: %s\n", topic_equal ? "OK" : "ERROR");
+    uint32_t type_size = sizeof($struct.name$);
+    printf("Topic $struct.name$ size: %s => payloadIn: %d, payloadOut: %d, type: %d\n", size_equal ? "OK" : "ERROR", payloadSize, payloadOutSize, type_size);
+    printf("Topic $struct.name$ comparation: %s\n", topic_equal ? "OK" : "ERROR");
 
     $if((ctx.generateTypesC))$
-    free_string$ctx.lastStructure.name$(&$ctx.lastStructure.name$_serialization_topic);
+    free_string$struct.name$(&$struct.name$_serialization_topic);
     $endif$
 
     if (!topic_equal)
     {
-        return 0;
+        return false;
     }
 
     return payload.length == payloadSize;
-}
-
-int main(void)
-{
-    srand((unsigned) time(NULL));
-    return test$ctx.lastStructure.name$() ? 0 : 1;
-}
-
+});
 >>
-
-struct_type(ctx, parent, struct) ::= <<>>
 
 union_type(ctx, parent, union) ::= <<>>
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/eprosima.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/eprosima.stg
@@ -47,7 +47,7 @@ bitset_inherit_copy_init(parent) ::= <<$parent.scopedname$(x)>>
 bitset_inherit_move_init(parent) ::= <<$parent.scopedname$(std::move(x))>>
 
 member_default_init(ctx, member, loopvar) ::= <<
-// m_$member.name$ $member.typecode$
+// $member.typecode.idlTypename$ m_$member.name$
 $if(member.typecode.forwarded)$m_$member.name$ = new $member.typecode.cppTypename$($if(member.annotationDefault)$$member.annotationDefaultValue$$endif$);$else$$if(member.typecode.primitive)$$if(member.typecode.isBitmaskType)$m_$member.name$ = $if(member.annotationDefault)$$member.annotationDefaultValue$$else$static_cast<$member.typecode.cppTypename$>(0)$endif$;$else$m_$member.name$ = $if(member.annotationDefault)$$member.annotationDefaultValue$$else$$member.typecode.initialValue$$endif$;$endif$$elseif(member.typecode.isStringType)$m_$member.name$ =$if(ctx.generateTypesC)$$if(member.annotationDefault)$$member.annotationDefaultValue$$else$nullptr$endif$$else$$if(member.annotationDefault)$$member.annotationDefaultValue$$else$$member.typecode.initialValue$$endif$$endif$;$elseif(member.typecode.isType_f)$$if(member.typecode.contentTypeCode.primitive)$memset(&m_$member.name$, $if(member.annotationDefault)$$member.annotationDefaultValue$$else$0$endif$, $member.typecode.size$ * $member.typecode.contentTypeCode.size$);$elseif(member.typecode.contentTypeCode.isStringType)$$if(ctx.generateTypesC)$$member_array_default_cstring_init(ctx=ctx, name=memberName(member.name), loopvar=ctx.newLoopVarName, dims=member.typecode.dimensions)$$endif$$endif$$endif$$endif$>>
 
 member_array_default_cstring_init(ctx, name, loopvar, dims) ::= <<$if(rest(dims))$for (uint32_t $loopvar$ = 0; $loopvar$ < $name$.size(); ++$loopvar$)

--- a/src/main/java/com/eprosima/fastdds/idl/templates/idlTypes.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/idlTypes.stg
@@ -58,4 +58,12 @@ type_10(name) ::= <<$name$>>
 
 type_e(type, maxsize, empty) ::= <<sequence<$type$$if(maxsize)$, $maxsize$$endif$>$empty$>>
 
-type_19() ::= <<map>>
+type_19(key, value, maxsize, empty) ::= <<map<$key$, $value$>$empty$>>
+
+type_1a(name, type) ::= <<$name$>>
+
+type_1b(name) ::= <<$name$>>
+
+type_1d(name) ::= <<int8>>
+
+type_1e(name) ::= <<uint8>>

--- a/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
+++ b/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
@@ -36,6 +36,7 @@ public class FastDDSGenTest
         //Configure idl tests
         TestManager tests = new TestManager(TestLevel.RUN, "share/fastddsgen/java/fastddsgen", INPUT_PATH,
                         OUTPUT_PATH + "/idls", "CMake");
+        tests.addCMakeArguments("-DCMAKE_BUILD_TYPE=Debug");
         tests.removeTests(IDL.ARRAY_NESTED, IDL.SEQUENCE_NESTED);
         boolean testResult = tests.runTests();
         System.exit(testResult ? 0 : -1);


### PR DESCRIPTION
According to OMG IDL standard, recursive structures are supported using `sequences` and forward declarations. This PR
add support for this and also:

- Improve test execution
- Fix bug generating bitset and bitmask

Depends on:

- eProsima/IDL-Parser#57
- #129