### PR TITLE
Runtime calculation about if a type is plain [18162]

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -261,7 +261,7 @@ bool $struct.scopedname$::operator ==(
 {
     $if(struct.inheritances)$    $struct.inheritances : { if ($it.scopedname$::operator !=(x)) return false;}; separator="\n"$ $endif$
 
-    return ($struct.members:{m_$it.name$ == x.m_$it.name$}; separator=" && "$);
+    return $if(struct.members)$($struct.members:{m_$it.name$ == x.m_$it.name$}; separator=" && "$)$else$true$endif$;
 }
 
 bool $struct.scopedname$::operator !=(

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -74,6 +74,29 @@ $typedefs : { typedef |typedef $typedef.typedefContentTypeCode.cppTypename$ $typ
 >>
 
 struct_type(ctx, parent, struct) ::= <<
+
+namespace detail {
+
+    template<typename Tag, typename Tag::type M>
+    struct $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_rob
+    {
+        friend constexpr typename Tag::type get(
+                Tag)
+        {
+            return M;
+        }
+    };
+
+    struct $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f
+    {
+        typedef $last(struct.members).typecode.cppTypename$ $struct.name$::* type;
+        friend constexpr type get(
+                $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f);
+    };
+
+    template struct $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_rob<$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f, &$struct.name$::m_$last(struct.members).name$>;
+}
+
 /*!
  * @brief This class represents the TopicDataType of the type $struct.name$ defined by the user in the IDL file.
  * @ingroup $ctx.trimfilename$
@@ -120,7 +143,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
     eProsima_user_DllExport inline bool is_plain() const override
     {
-        return $if (struct.isPlain)$true$else$false$endif$;
+        return $struct.maxSerializedSize$ULL == size_of_();
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -137,6 +160,13 @@ public:
 
     MD5 m_md5;
     unsigned char* m_keyBuffer;
+
+private:
+
+    static constexpr size_t size_of_()
+    {
+        return ((::size_t) &reinterpret_cast<char const volatile&>(((($struct.name$*)0)->*get(detail::$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f())))) + sizeof($last(struct.members).typecode.cppTypename$);
+    }
 };
 >>
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -79,7 +79,7 @@ $if(struct.isPlain)$
 namespace detail {
 
     template<typename Tag, typename Tag::type M>
-    struct $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_rob
+    struct $struct.name$_rob
     {
         friend constexpr typename Tag::type get(
                 Tag)
@@ -88,14 +88,19 @@ namespace detail {
         }
     };
 
-    struct $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f
+    struct $struct.name$_f
     {
         typedef $last(struct.members).typecode.cppTypename$ $struct.name$::* type;
         friend constexpr type get(
-                $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f);
+                $struct.name$_f);
     };
 
-    template struct $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_rob<$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f, &$struct.name$::m_$last(struct.members).name$>;
+    template struct $struct.name$_rob<$struct.name$_f, &$struct.name$::m_$last(struct.members).name$>;
+
+    template <typename T, typename Tag>
+    inline size_t constexpr $struct.name$_offset_of() {
+        return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+    }
 }
 $endif$
 
@@ -168,7 +173,7 @@ private:
 
     static constexpr bool is_plain_impl()
     {
-        return $struct.maxSerializedSize$ULL == ((::size_t) &reinterpret_cast<char const volatile&>(((($struct.name$*)0)->*get(detail::$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f())))) + sizeof($last(struct.members).typecode.cppTypename$);
+        return $struct.maxSerializedSize$ULL == (detail::$struct.name$_offset_of<$struct.name$, detail::$struct.name$_f>() + sizeof($last(struct.members).typecode.cppTypename$));
     }
 $endif$
 };

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -75,6 +75,7 @@ $typedefs : { typedef |typedef $typedef.typedefContentTypeCode.cppTypename$ $typ
 
 struct_type(ctx, parent, struct) ::= <<
 
+$if(struct.isPlain)$
 namespace detail {
 
     template<typename Tag, typename Tag::type M>
@@ -96,6 +97,7 @@ namespace detail {
 
     template struct $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_rob<$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f, &$struct.name$::m_$last(struct.members).name$>;
 }
+$endif$
 
 /*!
  * @brief This class represents the TopicDataType of the type $struct.name$ defined by the user in the IDL file.
@@ -143,7 +145,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
     eProsima_user_DllExport inline bool is_plain() const override
     {
-        return $struct.maxSerializedSize$ULL == size_of_();
+        return $if(struct.isPlain)$$struct.maxSerializedSize$ULL == size_of_()$else$false$endif$;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -163,10 +165,12 @@ public:
 
 private:
 
+    $if(struct.isPlain)$
     static constexpr size_t size_of_()
     {
         return ((::size_t) &reinterpret_cast<char const volatile&>(((($struct.name$*)0)->*get(detail::$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f())))) + sizeof($last(struct.members).typecode.cppTypename$);
     }
+    $endif$
 };
 >>
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -145,7 +145,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
     eProsima_user_DllExport inline bool is_plain() const override
     {
-        return $if(struct.isPlain)$$struct.maxSerializedSize$ULL == size_of_()$else$false$endif$;
+        return $if(struct.isPlain)$is_plain_impl()$else$false$endif$;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -166,9 +166,9 @@ public:
 $if(struct.isPlain)$
 private:
 
-    static constexpr size_t size_of_()
+    static constexpr bool is_plain_impl()
     {
-        return ((::size_t) &reinterpret_cast<char const volatile&>(((($struct.name$*)0)->*get(detail::$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f())))) + sizeof($last(struct.members).typecode.cppTypename$);
+        return $struct.maxSerializedSize$ULL == ((::size_t) &reinterpret_cast<char const volatile&>(((($struct.name$*)0)->*get(detail::$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f())))) + sizeof($last(struct.members).typecode.cppTypename$);
     }
 $endif$
 };

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -76,6 +76,7 @@ $typedefs : { typedef |typedef $typedef.typedefContentTypeCode.cppTypename$ $typ
 struct_type(ctx, parent, struct) ::= <<
 
 $if(struct.isPlain)$
+$if(struct.members)$
 namespace detail {
 
     template<typename Tag, typename Tag::type M>
@@ -102,6 +103,7 @@ namespace detail {
         return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
     }
 }
+$endif$
 $endif$
 
 /*!
@@ -173,7 +175,17 @@ private:
 
     static constexpr bool is_plain_impl()
     {
+        $if(struct.members)$
         return $struct.maxSerializedSize$ULL == (detail::$struct.name$_offset_of<$struct.name$, detail::$struct.name$_f>() + sizeof($last(struct.members).typecode.cppTypename$));
+        $elseif(struct.inheritances)$
+        $if(last(struct.inheritances).isPlain)$
+        return $struct.maxSerializedSize$ULL == (detail::$last(struct.inheritances).name$_offset_of<$last(struct.inheritances).name$, detail::$last(struct.inheritances).name$_f>() + sizeof($last(last(struct.inheritances).members).typecode.cppTypename$));
+        $else$
+        return true;
+        $endif$
+        $else$
+        return true;
+        $endif$
     }
 $endif$
 };

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -163,14 +163,14 @@ public:
     MD5 m_md5;
     unsigned char* m_keyBuffer;
 
+$if(struct.isPlain)$
 private:
 
-    $if(struct.isPlain)$
     static constexpr size_t size_of_()
     {
         return ((::size_t) &reinterpret_cast<char const volatile&>(((($struct.name$*)0)->*get(detail::$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$_f())))) + sizeof($last(struct.members).typecode.cppTypename$);
     }
-    $endif$
+$endif$
 };
 >>
 


### PR DESCRIPTION
This calculation is only done when fastddsgen thinks the structure is plain. This feature adds a runtime check to avoid errors.

Depends on:
- eProsima/idl-parser#71