### PR TITLE
Fix usage of is_plain() with extensibility values

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -25,6 +25,7 @@ import com.eprosima.idl.generator.manager.TemplateGroup;
 import com.eprosima.idl.generator.manager.TemplateManager;
 import com.eprosima.idl.parser.grammar.IDLLexer;
 import com.eprosima.idl.parser.grammar.IDLParser;
+import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.tree.AnnotationDeclaration;
 import com.eprosima.idl.parser.tree.AnnotationMember;
 import com.eprosima.idl.parser.tree.Specification;
@@ -308,6 +309,33 @@ public class fastddsgen
             {
                 m_case_sensitive = true;
             }
+            else if (arg.equals("-de") || arg.equals("-default_extensibility"))
+            {
+                if (count < args.length)
+                {
+                    String extensibility = args[count++];
+                    if (extensibility.equals(Annotation.final_str))
+                    {
+                        TypeCode.default_extensibility = TypeCode.ExtensibilityKind.FINAL;
+                    }
+                    else if (extensibility.equals(Annotation.appendable_str))
+                    {
+                        TypeCode.default_extensibility = TypeCode.ExtensibilityKind.APPENDABLE;
+                    }
+                    else if (extensibility.equals(Annotation.mutable_str))
+                    {
+                        TypeCode.default_extensibility = TypeCode.ExtensibilityKind.MUTABLE;
+                    }
+                    else
+                    {
+                        throw new BadArgumentException("Extensibility value " + extensibility + " is not valid");
+                    }
+                }
+                else
+                {
+                    throw new BadArgumentException("No extensibility value after -default_extensibility argument");
+                }
+            }
             else   // TODO: More options: -rpm, -debug
             {
                 throw new BadArgumentException("Unknown argument " + arg);
@@ -512,6 +540,12 @@ public class fastddsgen
         System.out.println("\t\t-cs: IDL grammar apply case sensitive matching.");
         System.out.println("\t\t-test: executes FastDDSGen tests.");
         System.out.println("\t\t-python: generates python bindings for the generated types.");
+        System.out.print("\t\t-default_extensibility | -de <ext>: sets the default extensibility for types without");
+        System.out.println(" the @extensibility annotation.");
+        System.out.println("\t\t Values:");
+        System.out.println("\t\t\t* " + Annotation.final_str + " (default)");
+        System.out.println("\t\t\t* " + Annotation.appendable_str);
+        System.out.println("\t\t\t* " + Annotation.mutable_str);
         System.out.println("\tand the supported input files are:");
         System.out.println("\t* IDL files.");
 

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/AliasTypeCode.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.fastdds.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+
 public class AliasTypeCode extends com.eprosima.idl.parser.typecode.AliasTypeCode
     implements TypeCode
 {
@@ -29,6 +31,14 @@ public class AliasTypeCode extends com.eprosima.idl.parser.typecode.AliasTypeCod
             long current_alignment)
     {
         return ((TypeCode) getTypedefContentTypeCode()).maxSerializedSize(current_alignment);
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64) throws RuntimeGenerationException
+    {
+        return ((TypeCode) getTypedefContentTypeCode()).maxPlainTypeSerializedSize(current_alignment, align64);
     }
 
     public boolean isNotZeroArray()

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/ArrayTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/ArrayTypeCode.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.fastdds.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+
 public class ArrayTypeCode extends com.eprosima.idl.parser.typecode.ArrayTypeCode
     implements TypeCode
 {
@@ -40,6 +42,27 @@ public class ArrayTypeCode extends com.eprosima.idl.parser.typecode.ArrayTypeCod
         for (long count = 0; count < size; ++count)
         {
             current_alignment += ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+        }
+
+        return current_alignment - initial_alignment;
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64) throws RuntimeGenerationException
+    {
+        long initial_alignment = current_alignment;
+
+        long size = 1;
+        for (int count = 0; count < getDimensions().size(); ++count)
+        {
+            size *= Long.parseLong(getDimensions().get(count), 10);
+        }
+
+        for (long count = 0; count < size; ++count)
+        {
+            current_alignment += ((TypeCode)getContentTypeCode()).maxPlainTypeSerializedSize(current_alignment, align64);
         }
 
         return current_alignment - initial_alignment;

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/ArrayTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/ArrayTypeCode.java
@@ -39,9 +39,15 @@ public class ArrayTypeCode extends com.eprosima.idl.parser.typecode.ArrayTypeCod
             size *= Long.parseLong(getDimensions().get(count), 10);
         }
 
-        for (long count = 0; count < size; ++count)
+        if (0 < size)
         {
             current_alignment += ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+
+            if (1 < size)
+            {
+                long element_size_after_first = ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+                current_alignment += element_size_after_first * (size - 1);
+            }
         }
 
         return current_alignment - initial_alignment;
@@ -60,9 +66,17 @@ public class ArrayTypeCode extends com.eprosima.idl.parser.typecode.ArrayTypeCod
             size *= Long.parseLong(getDimensions().get(count), 10);
         }
 
-        for (long count = 0; count < size; ++count)
+        if (0 < size)
         {
-            current_alignment += ((TypeCode)getContentTypeCode()).maxPlainTypeSerializedSize(current_alignment, align64);
+            current_alignment += ((TypeCode)getContentTypeCode()).maxPlainTypeSerializedSize(
+                    current_alignment, align64);
+
+            if (1 < size)
+            {
+                long element_size_after_first = ((TypeCode)getContentTypeCode()).maxPlainTypeSerializedSize(
+                        current_alignment, align64);
+                current_alignment += element_size_after_first * (size - 1);
+            }
         }
 
         return current_alignment - initial_alignment;

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitmaskTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitmaskTypeCode.java
@@ -36,12 +36,19 @@ public class BitmaskTypeCode extends com.eprosima.idl.parser.typecode.BitmaskTyp
     public long maxSerializedSize(
             long current_alignment)
     {
+        return maxPlainTypeSerializedSize(current_alignment, 8);
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64)
+    {
         long initial_alignment = current_alignment;
         long size = Long.parseLong(getSize(), 10);
 
-        current_alignment += size + TypeCode.cdr_alignment(current_alignment, size);
+        current_alignment += size + TypeCode.cdr_alignment(current_alignment, 4 < size ? align64 : size);
 
         return current_alignment - initial_alignment;
     }
-
 }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitsetTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitsetTypeCode.java
@@ -31,6 +31,14 @@ public class BitsetTypeCode extends com.eprosima.idl.parser.typecode.BitsetTypeC
     public long maxSerializedSize(
             long current_alignment)
     {
+        return maxPlainTypeSerializedSize(current_alignment, 8);
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64)
+    {
         long initial_alignment = current_alignment;
 
         int full_bit_size = getFullBitSize();
@@ -49,7 +57,7 @@ public class BitsetTypeCode extends com.eprosima.idl.parser.typecode.BitsetTypeC
         }
         else
         {
-            current_alignment += 8 + TypeCode.cdr_alignment(current_alignment, 8);
+            current_alignment += 8 + TypeCode.cdr_alignment(current_alignment, align64);
         }
 
         return current_alignment - initial_alignment;

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/EnumTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/EnumTypeCode.java
@@ -28,11 +28,18 @@ public class EnumTypeCode extends com.eprosima.idl.parser.typecode.EnumTypeCode
     public long maxSerializedSize(
             long current_alignment)
     {
+        return maxPlainTypeSerializedSize(current_alignment, 8);
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64)
+    {
         long initial_alignment = current_alignment;
 
         current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
 
         return current_alignment - initial_alignment;
     }
-
 }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/MapTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/MapTypeCode.java
@@ -42,10 +42,18 @@ public class MapTypeCode extends com.eprosima.idl.parser.typecode.MapTypeCode
 
         current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
 
-        for (long count = 0; count < maxsize; ++count)
+        if (0 < maxsize)
         {
             current_alignment += ((TypeCode)getKeyTypeCode()).maxSerializedSize(current_alignment);
             current_alignment += ((TypeCode)getValueTypeCode()).maxSerializedSize(current_alignment);
+
+            if (1 < maxsize)
+            {
+                long element_size_after_first = ((TypeCode)getKeyTypeCode()).maxSerializedSize(current_alignment);
+                element_size_after_first += ((TypeCode)getValueTypeCode()).maxSerializedSize(
+                        current_alignment + element_size_after_first);
+                current_alignment += element_size_after_first * (maxsize - 1);
+            }
         }
 
         return current_alignment - initial_alignment;

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/MapTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/MapTypeCode.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.fastdds.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+
 public class MapTypeCode extends com.eprosima.idl.parser.typecode.MapTypeCode
     implements TypeCode
 {
@@ -49,4 +51,11 @@ public class MapTypeCode extends com.eprosima.idl.parser.typecode.MapTypeCode
         return current_alignment - initial_alignment;
     }
 
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64) throws RuntimeGenerationException
+    {
+        throw new RuntimeGenerationException("MapTypeCode::maxPlainTypeSerializedSize(): Maps are not plain types.");
+    }
 }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/PrimitiveTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/PrimitiveTypeCode.java
@@ -28,17 +28,25 @@ public class PrimitiveTypeCode extends com.eprosima.idl.parser.typecode.Primitiv
     public long maxSerializedSize(
             long current_alignment)
     {
+        return maxPlainTypeSerializedSize(current_alignment, 8);
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64)
+    {
         long initial_alignment = current_alignment;
 
         switch (getKind())
         {
             case com.eprosima.idl.parser.typecode.Kind.KIND_LONGDOUBLE:
-                current_alignment += 16 + TypeCode.cdr_alignment(current_alignment, 8);
+                current_alignment += 16 + TypeCode.cdr_alignment(current_alignment, align64);
                 break;
             case com.eprosima.idl.parser.typecode.Kind.KIND_DOUBLE:
             case com.eprosima.idl.parser.typecode.Kind.KIND_LONGLONG:
             case com.eprosima.idl.parser.typecode.Kind.KIND_ULONGLONG:
-                current_alignment += 8 + TypeCode.cdr_alignment(current_alignment, 8);
+                current_alignment += 8 + TypeCode.cdr_alignment(current_alignment, align64);
                 break;
             case com.eprosima.idl.parser.typecode.Kind.KIND_LONG:
             case com.eprosima.idl.parser.typecode.Kind.KIND_ULONG:
@@ -61,5 +69,4 @@ public class PrimitiveTypeCode extends com.eprosima.idl.parser.typecode.Primitiv
 
         return current_alignment - initial_alignment;
     }
-
 }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SequenceTypeCode.java
@@ -50,9 +50,15 @@ public class SequenceTypeCode extends com.eprosima.idl.parser.typecode.SequenceT
 
         current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
 
-        for (long count = 0; count < maxsize; ++count)
+        if (0 < maxsize)
         {
             current_alignment += ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+
+            if (1 < maxsize)
+            {
+                long element_size_after_first = ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+                current_alignment += element_size_after_first * (maxsize - 1);
+            }
         }
 
         if (should_set_and_unset)

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SequenceTypeCode.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.fastdds.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+
 public class SequenceTypeCode extends com.eprosima.idl.parser.typecode.SequenceTypeCode
     implements TypeCode
 {
@@ -59,6 +61,14 @@ public class SequenceTypeCode extends com.eprosima.idl.parser.typecode.SequenceT
         }
 
         return current_alignment - initial_alignment;
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64) throws RuntimeGenerationException
+    {
+        throw new RuntimeGenerationException("MapTypeCode::maxPlainTypeSerializedSize(): Sequences are not plain types.");
     }
 
 }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SetTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SetTypeCode.java
@@ -34,9 +34,15 @@ public class SetTypeCode extends com.eprosima.idl.parser.typecode.SetTypeCode
 
         current_alignment += 4 + TypeCode.cdr_alignment(current_alignment, 4);
 
-        for (long count = 0; count < maxsize; ++count)
+        if (0 < maxsize)
         {
             current_alignment += ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+
+            if (1 < maxsize)
+            {
+                long element_size_after_first = ((TypeCode)getContentTypeCode()).maxSerializedSize(current_alignment);
+                current_alignment += element_size_after_first * (maxsize - 1);
+            }
         }
 
         return current_alignment - initial_alignment;

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SetTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/SetTypeCode.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.fastdds.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+
 public class SetTypeCode extends com.eprosima.idl.parser.typecode.SetTypeCode
     implements TypeCode
 {
@@ -38,6 +40,14 @@ public class SetTypeCode extends com.eprosima.idl.parser.typecode.SetTypeCode
         }
 
         return current_alignment - initial_alignment;
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64) throws RuntimeGenerationException
+    {
+        throw new RuntimeGenerationException("MapTypeCode::maxPlainTypeSerializedSize(): Sets are not plain types.");
     }
 
 }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StringTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StringTypeCode.java
@@ -14,6 +14,7 @@
 
 package com.eprosima.fastdds.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.typecode.Kind;
 
 public class StringTypeCode extends com.eprosima.idl.parser.typecode.StringTypeCode
@@ -44,6 +45,14 @@ public class StringTypeCode extends com.eprosima.idl.parser.typecode.StringTypeC
         }
 
         return current_alignment - initial_alignment;
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64) throws RuntimeGenerationException
+    {
+        throw new RuntimeGenerationException("StringTypeCode::maxPlainTypeSerializedSize(): Strings are not plain types.");
     }
 
 }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/TypeCode.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.fastdds.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+
 public interface TypeCode
 {
     static long cdr_alignment(
@@ -28,4 +30,11 @@ public interface TypeCode
      */
     public long maxSerializedSize(
             long current_alignment);
+
+    /*
+     * Returns the maximum serialized size for a plain Type
+     */
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64) throws RuntimeGenerationException;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/UnionTypeCode.java
@@ -14,6 +14,7 @@
 
 package com.eprosima.fastdds.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.typecode.Member;
 
 public class UnionTypeCode extends com.eprosima.idl.parser.typecode.UnionTypeCode
@@ -60,5 +61,13 @@ public class UnionTypeCode extends com.eprosima.idl.parser.typecode.UnionTypeCod
         current_alignment = MemberedTypeCode.xcdr_extra_endheader_serialized_size(union_max_size_serialized, union_ext_kind);
 
         return current_alignment - initial_alignment;
+    }
+
+    @Override
+    public long maxPlainTypeSerializedSize(
+            long current_alignment,
+            long align64) throws RuntimeGenerationException
+    {
+        throw new RuntimeGenerationException("UnionTypeCode::maxPlainTypeSerializedSize(): Unions are not plain types.");
     }
 }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -182,7 +182,25 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
     eProsima_user_DllExport inline bool is_plain() const override
     {
-        return $if(struct.isPlain)$is_plain_impl()$else$false$endif$;
+        return $if(struct.isPlain)$is_plain_xcdrv1_impl()$else$false$endif$;
+    }
+
+    eProsima_user_DllExport inline bool is_plain(
+        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+    {
+        $if(struct.isPlain)$
+        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        {
+            return is_plain_xcdrv2_impl();
+        }
+        else
+        {
+            return is_plain_xcdrv1_impl();
+        }
+        $else$
+        static_cast<void>(data_representation);
+        return false;
+        $endif$
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -203,15 +221,34 @@ public:
 $if(struct.isPlain)$
 private:
 
-    static constexpr bool is_plain_impl()
+    static constexpr bool is_plain_xcdrv1_impl()
     {
         $if(struct.members)$
-        return $struct.maxSerializedSize$ULL ==
+        return $struct.maxXCDRv1PlainTypeSerializedSize$ULL ==
                (detail::$struct.name$_offset_of<$struct.name$, detail::$struct.name$_f>() +
                sizeof($last(struct.members).typecode.cppTypename$));
         $elseif(struct.inheritances)$
         $if(last(struct.inheritances).isPlain)$
-        return $struct.maxSerializedSize$ULL ==
+        return $struct.maxXCDRv1PlainTypeSerializedSize$ULL ==
+               (detail::$last(struct.inheritances).name$_offset_of<$last(struct.inheritances).name$, detail::$last(struct.inheritances).name$_f>() +
+               sizeof($last(last(struct.inheritances).members).typecode.cppTypename$));
+        $else$
+        return true;
+        $endif$
+        $else$
+        return true;
+        $endif$
+    }
+
+    static constexpr bool is_plain_xcdrv2_impl()
+    {
+        $if(struct.members)$
+        return $struct.maxXCDRv2PlainTypeSerializedSize$ULL ==
+               (detail::$struct.name$_offset_of<$struct.name$, detail::$struct.name$_f>() +
+               sizeof($last(struct.members).typecode.cppTypename$));
+        $elseif(struct.inheritances)$
+        $if(last(struct.inheritances).isPlain)$
+        return $struct.maxXCDRv2PlainTypeSerializedSize$ULL ==
                (detail::$last(struct.inheritances).name$_offset_of<$last(struct.inheritances).name$, detail::$last(struct.inheritances).name$_f>() +
                sizeof($last(last(struct.inheritances).members).typecode.cppTypename$));
         $else$


### PR DESCRIPTION
Also add `-default_extension` option to the application and improve calculation of maximum serialized size for container types: maps, sequences, arrays and sets.