### PR TITLE
Fix generating code when the dependency is in another directory

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -862,16 +862,25 @@ public class fastddsgen
                     String fileName = output_dir + ctx.getFilename() + "SerializationTest.cpp";
                     returnedValue =
                             Utils.writeFile(fileName, maintemplates.getTemplate("SerializationTestSource"), m_replace);
+                    project.addCommonTestingFile(relative_dir + ctx.getFilename() + "SerializationTest.cpp");
 
                     System.out.println("Generating Serialization Source file...");
                     String fileNameS = output_dir + ctx.getFilename() + "Serialization.cpp";
                     returnedValue =
                             Utils.writeFile(fileNameS, maintemplates.getTemplate("SerializationSource"), m_replace);
+                    project.addCommonTestingFile(relative_dir + ctx.getFilename() + "Serialization.cpp");
 
                     System.out.println("Generating Serialization Header file...");
                     String fileNameH = output_dir + ctx.getFilename() + "Serialization.h";
                     returnedValue =
                             Utils.writeFile(fileNameH, maintemplates.getTemplate("SerializationHeader"), m_replace);
+                    project.addCommonTestingFile(relative_dir + ctx.getFilename() + "PubSubTypes.cxx");
+                    
+                    for (String element : project.getFullDependencies())
+                    {
+                        String trimmedElement = element.substring(0, element.length() - 4);// Remove .idl
+                        project.addCommonTestingFile(trimmedElement + "Serialization.cpp");
+                    }
                 }
 
                 // TODO: Uncomment following lines and create templates

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -230,7 +230,7 @@ public class fastddsgen
                 {
                     throw new BadArgumentException("Missing arguments for -extrastg");
                 }
-            } 
+            }
             else if (arg.equals("-ppDisable"))
             {
                 m_ppDisable = true;
@@ -382,7 +382,7 @@ public class fastddsgen
                             getVersion(), m_publishercode, m_subscribercode);
 
             // Load string templates
-            System.out.println("Loading templates from " + System.getProperty("java.class.path"));           
+            System.out.println("Loading templates from " + System.getProperty("java.class.path"));
             // Add path of custom templates to manager search path
             String extraPaths = "";
             for (Map.Entry<String, String> entry : m_customStgOutput.entrySet())
@@ -397,7 +397,7 @@ public class fastddsgen
                     extraPaths += ":./";
                 }
             }
-        	
+
             String templatePaths = "com/eprosima/fastdds/idl/templates:com/eprosima/fastcdr/idl/templates" + extraPaths;
             System.out.println("Template resource folders: " + templatePaths);
             TemplateManager.setGroupLoaderDirectories(templatePaths);
@@ -433,16 +433,9 @@ public class fastddsgen
             // Add product library
             solution.addLibrary("fastrtps");
 
-            ArrayList<String> includedIDL = new ArrayList<String>();
             for (int count = 0; returnedValue && (count < m_idlFiles.size()); ++count)
             {
-                Project project = process(m_idlFiles.get(count), true);
-
-                for (String include : project.getIDLIncludeFiles())
-                {
-                    //System.out.println(ColorMessage.error() + m_idlFiles.get(count) +  " includes " + include);
-                    includedIDL.add(include);
-                }
+                Project project = process(m_idlFiles.get(count), Util.getIDLFileDirectoryOnly(m_idlFiles.get(count)), true);
 
                 if (project != null)
                 {
@@ -456,16 +449,15 @@ public class fastddsgen
                 {
                     returnedValue = false;
                 }
-            }
 
-            // Add include idl files
-            for (String included : includedIDL)
-            {
-                Project inner = process(included, false);
-                if (inner != null && !solution.existsProject(inner.getFile()))
+                for (String include : project.getIDLIncludeFiles())
                 {
-                    System.out.println("Adding project: " + inner.getFile());
-                    solution.addProject(inner);
+                    Project inner = process(include, Util.getIDLFileDirectoryOnly(include), false);
+                    if (inner != null && !solution.existsProject(inner.getFile()))
+                    {
+                        System.out.println("Adding project: " + inner.getFile());
+                        solution.addProject(inner);
+                    }
                 }
             }
 
@@ -608,15 +600,42 @@ public class fastddsgen
 
     private Project process(
             String idlFilename,
+            String relative_directory,
             boolean processCustomTemplates)
     {
         Project project = null;
         System.out.println("Processing the file " + idlFilename + "...");
 
+        String output_dir = m_outputDir;
+        String relative_dir = "";
+
+        if(null != relative_directory && !relative_directory.isEmpty())
+        {
+            File rel_dir = new File(relative_directory);
+
+            if (!rel_dir.isAbsolute())
+            {
+                output_dir += relative_directory;
+                relative_dir = relative_directory;
+            }
+        }
+
+        // Check the output directory exists or create it.
+        File dir = new File(output_dir);
+
+        if (!dir.exists())
+        {
+            if (!dir.mkdirs())
+            {
+                System.out.println(ColorMessage.error() + "Directory " + output_dir + " cannot be created");
+                return null;
+            }
+        }
+
         try
         {
             // Protocol CDR
-            project = parseIDL(idlFilename, processCustomTemplates); // TODO: Quitar archivos copiados TypesHeader.stg, TypesSource.stg, PubSubTypeHeader.stg de la carpeta com.eprosima.fastdds.idl.templates
+            project = parseIDL(idlFilename, output_dir, relative_dir, processCustomTemplates); // TODO: Quitar archivos copiados TypesHeader.stg, TypesSource.stg, PubSubTypeHeader.stg de la carpeta com.eprosima.fastdds.idl.templates
         }
         catch (Exception ioe)
         {
@@ -633,6 +652,8 @@ public class fastddsgen
 
     private Project parseIDL(
             String idlFilename,
+            String output_dir,
+            String relative_dir,
             boolean processCustomTemplates)
     {
         boolean returnedValue = false;
@@ -734,7 +755,7 @@ public class fastddsgen
                 tmanager.addGroup("TypesSwigInterface");
                 tmanager.addGroup("DDSPubSubTypeSwigInterface");
             }
-            
+
             // Load custom templates into manager
             if (processCustomTemplates)
             {
@@ -790,16 +811,16 @@ public class fastddsgen
                         String templateName = path.getFileName().toString().substring(0, path.getFileName().toString().lastIndexOf('.'));
                         System.out.println("Generating from custom " + templateName + " to " + entry.getValue());
 
-                        if (returnedValue = Utils.writeFile(m_outputDir + entry.getValue(), maintemplates.getTemplate(templateName), m_replace))
+                        if (returnedValue = Utils.writeFile(output_dir + entry.getValue(), maintemplates.getTemplate(templateName), m_replace))
                         {
                             // Try to determine if the file is a header file.
                             if (entry.getValue().contains(".hpp") || entry.getValue().contains(".h"))
                             {
-                                project.addCommonIncludeFile(entry.getValue());
+                                project.addCommonIncludeFile(relative_dir + entry.getValue());
                             }
                             else
                             {
-                                project.addCommonSrcFile(ctx.getFilename() + entry.getValue());
+                                project.addCommonSrcFile(relative_dir + ctx.getFilename() + entry.getValue());
                             }
                         }
                         else
@@ -808,30 +829,30 @@ public class fastddsgen
                         }
                     }
                 }
-            	
+
                 System.out.println("Generating Type definition files...");
                 if ((returnedValue) && (returnedValue =
-                        Utils.writeFile(m_outputDir + ctx.getFilename() + ".h",
+                        Utils.writeFile(output_dir + ctx.getFilename() + ".h",
                         maintemplates.getTemplate("TypesHeader"),
                         m_replace)))
                 {
                     if (returnedValue =
-                            Utils.writeFile(m_outputDir + ctx.getFilename() + ".cxx",
+                            Utils.writeFile(output_dir + ctx.getFilename() + ".cxx",
                             maintemplates.getTemplate("TypesSource"), m_replace))
                     {
-                        project.addCommonIncludeFile(ctx.getFilename() + ".h");
-                        project.addCommonSrcFile(ctx.getFilename() + ".cxx");
+                        project.addCommonIncludeFile(relative_dir + ctx.getFilename() + ".h");
+                        project.addCommonSrcFile(relative_dir + ctx.getFilename() + ".cxx");
                         if (m_type_object_files)
                         {
                             System.out.println("Generating TypeObject files...");
-                            if (returnedValue = Utils.writeFile(m_outputDir + ctx.getFilename() + "TypeObject.h",
+                            if (returnedValue = Utils.writeFile(output_dir + ctx.getFilename() + "TypeObject.h",
                                     maintemplates.getTemplate("TypeObjectHeader"), m_replace))
                             {
-                                if (returnedValue = Utils.writeFile(m_outputDir + ctx.getFilename() + "TypeObject.cxx",
+                                if (returnedValue = Utils.writeFile(output_dir + ctx.getFilename() + "TypeObject.cxx",
                                         maintemplates.getTemplate("TypeObjectSource"), m_replace))
                                 {
-                                    project.addCommonIncludeFile(ctx.getFilename() + "TypeObject.h");
-                                    project.addCommonSrcFile(ctx.getFilename() + "TypeObject.cxx");
+                                    project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "TypeObject.h");
+                                    project.addCommonSrcFile(relative_dir + ctx.getFilename() + "TypeObject.cxx");
                                 }
                             }
                         }
@@ -839,7 +860,7 @@ public class fastddsgen
                         {
                             System.out.println("Generating Swig interface files...");
                             if (returnedValue =
-                                    Utils.writeFile(m_outputDir + ctx.getFilename() + ".i",
+                                    Utils.writeFile(output_dir + ctx.getFilename() + ".i",
                                     maintemplates.getTemplate("TypesSwigInterface"), m_replace))
                             {
 
@@ -851,17 +872,17 @@ public class fastddsgen
                 if (m_test)
                 {
                     System.out.println("Generating Serialization Test file...");
-                    String fileName = m_outputDir + ctx.getFilename() + "SerializationTest.cpp";
+                    String fileName = output_dir + ctx.getFilename() + "SerializationTest.cpp";
                     returnedValue =
                             Utils.writeFile(fileName, maintemplates.getTemplate("SerializationTestSource"), m_replace);
 
                     System.out.println("Generating Serialization Source file...");
-                    String fileNameS = m_outputDir + ctx.getFilename() + "Serialization.cpp";
+                    String fileNameS = output_dir + ctx.getFilename() + "Serialization.cpp";
                     returnedValue =
                             Utils.writeFile(fileNameS, maintemplates.getTemplate("SerializationSource"), m_replace);
 
                     System.out.println("Generating Serialization Header file...");
-                    String fileNameH = m_outputDir + ctx.getFilename() + "Serialization.h";
+                    String fileNameH = output_dir + ctx.getFilename() + "Serialization.h";
                     returnedValue =
                             Utils.writeFile(fileNameH, maintemplates.getTemplate("SerializationHeader"), m_replace);
                 }
@@ -874,20 +895,20 @@ public class fastddsgen
 
                     System.out.println("Generating TopicDataTypes files...");
                     if (returnedValue =
-                            Utils.writeFile(m_outputDir + ctx.getFilename() + "PubSubTypes.h",
+                            Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.h",
                             maintemplates.getTemplate("DDSPubSubTypeHeader"), m_replace))
                     {
                         if (returnedValue =
-                                Utils.writeFile(m_outputDir + ctx.getFilename() + "PubSubTypes.cxx",
+                                Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.cxx",
                                 maintemplates.getTemplate("DDSPubSubTypeSource"), m_replace))
                         {
-                            project.addProjectIncludeFile(ctx.getFilename() + "PubSubTypes.h");
-                            project.addProjectSrcFile(ctx.getFilename() + "PubSubTypes.cxx");
+                            project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "PubSubTypes.h");
+                            project.addProjectSrcFile(relative_dir + ctx.getFilename() + "PubSubTypes.cxx");
                             if (m_python)
                             {
                                 System.out.println("Generating Swig interface files...");
                                 returnedValue = Utils.writeFile(
-                                    m_outputDir + ctx.getFilename() + "PubSubTypes.i",
+                                    output_dir + ctx.getFilename() + "PubSubTypes.i",
                                     maintemplates.getTemplate("DDSPubSubTypeSwigInterface"), m_replace);
                             }
                         }
@@ -897,38 +918,38 @@ public class fastddsgen
                     {
                         System.out.println("Generating Publisher files...");
                         if (returnedValue =
-                                Utils.writeFile(m_outputDir + ctx.getFilename() + "Publisher.h",
+                                Utils.writeFile(output_dir + ctx.getFilename() + "Publisher.h",
                                 maintemplates.getTemplate("DDSPublisherHeader"), m_replace))
                         {
                             if (returnedValue =
-                                    Utils.writeFile(m_outputDir + ctx.getFilename() + "Publisher.cxx",
+                                    Utils.writeFile(output_dir + ctx.getFilename() + "Publisher.cxx",
                                     maintemplates.getTemplate("DDSPublisherSource"), m_replace))
                             {
-                                project.addProjectIncludeFile(ctx.getFilename() + "Publisher.h");
-                                project.addProjectSrcFile(ctx.getFilename() + "Publisher.cxx");
+                                project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "Publisher.h");
+                                project.addProjectSrcFile(relative_dir + ctx.getFilename() + "Publisher.cxx");
                             }
                         }
 
                         System.out.println("Generating Subscriber files...");
                         if (returnedValue =
-                                Utils.writeFile(m_outputDir + ctx.getFilename() + "Subscriber.h",
+                                Utils.writeFile(output_dir + ctx.getFilename() + "Subscriber.h",
                                 maintemplates.getTemplate("DDSSubscriberHeader"), m_replace))
                         {
                             if (returnedValue =
-                                    Utils.writeFile(m_outputDir + ctx.getFilename() + "Subscriber.cxx",
+                                    Utils.writeFile(output_dir + ctx.getFilename() + "Subscriber.cxx",
                                     maintemplates.getTemplate("DDSSubscriberSource"), m_replace))
                             {
-                                project.addProjectIncludeFile(ctx.getFilename() + "Subscriber.h");
-                                project.addProjectSrcFile(ctx.getFilename() + "Subscriber.cxx");
+                                project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "Subscriber.h");
+                                project.addProjectSrcFile(relative_dir + ctx.getFilename() + "Subscriber.cxx");
                             }
                         }
 
                         System.out.println("Generating main file...");
                         if (returnedValue =
-                                Utils.writeFile(m_outputDir + ctx.getFilename() + "PubSubMain.cxx",
+                                Utils.writeFile(output_dir + ctx.getFilename() + "PubSubMain.cxx",
                                 maintemplates.getTemplate("DDSPubSubMain"), m_replace))
                         {
-                            project.addProjectSrcFile(ctx.getFilename() + "PubSubMain.cxx");
+                            project.addProjectSrcFile(relative_dir + ctx.getFilename() + "PubSubMain.cxx");
                         }
                     }
                 }
@@ -937,12 +958,12 @@ public class fastddsgen
             // Java support (Java classes and JNI code)
             if (returnedValue && m_languageOption == LANGUAGE.JAVA)
             {
-                String outputDir = m_outputDir;
+                String outputDir = output_dir;
 
                 // Make directories from package.
                 if (!m_package.isEmpty())
                 {
-                    outputDir = m_outputDir + File.separator + m_package.replace('.', File.separatorChar);
+                    outputDir = output_dir + File.separator + m_package.replace('.', File.separatorChar);
                     File dirs = new File(outputDir);
 
                     if (!dirs.exists())
@@ -956,7 +977,7 @@ public class fastddsgen
                 }
 
                 // Java classes.
-                TypesGenerator typeGen = new TypesGenerator(tmanager, m_outputDir, m_replace);
+                TypesGenerator typeGen = new TypesGenerator(tmanager, output_dir, m_replace);
                 TypeCode.javapackage = m_package + (m_package.isEmpty() ? "" : ".");
                 if (!typeGen.generate(ctx, outputDir + File.separator, m_package, ctx.getFilename(), null))
                 {
@@ -966,7 +987,7 @@ public class fastddsgen
 
                 if (ctx.existsLastStructure())
                 {
-                    System.out.println("Generando fichero " + m_outputDir + ctx.getFilename() + "PubSub.java");
+                    System.out.println("Generando fichero " + output_dir + ctx.getFilename() + "PubSub.java");
                     if (!Utils.writeFile(outputDir + File.separator + ctx.getFilename() + "PubSub.java",
                             maintemplates.getTemplate("JavaSource"), m_replace))
                     {
@@ -980,11 +1001,11 @@ public class fastddsgen
                     }
                 }
 
-                if (Utils.writeFile(m_outputDir + ctx.getFilename() + "PubSubJNII.h",
+                if (Utils.writeFile(output_dir + ctx.getFilename() + "PubSubJNII.h",
                         maintemplates.getTemplate("JNIHeader"),
                         m_replace))
                 {
-                    project.addJniIncludeFile(ctx.getFilename() + "PubSubJNII.h");
+                    project.addJniIncludeFile(relative_dir + ctx.getFilename() + "PubSubJNII.h");
                 }
                 else
                 {
@@ -992,9 +1013,9 @@ public class fastddsgen
                 }
 
                 StringTemplate jnisourceTemplate = maintemplates.getTemplate("JNISource");
-                if (Utils.writeFile(m_outputDir + ctx.getFilename() + "PubSubJNI.cxx", jnisourceTemplate, m_replace))
+                if (Utils.writeFile(output_dir + ctx.getFilename() + "PubSubJNI.cxx", jnisourceTemplate, m_replace))
                 {
-                    project.addJniSrcFile(ctx.getFilename() + "PubSubJNI.cxx");
+                    project.addJniSrcFile(relative_dir + ctx.getFilename() + "PubSubJNI.cxx");
                 }
                 else
                 {

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -44,7 +44,6 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
 {
     // TODO Remove middleware parameter. It is temporal while cdr and rest don't have async functions.
     public Context(
-            String filename,
             String file,
             ArrayList<String> includePaths,
             boolean subscribercode,
@@ -54,7 +53,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             boolean generate_typesc,
             boolean generate_type_ros2)
     {
-        super(filename, file, includePaths);
+        super(file, includePaths);
         m_fileNameUpper = getFilename().toUpperCase();
         m_subscribercode = subscribercode;
         m_publishercode = publishercode;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
@@ -44,10 +44,9 @@ target_link_libraries($project.name$ $solution.libraries : {$it$}; separator=" "
 
 $if(test)$
 # $project.name$ Serialization Test
-add_executable($project.name$SerializationTest $project.name$SerializationTest.cpp
-        $project.name$Serialization.cpp
-        $project.dependencies : {$it$Serialization.cpp}; separator=" "$
-        $project.name$PubSubTypes.cxx)
+add_executable($project.name$SerializationTest
+        $project.commonTestingFiles : {$it$}; separator="\n"$
+)
 target_link_libraries($project.name$SerializationTest $solution.libraries : {$it$}; separator=" "$
         $project.name$_lib $project.dependencies : {$it$_lib}; separator=" "$)
 

--- a/src/main/java/com/eprosima/fastdds/solution/Project.java
+++ b/src/main/java/com/eprosima/fastdds/solution/Project.java
@@ -188,7 +188,6 @@ public class Project extends com.eprosima.solution.Project
             if(!getParent().getOS().contains("Windows") ||
                     getParent().existsProject(deps.get(count)))
             {
-                //System.out.println("Adding GUID of " + deps.get(count));
                 array.add(GUIDGenerator.genGUID(deps.get(count) + "JNI"));
             }
         }

--- a/src/main/java/com/eprosima/fastdds/util/Utils.java
+++ b/src/main/java/com/eprosima/fastdds/util/Utils.java
@@ -58,7 +58,7 @@ public class Utils
         if(index != -1)
             auxString = auxString.substring(0, index);
 
-           returnedValue = auxString;
+        returnedValue = auxString;
 
         return returnedValue;
     }
@@ -105,9 +105,9 @@ public class Utils
     }
 
     public static String getFileExtension(String fileName)
-	{
-	    int lastDot = fileName.lastIndexOf(".");
+    {
+        int lastDot = fileName.lastIndexOf(".");
 
-	    return fileName.substring(lastDot+1);
-	}
+        return fileName.substring(lastDot+1);
+    }
 }

--- a/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
+++ b/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
@@ -25,6 +25,73 @@ public class FastDDSGenTest
     }
 
     @Test
+    public void Context_getRelativeDir_Test()
+    {
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", "Prueba.idl", new ArrayList<String>());
+
+            assertEquals("", ctx.getRelativeDir(null));
+        }
+
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", "dir/Prueba.idl", new ArrayList<String>());
+
+            assertEquals("dir/", ctx.getRelativeDir(null));
+        }
+
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", "../../dir/Prueba.idl", new ArrayList<String>());
+
+            assertEquals("../../dir/", ctx.getRelativeDir(null));
+        }
+
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", System.getProperty("user.dir") + "Prueba.idl", new ArrayList<String>());
+
+            assertEquals("", ctx.getRelativeDir(null));
+        }
+
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", System.getProperty("user.dir") + "dir/Prueba.idl", new ArrayList<String>());
+
+            assertEquals("dir/", ctx.getRelativeDir(null));
+        }
+
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", System.getProperty("user.dir") + "../../dir/Prueba.idl", new ArrayList<String>());
+
+            assertEquals("../../dir/", ctx.getRelativeDir(null));
+        }
+
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", "/home/testing/Prueba.idl", new ArrayList<String>());
+
+            assertEquals("", ctx.getRelativeDir(null));
+        }
+
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", "/home/testing/Prueba.idl", new ArrayList<String>());
+
+            assertEquals("", ctx.getRelativeDir("/home/testing/"));
+        }
+
+        {
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    "Prueba.idl", "/home/testing/Prueba.idl", new ArrayList<String>());
+
+            assertEquals("testing/", ctx.getRelativeDir("/home/"));
+        }
+    }
+
+    @Test
     public void runTests()
     {
         if (!isUnix())
@@ -41,5 +108,4 @@ public class FastDDSGenTest
         boolean testResult = tests.runTests();
         System.exit(testResult ? 0 : -1);
     }
-
 }

--- a/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
+++ b/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
@@ -29,63 +29,63 @@ public class FastDDSGenTest
     {
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", "Prueba.idl", new ArrayList<String>());
+                    "Prueba.idl", new ArrayList<String>());
 
             assertEquals("", ctx.getRelativeDir(null));
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", "dir/Prueba.idl", new ArrayList<String>());
+                    "dir/Prueba.idl", new ArrayList<String>());
 
             assertEquals("dir/", ctx.getRelativeDir(null));
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", "../../dir/Prueba.idl", new ArrayList<String>());
+                    "../../dir/Prueba.idl", new ArrayList<String>());
 
             assertEquals("../../dir/", ctx.getRelativeDir(null));
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", System.getProperty("user.dir") + "Prueba.idl", new ArrayList<String>());
+                    System.getProperty("user.dir") + "Prueba.idl", new ArrayList<String>());
 
             assertEquals("", ctx.getRelativeDir(null));
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", System.getProperty("user.dir") + "dir/Prueba.idl", new ArrayList<String>());
+                    System.getProperty("user.dir") + "dir/Prueba.idl", new ArrayList<String>());
 
             assertEquals("dir/", ctx.getRelativeDir(null));
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", System.getProperty("user.dir") + "../../dir/Prueba.idl", new ArrayList<String>());
+                    System.getProperty("user.dir") + "../../dir/Prueba.idl", new ArrayList<String>());
 
             assertEquals("../../dir/", ctx.getRelativeDir(null));
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", "/home/testing/Prueba.idl", new ArrayList<String>());
+                    "/home/testing/Prueba.idl", new ArrayList<String>());
 
             assertEquals("", ctx.getRelativeDir(null));
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", "/home/testing/Prueba.idl", new ArrayList<String>());
+                    "/home/testing/Prueba.idl", new ArrayList<String>());
 
             assertEquals("", ctx.getRelativeDir("/home/testing/"));
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    "Prueba.idl", "/home/testing/Prueba.idl", new ArrayList<String>());
+                    "/home/testing/Prueba.idl", new ArrayList<String>());
 
             assertEquals("testing/", ctx.getRelativeDir("/home/"));
         }


### PR DESCRIPTION
Depends on:

- eProsima/IDL-Parser#76

For a case where an IDL file includes another one in another directory, the generation fails.
```idl
#include "helper/other.idl"
...
```