### PR TITLE
[18910] Correctly register type object with ROS 2 names

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectSource.stg
@@ -59,23 +59,23 @@ $definitions; separator="\n"$
 
 
 try_create(ctx, object, param) ::= <<
-if ($param$ == $if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$) return $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(complete);
+if ($param$ == $if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$if(object.hasScope)$$object.scope$::$endif$$object.name$"$endif$) return $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(complete);
 >>
 
 try_object(ctx, object, param) ::= <<
-if ($param$ == $if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$)
+if ($param$ == $if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$if(object.hasScope)$$object.scope$::$endif$$object.name$"$endif$)
 {
     $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(complete);
-    return TypeObjectFactory::get_instance()->get_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$, complete);
+    return TypeObjectFactory::get_instance()->get_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$if(object.hasScope)$$object.scope$::$endif$$object.name$"$endif$, complete);
 }
 >>
 
 register_type(ctx, object, param) ::= <<
 $if(!object.isModule)$
 $if(!object.isConstDeclaration)$
-factory->add_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$, $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(true),
+factory->add_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$if(object.hasScope)$$object.scope$::$endif$$object.name$"$endif$, $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(true),
         $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Object(true));
-factory->add_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$, $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(false),
+factory->add_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$if(object.hasScope)$$object.scope$::$endif$$object.name$"$endif$, $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(false),
         $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Object(false));
 $if(object.isAnnotation)$
 {

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypeObjectSource.stg
@@ -59,23 +59,23 @@ $definitions; separator="\n"$
 
 
 try_create(ctx, object, param) ::= <<
-if ($param$ == "$if(object.hasScope)$$object.scope$::$endif$$object.name$") return $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(complete);
+if ($param$ == $if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$) return $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(complete);
 >>
 
 try_object(ctx, object, param) ::= <<
-if ($param$ == "$if(object.hasScope)$$object.scope$::$endif$$object.name$")
+if ($param$ == $if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$)
 {
     $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(complete);
-    return TypeObjectFactory::get_instance()->get_type_object("$if(object.hasScope)$$object.scope$::$endif$$object.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$, complete);
 }
 >>
 
 register_type(ctx, object, param) ::= <<
 $if(!object.isModule)$
 $if(!object.isConstDeclaration)$
-factory->add_type_object("$if(object.hasScope)$$object.scope$::$endif$$object.name$", $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(true),
+factory->add_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$, $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(true),
         $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Object(true));
-factory->add_type_object("$if(object.hasScope)$$object.scope$::$endif$$object.name$", $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(false),
+factory->add_type_object($if(ctx.GenerateTypesROS2)$"$object.ROS2Scopedname$"$else$"$object.scopedname$"$endif$, $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Identifier(false),
         $if(object.hasScope)$$object.scope$::$endif$Get$object.name$Object(false));
 $if(object.isAnnotation)$
 {


### PR DESCRIPTION
This PR adds name mangling to type object registration code when using `-typeros2` flag