### PR TITLE
[16655] Update gradlew version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>

Fixes #146. `gradlew` script downloads Gradle 7.0. Support for Java 17 was introduced in Gradle 7.3. This PR updates Gradle version in `gradlew`script to Gradle 7.6.