### PR TITLE
Feature/json

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/JsonSupportHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/JsonSupportHeader.stg
@@ -1,0 +1,99 @@
+/*
+ * 
+ */
+
+group JsonSupportHeader;
+
+fromJsonDeclaration(type) ::= <<
+/*!
+ * @brief Create an instance of $type$ from a JSON string.
+ * @throws std::runtime_error on JSON error.
+ */
+eProsima_user_DllExport $type$ $type$FromJson(std::string const& jsonText);
+>>
+
+main(ctx, definitions) ::= <<
+$fileHeader(file=[ctx.filename, "JsonSupport.h"], description=["This header file contains JSON support for the described types in the IDL file."])$
+
+#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_JSON_SUPPORT_H_
+#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_JSON_SUPPORT_H_
+
+$ctx.directIncludeDependencies : {include | #include "$include$JsonSupport.h"}; separator="\n"$
+
+#include <string>
+#include "$ctx.filename$.h"
+
+#if defined(_WIN32)
+#if defined(EPROSIMA_USER_DLL_EXPORT)
+#define eProsima_user_DllExport __declspec( dllexport )
+#else
+#define eProsima_user_DllExport
+#endif
+#else
+#define eProsima_user_DllExport
+#endif
+
+#if defined(_WIN32)
+#if defined(EPROSIMA_USER_DLL_EXPORT)
+#if defined($ctx.filename;format="toUpper"$_SOURCE)
+#define $ctx.filename;format="toUpper"$_DllAPI __declspec( dllexport )
+#else
+#define $ctx.filename;format="toUpper"$_DllAPI __declspec( dllimport )
+#endif // $ctx.filename;format="toUpper"$_SOURCE
+#else
+#define $ctx.filename;format="toUpper"$_DllAPI
+#endif
+#else
+#define $ctx.filename;format="toUpper"$_DllAPI
+#endif // _WIN32
+
+$definitions; separator="\n"$
+
+#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_JSON_SUPPORT_H_
+
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+$definition_list$
+} // namespace $module.name$
+>>
+
+definition_list(definitions) ::= <<
+$definitions; separator="\n\n"$
+>>
+
+
+struct_type(ctx, parent, struct, extension) ::= <<
+$fromJsonDeclaration(struct.name)$
+>>
+
+bitset_type(ctx, parent, bitset) ::= <<
+$fromJsonDeclaration(bitset.name)$
+>>
+
+union_type(ctx, parent, union) ::= <<
+$fromJsonDeclaration(union.name)$
+>>
+
+enum_type(ctx, parent, enum) ::= <<
+$fromJsonDeclaration(enum.name)$
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<>>
+
+export_list(exports) ::= <<>>
+
+exception(ctx, parent, exception) ::= <<>>
+
+operation(ctx, parent, operation, param_list) ::= <<>>
+
+param_list(parameters) ::= <<>>
+
+param(parameter) ::= <<>>
+
+const_decl(ctx, parent, const) ::= <<>>
+
+typedef_decl(ctx, parent, typedefs) ::= <<>>
+
+bitmask_type(ctx, parent, bitmask) ::= <<>>

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/JsonSupportSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/JsonSupportSource.stg
@@ -1,0 +1,252 @@
+
+group JsonSupportSource;
+
+main(ctx, definitions) ::= <<
+/*
+ * This automatically generated source file contains JSON support for the types 
+ * described in $ctx.filename$.idl 
+ */
+
+#ifdef _WIN32
+// Remove linker warning LNK4221 on Visual Studio
+namespace { char dummy; }
+#endif
+
+#include "$ctx.filename$.h"
+#include "$ctx.filename$JsonSupport.h"
+#include <utility>
+#include <stdexcept>
+#include <type_traits>
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+namespace {
+template<class T>
+struct Assign {
+    T& target;
+    Assign(T& i_target) : target(i_target) { }
+    void operator()(T const& i_value) { target = i_value; }
+};
+
+template<class T>
+T fromString(std::string const& value);
+
+template<>
+bool fromString<bool>(std::string const& value)
+{
+    if (value.size() > 0 && std::tolower(value.front()) == 't') {
+        return true;
+    }
+    return false;
+}
+
+template<>
+float fromString<float>(std::string const& value)
+{
+    return std::stod(value);
+}
+
+template<>
+double fromString<double>(std::string const& value)
+{
+    return std::stod(value);
+}
+
+template<>
+std::string fromString<std::string>(std::string const& value)
+{
+    return value;
+}
+
+template<class T>
+typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value,T>::type
+fromString(std::string const& value)
+{
+    return std::stoull(value);
+}
+
+template<class T>
+typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value,T>::type
+fromString(std::string const& value)
+{
+    return std::stoll(value);
+}
+
+}
+
+$definitions; separator="\n"$
+
+>>
+
+name_access(it) ::= "sample.$it.name$"
+
+back_access(access) ::= "$access$().push_back"
+
+json_access(key) ::= <<data["$key$"]>>
+
+json_ref_name(name) ::= "ref_$name$"
+
+element_name(name) ::= "element_$name$"
+
+array_access(access, index) ::= "$access$()[$index$]"
+
+array_assign(name) ::= "$name$Access"
+
+member_deserialize(member, typecode, access, json) ::= <<
+$if(typecode.isEnumType)$
+if (!$json$.is_string()) {
+    throw std::runtime_error("$member.name$ expected to be a string type");
+}
+$access$($typecode.name$FromJson($json$.get<std::string>()));
+$elseif(typecode.primitive)$
+$access$($json$.get<$typecode.cppTypename$>());
+$elseif(typecode.isStringType)$
+if (!$json$.is_string()) {
+    throw std::runtime_error("$member.name$ expected to be a string type");
+}
+$access$($json$.get<std::string>());
+$elseif(typecode.isStructType)$
+if (!$json$.is_object()) {
+    throw std::runtime_error("$member.name$ expected to be an object type");
+}
+$access$($typecode.name$FromJson($json$));
+$elseif(typecode.isMapType)$
+if (!$json$.is_object()) {
+    throw std::runtime_error("$member.name$ expected to be an object type");
+}
+for (auto const& $element_name(member.name)$ : $json$) {
+    // DANGER does not work for enums
+    auto key_$member.name$ = fromString<$typecode.keyTypeCode.cppTypename$>($element_name(member.name)$.first);
+    auto value_$member.name$ = $element_name(member.name)$.second.get<$typecode.valueTypeCode.cppTypename$>();
+    $access$()[key_$member.name$] = value_$member.name$;
+}
+$elseif(typecode.isUnionType)$
+if (!$json$.is_object()) {
+    throw std::runtime_error("$member.name$ expected to be an object type");
+}
+$access$($typecode.name$FromJson($json$));
+$elseif(typecode.isSequenceType)$
+if (!$json$.is_array()) {
+    throw std::runtime_error("$member.name$ expected to be an array type");
+}
+for (auto const& $element_name(member.name)$ : $json$) {        
+    $member_deserialize( member=member, typecode=typecode.contentTypeCode, access=back_access(access), json=element_name(member.name))$
+}
+$elseif(typecode.isArrayType)$
+if (!$json$.is_array()) {
+    throw std::runtime_error("$member.name$ expected to be an array type");
+}
+if ($json$.size() != $typecode.size$) {
+    throw std::runtime_error("$member.name$ expected array of exactly $typecode.size$ values");
+}
+for (std::size_t $element_name(member.name)$=0; $element_name(member.name)$ < $json$.size(); $element_name(member.name)$++) {
+    Assign<$typecode.contentTypeCode.cppTypename$> $array_assign(member.name)$($array_access(access=access, index=element_name(member.name))$);
+    json const& $json_ref_name(member.name)$ = $json$[$element_name(member.name)$];    
+    $member_deserialize( member=member, typecode=typecode.contentTypeCode, access=array_assign(member.name), json=json_ref_name(member.name))$
+}
+$elseif(typecode.isBitsetType)$
+if (!$json$.is_object()) {
+    throw std::runtime_error("$member.name$ expected to be an object type");
+}
+$access$($typecode.name$FromJson($json$));
+$else$
+// Unhandled type $member.name$
+$endif$
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+$definition_list$
+} // namespace $module.name$
+>>
+
+definition_list(definitions) ::= <<
+$definitions; separator="\n\n"$
+>>
+
+
+struct_type(ctx, parent, struct, extension) ::= <<
+$struct.name$ $struct.name$FromJson(json const& data)
+{
+    $struct.name$ sample;
+    $struct.members:member_deserialize(member=it, typecode=it.typecode, access=name_access(it), json=json_access(it.name)); separator="\n"$
+    return sample;
+}
+$struct.name$ $struct.name$FromJson(std::string const& text)
+{
+    return $struct.name$FromJson(json::parse(text));
+}
+>>
+
+bitset_type(ctx, parent, bitset) ::= <<
+$bitset.name$ $bitset.name$FromJson(json const& data)
+{
+    $bitset.name$ sample;      
+    $bitset.bitfields:{$name_access(it)$($json_access(it.name)$.get<$it.spec.cppTypename$>());}; separator="\n"$
+    return sample;
+}
+$bitset.name$ $bitset.name$FromJson(std::string const& text)
+{
+    return $bitset.name$FromJson(json::parse(text));
+}
+>>
+
+union_type(ctx, parent, union) ::= <<
+$union.name$ $union.name$FromJson(json const& data)
+{
+    $union.name$ sample;
+    $first(union.members),first(union.discriminator.members):{it,dname|if (data.contains("$it.name$")) {
+    sample._d() = $dname.name$;
+    $member_deserialize(member=it, typecode=it.typecode, access=name_access(it), json=json_access(it.name))$ 
+}}; separator="\n"$
+    $rest(union.members),rest(union.discriminator.members):{it,dname|else if (data.contains("$it.name$")) { 
+    sample._d() = $dname.name$;
+    $member_deserialize(member=it, typecode=it.typecode, access=name_access(it), json=json_access(it.name))$ 
+}}; separator="\n"$
+    return sample;
+}
+$union.name$ $union.name$FromJson(std::string const& text)
+{
+    return $union.name$FromJson(json::parse(text));
+}
+>>
+
+enum_type(ctx, parent, enum) ::= <<
+$enum.name$ $enum.name$FromJson(json const& data)
+{
+    if (data.is_number()) {
+        int v = data.get<int>();
+        switch(v) {
+            $enum.members : {case $it.name$: return $it.name$;}; separator="\n"$
+        }
+        throw std::runtime_error("Value not recognized as type of enum $enum.name$");
+    } else if (data.is_string()) {
+        return $enum.name$FromJson(data.get<std::string>());
+    }
+    throw std::runtime_error("String not recognized as type of enum $enum.name$");
+}
+$enum.name$ $enum.name$FromJson(std::string const& text)
+{
+    $enum.members : {if (text == "$it.name$") return $it.name$;}; separator="\n"$    
+    throw std::runtime_error("String not recognized as type of enum $enum.name$");
+}
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<>>
+
+export_list(exports) ::= <<>>
+
+exception(ctx, parent, exception) ::= <<>>
+
+operation(ctx, parent, operation, param_list) ::= <<>>
+
+param_list(parameters) ::= <<>>
+
+param(parameter) ::= <<>>
+
+const_decl(ctx, parent, const) ::= <<>>
+
+typedef_decl(ctx, parent, typedefs) ::= <<>>
+
+bitmask_type(ctx, parent, bitmask) ::= <<>>

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -501,6 +501,7 @@ enum $enum.name$ : uint32_t
 {
     $enum.members:{$it.name$}; separator=",\n"$
 };
+std::string to_string($enum.name$ const& value);
 >>
 
 bitmask_type(ctx, parent, bitmask) ::= <<

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -281,6 +281,11 @@ public:
 
     $struct.members:{$public_member_declaration(it)$}; separator="\n"$
 
+    /*!
+     * @brief Serialize to JSON.
+     */
+     eProsima_user_DllExport std::string toJson() const;
+
     $if(ctx.anyCdr)$
     /*!
     * @brief This function returns the maximum serialized size of an object
@@ -388,6 +393,11 @@ public:
 
     $union.members:{$public_unionmember_declaration(it)$}; separator="\n"$
 
+    /*!
+     * @brief Serialize the active member to Json.
+     */
+    std::string toJson() const;
+
     $size_functions(union)$
 
     $serialization_functions(union)$
@@ -464,6 +474,11 @@ public:
             const $bitset.name$& x) const;
 
     $bitset.bitfields:{$public_bitfield_declaration(it)$}; separator="\n"$
+
+    /*!
+     * @brief Make a json representation
+     */
+     std::string toJson() const;
 
     $size_functions(bitset)$
 

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -29,6 +29,40 @@ $if(ctx.generateTypeObject)$
 #include "$ctx.filename$TypeObject.h"
 $endif$
 
+/*
+ * Convert primitive values to string for json representation
+ */
+namespace {
+template<class T>
+std::string ToJsonString(T const& value)
+{
+    return std::to_string(value);
+}
+
+template<>
+std::string ToJsonString<bool>(bool const& value)
+{
+    return value? "true" : "false";
+}
+
+template<>
+std::string ToJsonString<double>(double const& value)
+{
+    std::string result(31, 0);
+    snprintf(const_cast<char*>(result.c_str()), 31, "%.16f", value);
+    return result;
+}
+
+template<>
+std::string ToJsonString<float>(float const& value)
+{
+    std::string result(15, 0);
+    snprintf(const_cast<char*>(result.c_str()), 14, "%.9f", value);
+    return result;
+}
+} // namespace
+
+
 $if(ctx.cdr)$
 #include <fastcdr/Cdr.h>
 
@@ -61,6 +95,60 @@ $definitions; separator="\n"$
 
 module(ctx, parent, module, definition_list) ::= <<
 $definition_list$
+>>
+
+json_member_access(member) ::= "$member.name$()"
+
+json_element_name(member) ::= "element_$member.name$"
+
+json_map_key(member) ::= "element_$member.name$.first"
+
+json_map_value(member) ::= "element_$member.name$.second"
+
+to_json_sequence(member) ::= <<
+json += "[";
+for (auto const& $json_element_name(member)$ : $member.name$()) {
+    $to_json_value(member=member, typecode=member.typecode.contentTypeCode, access=json_element_name(member))$
+    json += ',';
+}
+if (json.back() == '[') 
+    json.push_back(']');    
+else
+    json.back() = ']';
+>>
+
+to_json_map(member) ::= <<
+json += "{";
+for (auto const& entry_$member.name$ : $member.name$()) {       
+    $if (member.typecode.keyTypeCode.isStringType)$
+    json += "\"" + $json_map_key(member)$ "\":";
+    $else$
+    json += "\"" + ToJsonString($json_map_key(member)$) "\":";
+    $endif$                
+    $to_json_value(member=member, typecode=member.typecode.valueTypeCode, access=json_map_value(member))$        
+    json += ',';
+}
+if (json.back() == '{') 
+    json.push_back('}');
+else 
+    json.back() = '}';
+>>
+
+
+to_json_value(member, typecode, access) ::= <<
+$! 
+ ! Note the strange formatting is used to suppress unwanted newlines in the output 
+ !$
+$if(typecode.primitive)$
+json += ToJsonString($access$);$elseif(typecode.isStringType)$json += "\"" + $access$ + "\"";$elseif(typecode.isStructType)$json += $access$.toJson();$elseif(typecode.isMapType)$$to_json_map(member)$$elseif(typecode.isUnionType)$json += $access$.toJson();$elseif(typecode.isSequenceType)$$to_json_sequence(member)$$elseif(typecode.isArrayType)$$to_json_sequence(member)$$elseif(typecode.isBitsetType)$json += $access$.toJson();$else$// Unhandled typecode $typecode$ for $member.name$
+$endif$
+>>
+
+
+to_json(member) ::= <<
+json += "\"$member.name$\":";
+$to_json_value(member=member, typecode=member.typecode, access=json_member_access(member))$
+json += ",";
 >>
 
 definition_list(definitions) ::= <<
@@ -270,6 +358,16 @@ bool $struct.scopedname$::operator !=(
     return !(*this == x);
 }
 
+std::string $struct.scopedname$::toJson() const
+{
+    std::string json;
+    json += "{";    
+    $trunc(struct.members):to_json(); separator="\n"$
+    $last(struct.members):{member | json += "\"$member.name$\":";$\n$$to_json_value(member=member, typecode=member.typecode, access=json_member_access(member))$}$    
+    json += "}";
+    return json;
+}
+
 $if(ctx.anyCdr)$
 size_t $struct.scopedname$::getMaxCdrSerializedSize(
         size_t current_alignment)
@@ -397,6 +495,11 @@ bool $bitset.scopedname$::operator !=(
         const $bitset.name$& x) const
 {
     return !(*this == x);
+}
+
+std::string $bitset.scopedname$::toJson() const
+{    
+    return "\"" + m_bitset.to_string() + "\"";
 }
 
 $if(ctx.anyCdr)$
@@ -615,6 +718,21 @@ $union.discriminator.cppTypename$& $union.scopedname$::_d()
 }
 
 $union.members:{$public_unionmember_declaration(class=union.scopedname, member=it, defaultvalue=union.defaultvalue, totallabels=union.totallabels)$}; separator="\n"$
+
+std::string $union.scopedname$::toJson() const
+{
+    std::string json;
+    json += "{";
+    switch(m__d) {
+        $union.members:{member | $member.labels:{case $it$: }; separator="\n"$ 
+        json += "\"$member.name$\":";
+        $to_json_value(member=member, typecode=member.typecode, access=json_member_access(member))$break; }; anchor, separator="\n"$
+        default: 
+            json += "\"unknown\":null";
+    }
+    json += "}";
+    return json;
+}
 
 $if(ctx.anyCdr)$
 // TODO(Ricardo) Review

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -36,7 +36,8 @@ namespace {
 template<class T>
 std::string ToJsonString(T const& value)
 {
-    return std::to_string(value);
+    using std::to_string;
+    return to_string(value);
 }
 
 template<>
@@ -48,17 +49,17 @@ std::string ToJsonString<bool>(bool const& value)
 template<>
 std::string ToJsonString<double>(double const& value)
 {
-    std::string result(31, 0);
-    snprintf(const_cast<char*>(result.c_str()), 31, "%.16f", value);
-    return result;
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%.16g", value);
+    return buf;
 }
 
 template<>
 std::string ToJsonString<float>(float const& value)
 {
-    std::string result(15, 0);
-    snprintf(const_cast<char*>(result.c_str()), 14, "%.9f", value);
-    return result;
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%.9g", value);
+    return buf;
 }
 } // namespace
 
@@ -109,7 +110,7 @@ to_json_sequence(member) ::= <<
 json += "[";
 for (auto const& $json_element_name(member)$ : $member.name$()) {
     $to_json_value(member=member, typecode=member.typecode.contentTypeCode, access=json_element_name(member))$
-    json += ',';
+    json += ",";
 }
 if (json.back() == '[') 
     json.push_back(']');    
@@ -121,26 +122,40 @@ to_json_map(member) ::= <<
 json += "{";
 for (auto const& entry_$member.name$ : $member.name$()) {       
     $if (member.typecode.keyTypeCode.isStringType)$
-    json += "\"" + $json_map_key(member)$ "\":";
+    json += "\"" + $json_map_key(member)$ + "\":";
     $else$
-    json += "\"" + ToJsonString($json_map_key(member)$) "\":";
+    json += "\"" + ToJsonString($json_map_key(member)$) + "\":";
     $endif$                
     $to_json_value(member=member, typecode=member.typecode.valueTypeCode, access=json_map_value(member))$        
-    json += ',';
+    json += ",";
 }
-if (json.back() == '{') 
+if (json.back() =='{') 
     json.push_back('}');
 else 
     json.back() = '}';
 >>
 
-
 to_json_value(member, typecode, access) ::= <<
-$! 
- ! Note the strange formatting is used to suppress unwanted newlines in the output 
- !$
-$if(typecode.primitive)$
-json += ToJsonString($access$);$elseif(typecode.isStringType)$json += "\"" + $access$ + "\"";$elseif(typecode.isStructType)$json += $access$.toJson();$elseif(typecode.isMapType)$$to_json_map(member)$$elseif(typecode.isUnionType)$json += $access$.toJson();$elseif(typecode.isSequenceType)$$to_json_sequence(member)$$elseif(typecode.isArrayType)$$to_json_sequence(member)$$elseif(typecode.isBitsetType)$json += $access$.toJson();$else$// Unhandled typecode $typecode$ for $member.name$
+$if(typecode.isEnumType)$
+json += "\"" + ToJsonString($access$) + "\"";
+$elseif(typecode.primitive)$
+json += ToJsonString($access$);
+$elseif(typecode.isStringType)$
+json += "\"" + $access$ + "\"";
+$elseif(typecode.isStructType)$
+json += $access$.toJson();
+$elseif(typecode.isMapType)$
+$to_json_map(member)$
+$elseif(typecode.isUnionType)$
+json += $access$.toJson();
+$elseif(typecode.isSequenceType)$
+$to_json_sequence(member)$
+$elseif(typecode.isArrayType)$
+$to_json_sequence(member)$
+$elseif(typecode.isBitsetType)$
+json += $access$.toJson();
+$else$
+// Unhandled typecode $typecode$ for $member.name$
 $endif$
 >>
 
@@ -499,7 +514,13 @@ bool $bitset.scopedname$::operator !=(
 
 std::string $bitset.scopedname$::toJson() const
 {    
-    return "\"" + m_bitset.to_string() + "\"";
+    std::string json;
+    json += "{";
+    $trunc(bitset.bitfields):{$if(!it.annotationNonSerialized)$json += "\"$it.name$\":" + std::to_string($it.name$()) + ",";$endif$}; separator="\n"$
+    $last(bitset.bitfields):{$if(!it.annotationNonSerialized)$json += "\"$it.name$\":" + std::to_string($it.name$());$endif$}; separator="\n"$
+    json += "}";
+    return json;
+    // return "\"" + m_bitset.to_string() + "\"";
 }
 
 $if(ctx.anyCdr)$
@@ -812,7 +833,15 @@ $endif$
 
 >>
 
-enum_type(ctx, parent, enum) ::= <<>>
+enum_type(ctx, parent, enum) ::= <<
+std::string $if(enum.hasScope)$$enum.scope$::$endif$to_string($enum.scopedname$ const& value)
+{
+    switch(value) {
+        $enum.members:{case $enum.scopedname$::$it.name$: return "$it.name$";}; separator="\n"$
+        default: return "";
+    }    
+}
+>>
 
 bitmask_type(ctx, parent, bitmask) ::= <<>>
 

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -117,6 +117,9 @@ public class fastddsgen
     // Generate python binding files
     private boolean m_python = false;
 
+    // Generate json support files
+    private boolean m_json_files = false;
+
     private boolean m_case_sensitive = false;
 
     // Testing
@@ -290,6 +293,10 @@ public class fastddsgen
             else if (arg.equals("-python"))
             {
                 m_python = true;
+            }
+            else if (arg.equals("-json"))
+            {
+                m_json_files = true;
             }
             else if (arg.equals("-test"))
             {
@@ -562,6 +569,7 @@ public class fastddsgen
         System.out.println("\t\t-cs: IDL grammar apply case sensitive matching.");
         System.out.println("\t\t-test: executes FastDDSGen tests.");
         System.out.println("\t\t-python: generates python bindings for the generated types.");
+        System.out.println("\t\t-json: generates json-to-type support for the generated types.");
         System.out.println("\tand the supported input files are:");
         System.out.println("\t* IDL files.");
 
@@ -726,6 +734,12 @@ public class fastddsgen
                 tmanager.addGroup("SerializationSource");
             }
 
+            if (m_json_files)
+            {
+                tmanager.addGroup("JsonSupportHeader");
+                tmanager.addGroup("JsonSupportSource");
+            }
+
             // Add JNI sources.
             if (m_languageOption == LANGUAGE.JAVA)
             {
@@ -766,7 +780,7 @@ public class fastddsgen
                 lexer.setContext(ctx);
                 CommonTokenStream tokens = new CommonTokenStream(lexer);
                 IDLParser parser = new IDLParser(tokens);
-                // Pass the finelame without the extension
+                // Pass the filename without the extension
 
                 Specification specification = parser.specification(ctx, tmanager, maintemplates).spec;
                 returnedValue = specification != null;
@@ -853,6 +867,19 @@ public class fastddsgen
 
                             }
                         }
+                        
+                        if (m_json_files)
+                        {
+                            System.out.println("Generating json support files...");
+                            if (returnedValue =
+                                    Utils.writeFile(output_dir + ctx.getFilename() + "JsonSupport.h",
+                                    maintemplates.getTemplate("JsonSupportHeader"), m_replace))
+                            {
+                                returnedValue = Utils.writeFile(output_dir + ctx.getFilename() + "JsonSupport.cxx",
+                                    maintemplates.getTemplate("JsonSupportSource"), m_replace);
+                            }
+                        }
+                        
                     }
                 }
 


### PR DESCRIPTION
Add to/from json support.

For type-to-json, I've added a method to generated types `toJson()` that produces a json string. This requires the changes to the idl parser to distinguish enum types (so that they may be serialized as strings in json). These json strings provide a simple way to view the contents of an idl-derived type when debugging an application.

For type-from-json, I added optional extra output files.

- The new `-json` command-line argument will generate FooJsonSupport.h/cxx from Foo.idl along with the other artifacts.
- The FooJsonSupport.h files `XXXFromJson(std::string)` functions that return instances of the idl-derived type by value.
- FooJsonSupport.cxx relies on https://github.com/nlohmann/json for json parsing. The `json.hpp` file must be in the include path when compiling FooJsonSupport.cxx.

I know requiring users of fastddsgen to supply libraries other than fastcdr is a burden, so I've tried to isolate use by making these files (a) optionally generated and (b) only requiring the library for the cxx.

