### PR TITLE
Fix including an IDL file with no structures [19387]

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -875,7 +875,7 @@ public class fastddsgen
                     returnedValue =
                             Utils.writeFile(fileNameH, maintemplates.getTemplate("SerializationHeader"), m_replace);
                     project.addCommonTestingFile(relative_dir + ctx.getFilename() + "PubSubTypes.cxx");
-                    
+
                     for (String element : project.getFullDependencies())
                     {
                         String trimmedElement = element.substring(0, element.length() - 4);// Remove .idl
@@ -884,29 +884,28 @@ public class fastddsgen
                 }
 
                 // TODO: Uncomment following lines and create templates
+                System.out.println("Generating TopicDataTypes files...");
+                    returnedValue &=
+                            Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.h",
+                            maintemplates.getTemplate("DDSPubSubTypeHeader"), m_replace);
+
                 if (ctx.existsLastStructure())
                 {
                     m_atLeastOneStructure = true;
                     project.setHasStruct(true);
 
-                    System.out.println("Generating TopicDataTypes files...");
                     if (returnedValue =
-                            Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.h",
-                            maintemplates.getTemplate("DDSPubSubTypeHeader"), m_replace))
+                            Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.cxx",
+                            maintemplates.getTemplate("DDSPubSubTypeSource"), m_replace))
                     {
-                        if (returnedValue =
-                                Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.cxx",
-                                maintemplates.getTemplate("DDSPubSubTypeSource"), m_replace))
+                        project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "PubSubTypes.h");
+                        project.addProjectSrcFile(relative_dir + ctx.getFilename() + "PubSubTypes.cxx");
+                        if (m_python)
                         {
-                            project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "PubSubTypes.h");
-                            project.addProjectSrcFile(relative_dir + ctx.getFilename() + "PubSubTypes.cxx");
-                            if (m_python)
-                            {
-                                System.out.println("Generating Swig interface files...");
-                                returnedValue = Utils.writeFile(
-                                    output_dir + ctx.getFilename() + "PubSubTypes.i",
-                                    maintemplates.getTemplate("DDSPubSubTypeSwigInterface"), m_replace);
-                            }
+                            System.out.println("Generating Swig interface files...");
+                            returnedValue = Utils.writeFile(
+                                output_dir + ctx.getFilename() + "PubSubTypes.i",
+                                maintemplates.getTemplate("DDSPubSubTypeSwigInterface"), m_replace);
                         }
                     }
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
@@ -37,9 +37,11 @@ message(STATUS "Configuring $project.name$...")
 add_library($project.name$_lib $project.commonSrcFiles : {$it$}; separator=" "$)
 target_link_libraries($project.name$_lib $solution.libraries : {$it$}; separator=" "$)
 
+$if(!project.projectSrcFiles.empty)$
 add_executable($project.name$ $project.projectSrcFiles : {$it$}; separator=" "$)
 target_link_libraries($project.name$ $solution.libraries : {$it$}; separator=" "$
         $project.name$_lib $project.dependencies : {$it$_lib}; separator=" "$)
+$endif$
 
 
 $if(test)$


### PR DESCRIPTION
PR #156 added the inclusion of `PubSubTypes.h` headers of dependant IDL files in the current generated `PubSubTypes.h`. But these files not always are generated if there are no structures in the IDL file. This causes a compilation error.

This PR fixes this always creating the `PubSubTypes.h` files. 