### PR TITLE
Fix the type object with its full scoped name

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectSource.stg
@@ -91,17 +91,17 @@ $annotation.typeDefs : {$register_annotation_typedef(it)$}; separator="\n"$
 >>
 
 register_annotation_enum(enum) ::= <<
-factory->add_type_object("$enum.name$", $if(object.hasScope)$$object.scope$::$endif$Get$enum.name$Identifier(true),
+factory->add_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", $if(object.hasScope)$$object.scope$::$endif$Get$enum.name$Identifier(true),
         $if(object.hasScope)$$object.scope$::$endif$Get$enum.name$Object(true));
-factory->add_type_object("$enum.name$", $if(object.hasScope)$$object.scope$::$endif$Get$enum.name$Identifier(false),
+factory->add_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", $if(object.hasScope)$$object.scope$::$endif$Get$enum.name$Identifier(false),
         $if(object.hasScope)$$object.scope$::$endif$Get$enum.name$Object(false));
 >>
 
 register_annotation_typedef(typedef) ::= <<
-factory->add_type_object("$typedef.name$",
+factory->add_type_object("$if(typedef.hasScope)$$typedef.scope$::$endif$$typedef.name$",
         $if(object.hasScope)$$object.scope$::$endif$Get$typedef.name$Identifier(true),
         $if(object.hasScope)$$object.scope$::$endif$Get$typedef.name$Object(true));
-factory->add_type_object("$typedef.name$",
+factory->add_type_object("$if(typedef.hasScope)$$typedef.scope$::$endif$$typedef.name$",
         $if(object.hasScope)$$object.scope$::$endif$Get$typedef.name$Identifier(false),
         $if(object.hasScope)$$object.scope$::$endif$Get$typedef.name$Object(false));
 >>
@@ -295,19 +295,19 @@ const_decl(ctx, parent, const) ::= <<>>
 typedef_decl(ctx, parent, typedefs) ::= <<
 const TypeIdentifier* Get$typedefs.name$Identifier(bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$typedefs.name$", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$typedefs.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$typedefs.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", complete);
 }
 
 const TypeObject* Get$typedefs.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -324,7 +324,7 @@ const TypeObject* Get$typedefs.name$Object(bool complete)
 
 const TypeObject* GetMinimal$typedefs.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -390,16 +390,16 @@ const TypeObject* GetMinimal$typedefs.name$Object()
     }
 
     // Don't add our TypeIdentifier but our alias
-    TypeObjectFactory::get_instance()->add_alias("$typedefs.name$", $get_content_type(ctx=ctx, type=typedefs.typedefContentTypeCode)$);
+    TypeObjectFactory::get_instance()->add_alias("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", $get_content_type(ctx=ctx, type=typedefs.typedefContentTypeCode)$);
 
-    TypeObjectFactory::get_instance()->add_type_object("$typedefs.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", false);
 }
 
 const TypeObject* GetComplete$typedefs.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -420,7 +420,7 @@ const TypeObject* GetComplete$typedefs.name$Object()
     //type_object->complete().alias_type().header().detail().ann_builtin().verbatim().language("language");
     //type_object->complete().alias_type().header().detail().ann_builtin().verbatim().text("text");
     //type_object->complete().alias_type().header().detail().ann_custom().push_back(...);
-    type_object->complete().alias_type().header().detail().type_name("$typedefs.name$");
+    type_object->complete().alias_type().header().detail().type_name("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$");
 
     // No flags apply
     //type_object->complete().alias_type().body().common().related_flags().TRY_CONSTRUCT1(false);
@@ -472,11 +472,11 @@ const TypeObject* GetComplete$typedefs.name$Object()
     }
 
     // Don't add our TypeIdentifier but our alias
-    TypeObjectFactory::get_instance()->add_alias("$typedefs.name$", $get_content_type(ctx=ctx, type=typedefs.typedefContentTypeCode)$);
+    TypeObjectFactory::get_instance()->add_alias("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", $get_content_type(ctx=ctx, type=typedefs.typedefContentTypeCode)$);
 
-    TypeObjectFactory::get_instance()->add_type_object("$typedefs.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", true);
 }
 
 >>
@@ -484,19 +484,19 @@ const TypeObject* GetComplete$typedefs.name$Object()
 enum_type(ctx, parent, enum) ::= <<
 const TypeIdentifier* Get$enum.name$Identifier(bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$enum.name$", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$enum.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$enum.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", complete);
 }
 
 const TypeObject* Get$enum.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$enum.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -511,7 +511,7 @@ const TypeObject* Get$enum.name$Object(bool complete)
 
 const TypeObject* GetMinimal$enum.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$enum.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -555,14 +555,14 @@ const TypeObject* GetMinimal$enum.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$enum.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$enum.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", false);
 }
 
 const TypeObject* GetComplete$enum.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$enum.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -580,7 +580,7 @@ const TypeObject* GetComplete$enum.name$Object()
     //type_object->complete().enumerated_type().enum_flags().IS_AUTOID_HASH(false);
 
     type_object->complete().enumerated_type().header().common().bit_bound(32); // TODO fixed by IDL, isn't?
-    type_object->complete().enumerated_type().header().detail().type_name("$enum.name$");
+    type_object->complete().enumerated_type().header().detail().type_name("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$");
 
     $if(enum.annotationList)$
     $enum.annotationList:{ ann |
@@ -635,9 +635,9 @@ const TypeObject* GetComplete$enum.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$enum.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$enum.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", true);
 }
 
 >>
@@ -708,19 +708,19 @@ type_object->complete().enumerated_type().literal_seq().emplace_back(cel_$object
 struct_type(ctx, parent, struct, extensions) ::= <<
 const TypeIdentifier* Get$struct.name$Identifier(bool complete)
 {
-    const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$struct.name$", complete);
+    const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$struct.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$struct.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", complete);
 }
 
 const TypeObject* Get$struct.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$struct.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -735,7 +735,7 @@ const TypeObject* Get$struct.name$Object(bool complete)
 
 const TypeObject* GetMinimal$struct.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$struct.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -782,14 +782,14 @@ const TypeObject* GetMinimal$struct.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$struct.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$struct.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", false);
 }
 
 const TypeObject* GetComplete$struct.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$struct.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -809,7 +809,7 @@ const TypeObject* GetComplete$struct.name$Object()
     $struct.members:{ member | $complete_member_object_type(ctx=ctx, object=member)$}; separator="\n"$
 
     // Header
-    type_object->complete().struct_type().header().detail().type_name("$struct.name$");
+    type_object->complete().struct_type().header().detail().type_name("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$");
     // TODO inheritance
     $struct.inheritances:{$complete_struct_inheritance(it)$}; separator="\n"$
 
@@ -863,9 +863,9 @@ const TypeObject* GetComplete$struct.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$struct.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$struct.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", true);
 }
 
 >>
@@ -966,19 +966,19 @@ get_content_type(ctx, type) ::= <<$if(type.plainType)$$if(type.isSequenceType)$T
 union_type(ctx, parent, union) ::= <<
 const TypeIdentifier* Get$union.name$Identifier(bool complete)
 {
-    const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$union.name$", complete);
+    const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(union.hasScope)$$union.scope$::$endif$$union.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$union.name$Object(complete);
-    return TypeObjectFactory::get_instance()->get_type_identifier("$union.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(union.hasScope)$$union.scope$::$endif$$union.name$", complete);
 }
 
 const TypeObject* Get$union.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$union.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -993,7 +993,7 @@ const TypeObject* Get$union.name$Object(bool complete)
 
 const TypeObject* GetMinimal$union.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$union.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1047,15 +1047,15 @@ const TypeObject* GetMinimal$union.name$Object()
         identifier->equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$union.name$", identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", identifier, type_object);
     delete type_object;
     delete identifier;
-    return TypeObjectFactory::get_instance()->get_type_object("$union.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", false);
 }
 
 const TypeObject* GetComplete$union.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$union.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -1113,7 +1113,7 @@ const TypeObject* GetComplete$union.name$Object()
     $union.members:{ member | $complete_union_member_object_type(ctx=ctx, object=member, discriminator=union.discriminator)$}; separator="\n"$
 
     // Header
-    type_object->complete().union_type().header().detail().type_name("$union.name$");
+    type_object->complete().union_type().header().detail().type_name("$if(union.hasScope)$$union.scope$::$endif$$union.name$");
 
     $if(union.annotationList)$
     $union.annotationList:{ ann |
@@ -1165,10 +1165,10 @@ const TypeObject* GetComplete$union.name$Object()
         identifier->equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$union.name$", identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", identifier, type_object);
     delete type_object;
     delete identifier;
-    return TypeObjectFactory::get_instance()->get_type_object("$union.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", true);
 }
 
 >>
@@ -1265,19 +1265,19 @@ type_object->complete().union_type().member_seq().emplace_back(cst_$object.name$
 bitmask_type(ctx, parent, bitmask) ::= <<
 const TypeIdentifier* Get$bitmask.name$Identifier(bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$bitmask.name$", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$bitmask.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$bitmask.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", complete);
 }
 
 const TypeObject* Get$bitmask.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1292,7 +1292,7 @@ const TypeObject* Get$bitmask.name$Object(bool complete)
 
 const TypeObject* GetMinimal$bitmask.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1328,14 +1328,14 @@ const TypeObject* GetMinimal$bitmask.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$bitmask.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", false);
 }
 
 const TypeObject* GetComplete$bitmask.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -1382,7 +1382,7 @@ const TypeObject* GetComplete$bitmask.name$Object()
     }; separator="\n"$
     $endif$
 
-    type_object->complete().bitmask_type().header().detail().type_name("$bitmask.name$");
+    type_object->complete().bitmask_type().header().detail().type_name("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$");
 
     $bitmask.members:{ member | $complete_bitmask_flag(ctx=ctx, object=member)$}; separator="\n"$
 
@@ -1408,9 +1408,9 @@ const TypeObject* GetComplete$bitmask.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$bitmask.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", true);
 }
 
 >>
@@ -1503,19 +1503,19 @@ type_object->complete().bitmask_type().flag_seq().emplace_back(cbf_$object.name$
 bitset_type(ctx, parent, bitset, extensions) ::= <<
 const TypeIdentifier* Get$bitset.name$Identifier(bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$bitset.name$", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$bitset.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$bitset.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", complete);
 }
 
 const TypeObject* Get$bitset.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1530,7 +1530,7 @@ const TypeObject* Get$bitset.name$Object(bool complete)
 
 const TypeObject* GetMinimal$bitset.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1566,14 +1566,14 @@ const TypeObject* GetMinimal$bitset.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$bitset.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", false);
 }
 
 const TypeObject* GetComplete$bitset.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -1618,7 +1618,7 @@ const TypeObject* GetComplete$bitset.name$Object()
     }; separator="\n"$
     $endif$
 
-    type_object->complete().bitset_type().header().detail().type_name("$bitset.name$");
+    type_object->complete().bitset_type().header().detail().type_name("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$");
 
     $bitset.bitfields:{ member | $complete_bitfield(ctx=ctx, object=member)$}; separator="\n"$
 
@@ -1646,9 +1646,9 @@ const TypeObject* GetComplete$bitset.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$bitset.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", true);
 }
 
 >>
@@ -1776,3 +1776,4 @@ type_object->complete().bitset_type().header().base_type(*Get$parent.name$Identi
 >>
 
 /***** Utils *****/
+


### PR DESCRIPTION
When adding a type object, only the type name is added. Its scope is omitted. That may result in a conflict between two types with the same name but in different scopes. For example, `mod1::structA` and `mod2::structA`

```
module mod1 { struct structA {...}; };
module mod2 { struct structA {...}; };
```