### PR TITLE
Simplify unions to never throw

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "thirdparty/idl-parser"]
 	path = thirdparty/idl-parser
-	url = https://github.com/eProsima/IDL-Parser.git
+	url = git@github.com:mikegratton/IDL-Parser.git
 [submodule "thirdparty/dds-types-test"]
 	path = thirdparty/dds-types-test
 	url = https://github.com/eProsima/dds-types-test.git

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSource.stg
@@ -589,19 +589,7 @@ bool $union.scopedname$::operator !=(
 void $union.scopedname$::_d(
         $union.discriminator.cppTypename$ __d)
 {
-    bool b = false;
-
-    switch(m__d)
-    {
-        $union.members:{$unionmember_discriminator_case(member=it, totallabels=union.totallabels)$}; separator="\n"$
-    }
-
-    if(!b)
-    {
-        throw BadParamException("Discriminator doesn't correspond with the selected union member");
-    }
-
-    m__d = __d;
+    m__d = __d;    
 }
 
 $union.discriminator.cppTypename$ $union.scopedname$::_d() const
@@ -808,7 +796,15 @@ $member.typecode.cppTypename$& $class$::$member.name$()
 >>
 
 public_unionmember_declaration(class, member, totallabels, defaultvalue) ::= <<
-$if(ctx.generateTypesC)$$if(member.typecode.isStringType)$$unionmember_cstring_declaration(class=class, member=member, totallabels=totallabels, defaultvalue=defaultvalue)$$else$$public_unionmember_cpp_declaration(class=class, member=member, totallabels=totallabels, defaultvalue=defaultvalue)$$endif$$else$$public_unionmember_cpp_declaration(class=class, member=member, totallabels=totallabels, defaultvalue=defaultvalue)$$endif$
+$if(ctx.generateTypesC)$
+$if(member.typecode.isStringType)$
+$unionmember_cstring_declaration(class=class, member=member, totallabels=totallabels, defaultvalue=defaultvalue)$
+$else$
+$public_unionmember_cpp_declaration(class=class, member=member, totallabels=totallabels, defaultvalue=defaultvalue)$
+$endif$
+$else$
+$public_unionmember_cpp_declaration(class=class, member=member, totallabels=totallabels, defaultvalue=defaultvalue)$
+$endif$
 >>
 
 unionmember_cstring_declaration(class, member, totallabels, defaultvalue) ::= <<
@@ -840,15 +836,11 @@ void $class$::$member.name$(
 
 $member.typecode.cppTypename$ $class$::$member.name$() const
 {
-    $unionmember_check_case_list(member=member, totallabels=totallabels)$
-
     return m_$member.name$;
 }
 
 $member.typecode.cppTypename$& $class$::$member.name$()
 {
-    $unionmember_check_case_list(member=member, totallabels=totallabels)$
-
     return m_$member.name$;
 }
 $else$
@@ -868,15 +860,11 @@ void $class$::$member.name$(
 
 const $member.typecode.cppTypename$& $class$::$member.name$() const
 {
-    $unionmember_check_case_list(member=member, totallabels=totallabels)$
-
     return m_$member.name$;
 }
 
 $member.typecode.cppTypename$& $class$::$member.name$()
 {
-    $unionmember_check_case_list(member=member, totallabels=totallabels)$
-
     return m_$member.name$;
 }
 $endif$
@@ -1012,37 +1000,6 @@ m__d = $defaultvalue$;
 $else$
 m__d = $first(member.labels)$;
 $endif$
->>
-
-unionmember_check_case_list(member, totallabels) ::= <<
-$if(member.default)$
-bool b = true;
-
-switch(m__d)
-{
-    $totallabels:{case $it$:}; separator="\n"$
-    b = false;
-    break;
-    default:
-    break;
-}
-$else$
-bool b = false;
-
-switch(m__d)
-{
-    $member.labels:{case $it$:}; separator="\n"$
-    b = true;
-    break;
-    default:
-    break;
-}
-$endif$
-
-if(!b)
-{
-    throw BadParamException("This member has not been selected");
-}
 >>
 
 unionmember_case_selection_se(ctx, member) ::= <<


### PR DESCRIPTION
Simplify union types to never throw. Changing the discriminator always succeeds, and accessing a non-active member is legal. 

For example, these changes make the following legal
```
SomeUnionType foo;
foo._d(kCaseBar); // Select another member "bar"
foo.bar().push_back(4); // Then mutate that member
```
