### PR TITLE
[19898] Add mirror workflow

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,22 @@
+# .github/workflows/mirror.yml
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  mirror_job:
+    runs-on: ubuntu-latest
+    name: Mirror master branch to compatible minor version branches
+    strategy:
+      fail-fast: false
+      matrix:
+        dest_branch:
+          - '3.1.x'
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: eProsima/eProsima-CI/external/mirror-branch-action@v0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: 'master'
+        dest: ${{ matrix.dest_branch }}


### PR DESCRIPTION
This PR adds a mirror workflow so that the latest version branch is kept up to date with master.
This is necessary to transition to a branching model similar to Fast DDS', where master is kept as a development branch, and each minor version has a corresponding X.Y.x branch so we can handle backports and releases in a more consistent manner.