### PR TITLE
[15824] Cleanup visual studio example generators

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -376,6 +376,7 @@ public class fastddsgen
                 if (m_exampleOption != null)
                 {
                     solution.addLibraryPath("$(" + m_appEnv + ")/lib/" + m_exampleOption);
+                    solution.addLibraryPath("$(" + m_appEnv + ")/lib/" + m_exampleOption + "/VC/static");
                 }
             }
 
@@ -468,10 +469,8 @@ public class fastddsgen
 
         fastddsgen.m_platforms = new ArrayList<String>();
 
-        fastddsgen.m_platforms.add("i86Win32VS2013");
-        fastddsgen.m_platforms.add("x64Win64VS2013");
-        fastddsgen.m_platforms.add("i86Win32VS2015");
-        fastddsgen.m_platforms.add("x64Win64VS2015");
+        fastddsgen.m_platforms.add("i86Win32VS2019");
+        fastddsgen.m_platforms.add("x64Win64VS2019");
         fastddsgen.m_platforms.add("i86Linux2.6gcc");
         fastddsgen.m_platforms.add("x64Linux2.6gcc");
         fastddsgen.m_platforms.add("armLinux2.6gcc");
@@ -517,7 +516,7 @@ public class fastddsgen
         System.out.println("\t\t-help: shows this help");
         System.out.println("\t\t-version: shows the current version of eProsima Fast DDS gen.");
         System.out.println(
-            "\t\t-example <platform>: Generates a solution for a specific platform (example: x64Win64VS2015)");
+            "\t\t-example <platform>: Generates a solution for a specific platform (example: x64Win64VS2019)");
         System.out.println("\t\t\tSupported platforms:");
         for (int count = 0; count < m_platforms.size(); ++count)
         {
@@ -944,17 +943,9 @@ public class fastddsgen
                 else if (m_exampleOption.substring(3, 6).equals("Win"))
                 {
                     System.out.println("Generating Windows solution");
-
                     if (m_exampleOption.startsWith("i86"))
                     {
-                        if (m_exampleOption.charAt(m_exampleOption.length() - 1) == '3')
-                        {
-                            returnedValue = genVS(solution, null, "12");
-                        }
-                        else
-                        {
-                            returnedValue = genVS(solution, null, "14");
-                        }
+                        returnedValue = genVS(solution, null, "16", "142");
                     }
                     else if (m_exampleOption.startsWith("x64"))
                     {
@@ -962,14 +953,7 @@ public class fastddsgen
                         {
                             m_vsconfigurations[index].setPlatform("x64");
                         }
-                        if (m_exampleOption.charAt(m_exampleOption.length() - 1) == '3')
-                        {
-                            returnedValue = genVS(solution, "x64", "12");
-                        }
-                        else
-                        {
-                            returnedValue = genVS(solution, "x64", "14");
-                        }
+                        returnedValue = genVS(solution, "x64", "16", "142");
                     }
                     else
                     {
@@ -1012,7 +996,8 @@ public class fastddsgen
     private boolean genVS(
             Solution solution,
             String arch,
-            String vsVersion)
+            String vsVersion,
+            String toolset)
     {
 
         final String METHOD_NAME = "genVS";
@@ -1044,7 +1029,8 @@ public class fastddsgen
                 tproject.setAttribute("solution", solution);
                 tproject.setAttribute("project", project);
                 tproject.setAttribute("example", m_exampleOption);
-                tproject.setAttribute("vsVersion",  vsVersion);
+                tproject.setAttribute("vsVersion", vsVersion);
+                tproject.setAttribute("toolset", toolset);
 
                 tprojectFiles.setAttribute("project", project);
                 tprojectFiles.setAttribute("vsVersion", vsVersion);
@@ -1053,6 +1039,7 @@ public class fastddsgen
                 tprojectPubSub.setAttribute("project", project);
                 tprojectPubSub.setAttribute("example", m_exampleOption);
                 tprojectPubSub.setAttribute("vsVersion", vsVersion);
+                tprojectPubSub.setAttribute("toolset", toolset);
 
                 tprojectFilesPubSub.setAttribute("project", project);
                 tprojectFilesPubSub.setAttribute("vsVersion", vsVersion);
@@ -1063,8 +1050,10 @@ public class fastddsgen
                     tprojectJNI.setAttribute("project", project);
                     tprojectJNI.setAttribute("example", m_exampleOption);
                     tprojectJNI.setAttribute("vsVersion", vsVersion);
+                    tprojectJNI.setAttribute("toolset", toolset);
 
                     tprojectFilesJNI.setAttribute("project", project);
+                    tprojectFilesJNI.setAttribute("vsVersion", vsVersion);
                 }
 
                 for (int index = 0; index < m_vsconfigurations.length; index++)
@@ -1139,11 +1128,7 @@ public class fastddsgen
                     tsolution.setAttribute("generateJava", true);
                 }
 
-                String vsVersion_sol = "2013";
-                if (vsVersion.equals("14"))
-                {
-                    vsVersion_sol = "2015";
-                }
+                String vsVersion_sol = "2019";
                 tsolution.setAttribute("vsVersion", vsVersion_sol);
 
                 returnedValue = Utils.writeFile(m_outputDir + "solution-" + m_exampleOption + ".sln", tsolution,
@@ -1153,7 +1138,7 @@ public class fastddsgen
         }
         else
         {
-            System.out.println("ERROR<" + METHOD_NAME + ">: Cannot load the template group VS2013");
+            System.out.println("ERROR<" + METHOD_NAME + ">: Cannot load the template group VS");
         }
 
         return returnedValue;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/VS.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/VS.stg
@@ -32,8 +32,8 @@ EndGlobal
 
 >>
 
-project(solution, project, example, configurations, vsVersion) ::= <<
-<?xml version="1.0" encoding="Windows-1252"?>
+project(solution, project, example, configurations, vsVersion, toolset) ::= <<
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="$vsVersion$.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     $configurations:{<ProjectConfiguration Include="$it.name$|$it.platform$">
@@ -52,7 +52,7 @@ project(solution, project, example, configurations, vsVersion) ::= <<
     <UseDebugLibraries>$if(it.debug)$true$else$false$endif$</UseDebugLibraries>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-	<PlatformToolset>v$vsVersion$0</PlatformToolset>
+	<PlatformToolset>v$toolset$</PlatformToolset>
   </PropertyGroup>};separator="\n"$
   <Import Project="\$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -80,7 +80,7 @@ project(solution, project, example, configurations, vsVersion) ::= <<
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$if(!it.dll)$libeay32MD$if(it.debug)$d$endif$.lib;$endif$Shlwapi.lib;Iphlpapi.lib;$project.dependencies : {dep |$if(!it.dll)$lib$endif$$dep$Types$if(it.debug)$d$endif$.lib}; separator=";"$;$if(!it.dll)$WS2_32.lib;$endif$%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$project.dependencies : {dep |$if(!it.dll)$lib$endif$$dep$Types$if(it.debug)$d$endif$.lib}; separator=";"$;%(AdditionalDependencies)</AdditionalDependencies>
       $if(it.dll)$
       <OutputFile>\$(TargetDir)\$(TargetName)\$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>$solution.libraryPaths : {path |$path$;}$.\lib\\$example$;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -105,7 +105,7 @@ project(solution, project, example, configurations, vsVersion) ::= <<
 </Project>
 >>
 
-projectPubSub(solution, project, example, configurations, vsVersion) ::= <<
+projectPubSub(solution, project, example, configurations, vsVersion, toolset) ::= <<
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="$vsVersion$.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
@@ -125,7 +125,7 @@ projectPubSub(solution, project, example, configurations, vsVersion) ::= <<
     <UseDebugLibraries>$if(it.debug)$true$else$false$endif$</UseDebugLibraries>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-	<PlatformToolset>v$vsVersion$0</PlatformToolset>
+	<PlatformToolset>v$toolset$</PlatformToolset>
   </PropertyGroup>};separator="\n"$
   <Import Project="\$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -152,7 +152,7 @@ projectPubSub(solution, project, example, configurations, vsVersion) ::= <<
     </ClCompile>
     <Link>
       <GenerateDebugInformation>$if(it.debug)$true$else$false$endif$</GenerateDebugInformation>
-      <AdditionalDependencies>$if(!it.dll)$lib$endif$$project.name$Types$if(it.debug)$d$endif$.lib;$if(!it.dll)$libeay32MD$if(it.debug)$d$endif$.lib;Shlwapi.lib;Iphlpapi.lib;$endif$$project.dependencies : {dep |$if(!it.dll)$lib$endif$$dep$Types$if(it.debug)$d$endif$.lib}; separator=";"$;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$if(!it.dll)$lib$endif$$project.name$Types$if(it.debug)$d$endif$.lib;$if(!it.dll)$$it.staticLibraries : {sl|$sl$}; separator=";"$;Shlwapi.lib;Iphlpapi.lib;$endif$$project.dependencies : {dep |$if(!it.dll)$lib$endif$$dep$Types$if(it.debug)$d$endif$.lib}; separator=";"$;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>\$(TargetDir)\$(TargetName)\$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>$solution.libraryPaths : {path |$path$;}$.\lib\\$example$;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
@@ -169,9 +169,9 @@ projectPubSub(solution, project, example, configurations, vsVersion) ::= <<
 </Project>
 >>
 
-projectJNI(solution, project, example, configurations, vsVersion) ::= <<
-<?xml version="1.0" encoding="Windows-1252"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+projectJNI(solution, project, example, configurations, vsVersion, toolset) ::= <<
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="$vsVersion$.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     $configurations:{<ProjectConfiguration Include="$it.name$|$it.platform$">
       <Configuration>$it.name$</Configuration>
@@ -189,7 +189,7 @@ projectJNI(solution, project, example, configurations, vsVersion) ::= <<
     <UseDebugLibraries>$if(it.debug)$true$else$false$endif$</UseDebugLibraries>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-	<PlatformToolset>v$vsVersion$0</PlatformToolset>
+	<PlatformToolset>v$toolset$</PlatformToolset>
   </PropertyGroup>};separator="\n"$
   <Import Project="\$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -253,7 +253,7 @@ projectJNI(solution, project, example, configurations, vsVersion) ::= <<
 >>
 
 projectFiles(project, vsVersion) ::= <<
-<?xml version="1.0" encoding="Windows-1252"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="$vsVersion$.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -283,7 +283,7 @@ projectFiles(project, vsVersion) ::= <<
 >>
 
 projectFilesPubSub(project, vsVersion) ::= <<
-<?xml version="1.0" encoding="Windows-1252"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="$vsVersion$.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -312,9 +312,9 @@ projectFilesPubSub(project, vsVersion) ::= <<
 </Project>
 >>
 
-projectFilesJNI(project) ::= <<
-<?xml version="1.0" encoding="Windows-1252"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+projectFilesJNI(project, vsVersion) ::= <<
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="$vsVersion$.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>

--- a/src/main/java/com/eprosima/fastdds/util/VSConfiguration.java
+++ b/src/main/java/com/eprosima/fastdds/util/VSConfiguration.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 package com.eprosima.fastdds.util;
+import java.util.ArrayList;
 
 public class VSConfiguration {
 
@@ -63,4 +64,42 @@ public class VSConfiguration {
 	{
 	    return !debug;
 	}
+    
+    public ArrayList<String> getStaticLibraries()
+    {
+        ArrayList<String> ret = new ArrayList<String>();
+        
+        if (debug)
+        {
+            ret.add("foonathan_memory-0.7.1-dbg.lib");
+            if (platform == "x64")
+            {
+                ret.add("libcrypto64MDd.lib");
+                ret.add("libssl64MDd.lib");
+            }
+            else
+            {
+                ret.add("libcrypto32MDd.lib");
+                ret.add("libssl32MDd.lib");
+            }
+        }
+        else
+        {
+            ret.add("foonathan_memory-0.7.1.lib");
+            if (platform == "x64")
+            {
+                ret.add("libcrypto64MD.lib");
+                ret.add("libssl64MD.lib");
+            }
+            else
+            {
+                ret.add("libcrypto32MD.lib");
+                ret.add("libssl32MD.lib");
+            }
+        }
+        
+        ret.add("Crypt32.lib");
+        
+        return ret;
+    }
 }


### PR DESCRIPTION
Align visual studio generators with current windows installer of Fast DDS

1. Generate solutions for VS 2019
2. Fixed the static libraries linked