### PR TITLE
[19837] Fix CLang warning in generated code about unused lambda capture

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -138,6 +138,7 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
                 $else$
+                static_cast<void>(data);
                 static_cast<void>(dcdr);
                 static_cast<void>(mid);
                 return false;


### PR DESCRIPTION
This PR fixes warnings in:

* eProsima/Fast-DDS#3996

Before merging, let's see if no more warnings appear.

This PR also updates the DDS Types Test submodule to the latest main commit.