### PR TITLE
[17336] Forced unsigned usage on assignment

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -494,7 +494,7 @@ bitmask_type(ctx, parent, bitmask) ::= <<
  */
 enum $bitmask.name$$bitmask.boundType$
 {
-    $bitmask.members:{$it.name$ = 0x01 << $it.position$}; separator=",\n"$
+    $bitmask.members:{$it.name$ = 0x01ull << $it.position$}; separator=",\n"$
 };
 >>
 


### PR DESCRIPTION
When handling the bitmask bit shifts, the `0x01` literal is treated as a signed integer producing, making the resulting value a negative when shifting the whole size of the datatype.

This PR forces the usage of an `unsigned long long` integer instead. 