### PR TITLE
[15612] Make generated destructors non virtual

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -234,7 +234,7 @@ public:
     /*!
      * @brief Default destructor.
      */
-    eProsima_user_DllExport virtual ~$struct.name$()$if(struct.inheritances)$ override$endif$;
+    eProsima_user_DllExport ~$struct.name$();
 
     /*!
      * @brief Copy constructor.
@@ -406,7 +406,7 @@ public:
     /*!
      * @brief Default destructor.
      */
-    eProsima_user_DllExport virtual ~$bitset.name$()$if(bitset.parents)$ override$endif$;
+    eProsima_user_DllExport ~$bitset.name$();
 
     /*!
      * @brief Copy constructor.


### PR DESCRIPTION
Since:

1. OMG IDL to C++ mapping of structured types does not require it
2. We want plain types to be plain (i.e. have nothing more in memory than plain data)

This PR makes the destructors of the generated data types non virtual.