### PR TITLE
[20176] Downgrade cmake version

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
@@ -16,7 +16,7 @@ group CMakeLists;
 
 cmakelists(solution, test) ::= <<
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 project("generated_code")
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -16,7 +16,7 @@ group SwigCMake;
 
 swig_cmake(solution) ::= <<
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.22)
 
 # SWIG: use standard target name.
 if(POLICY CMP0078)

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -16,7 +16,7 @@ group SwigCMake;
 
 swig_cmake(solution) ::= <<
 
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.20)
 
 # SWIG: use standard target name.
 if(POLICY CMP0078)


### PR DESCRIPTION
Reduce CMake minimum version required for Fast DDS compatibility against RHEL 9.