### PR TITLE
Fix error when swig read a generated header file [18521]

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -79,6 +79,7 @@ struct_type(ctx, parent, struct) ::= <<
 
 $if(struct.isPlain)$
 $if(struct.members)$
+#ifndef SWIG
 namespace detail {
 
     template<typename Tag, typename Tag::type M>
@@ -105,6 +106,8 @@ namespace detail {
         return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
     }
 }
+#endif
+
 $endif$
 $endif$
 


### PR DESCRIPTION
This bug was introduced by #169.

More info in redmine 18520.