### PR TITLE
[18918] Generate Common Types ending with an empty line

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -87,6 +87,7 @@ $endif$
 $definitions; separator="\n"$
 
 #endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_H_
+$"\n"$
 >>
 
 // TODO name -> module

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -52,7 +52,7 @@ $definitions; separator="\n"$
 
 // Include the corresponding TopicDataType
 %include "$ctx.filename$PubSubTypes.i"
-
+$"\n"$
 >>
 
 fast_macro_declarations() ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/Common.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/Common.stg
@@ -115,7 +115,7 @@ void $struct.scopedname$::serializeKey(
     $if(struct.inheritances)$ $struct.inheritances : { $it.scopedname$::serializeKey(scdr); }; separator="\n"$ $endif$
     $if(struct.hasKey)$ $struct.members : { member | $if(member.annotationKey)$ $if(member.typecode.isStructType)$ $if(member.typecode.hasKey)$ m_$member.name$.serializeKey(scdr); $else$ m_$member.name$.serialize(scdr); $endif$ $else$ $object_serialization(ctx=ctx, object=member, preffix="m_")$ $endif$ $endif$ }; separator="\n"$ $endif$
 }
-
+$"\n"$
 >>
 
 keyFunctionSourcesMain(ctx, definitions) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -36,6 +36,7 @@ $ctx.directIncludeDependencies : {include | #include "$include$PubSubTypes.h"}; 
 $definitions; separator="\n"$
 
 #endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBSUBTYPES_H_
+$"\n"$
 >>
 
 // TODO name -> module

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -34,6 +34,7 @@ module(ctx, parent, module, definition_list) ::= <<
 namespace $module.name$ {
     $definition_list$
 } //End of namespace $module.name$
+
 >>
 
 definition_list(definitions) ::= <<


### PR DESCRIPTION
This PR suggests adding some line breaks at the end of the generated files (`PubSubTypes`, `Type`, `Swig` files)