### PR TITLE
Fix generation of an empty struct [17527]

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -26,6 +26,8 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.h"], description=["This h
 
 #include "$ctx.filename$.h"
 
+$ctx.directIncludeDependencies : {include | #include "$include$PubSubTypes.h"}; separator="\n"$
+
 #if !defined(GEN_API_VER) || (GEN_API_VER != 1)
 #error \
     Generated $ctx.filename$ is not compatible with current installed Fast DDS. Please, regenerate it with fastddsgen.


### PR DESCRIPTION
Next idl

```idl
struct EmptyDerived : Basic
{
};
```
generates a wrong `operator==`. This PR fixes it.

Depends on:

- eprosima/idl-parser#67
