### PR TITLE
20538 Update FastDDSGen tests for indirect hashes

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
@@ -1097,6 +1097,7 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_ARRAY_SMALL)
     {
         EXPECT_EQ(type_ids.type_identifier1().array_sdefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().array_sdefn().element_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
     }
     else
     {
@@ -1123,6 +1124,7 @@ else
     {
         EXPECT_EQ(type_ids.type_identifier1().array_ldefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().array_ldefn().element_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
     }
     else
     {
@@ -1180,6 +1182,7 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_SEQUENCE_SMALL)
     {
         EXPECT_EQ(type_ids.type_identifier1().seq_sdefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().seq_sdefn().element_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
     }
     else
     {
@@ -1204,6 +1207,7 @@ else
     {
         EXPECT_EQ(type_ids.type_identifier1().seq_ldefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().seq_ldefn().element_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
     }
     else
     {
@@ -1260,6 +1264,7 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_MAP_SMALL)
         EXPECT_EQ(type_ids.type_identifier1().map_sdefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().element_identifier());
         EXPECT_TRUE(key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().key_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
     }
     else
     {
@@ -1308,6 +1313,7 @@ else
         EXPECT_EQ(type_ids.type_identifier1().map_ldefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().element_identifier());
         EXPECT_TRUE(key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().key_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
     }
     else
     {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
@@ -1097,7 +1097,7 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_ARRAY_SMALL)
     {
         EXPECT_EQ(type_ids.type_identifier1().array_sdefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().array_sdefn().element_identifier());
-        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
+        EXPECT_TRUE(element_type_ids.type_identifier2()._d() == TK_NONE);
     }
     else
     {
@@ -1124,7 +1124,7 @@ else
     {
         EXPECT_EQ(type_ids.type_identifier1().array_ldefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().array_ldefn().element_identifier());
-        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
+        EXPECT_TRUE(element_type_ids.type_identifier2()._d() == TK_NONE);
     }
     else
     {
@@ -1182,7 +1182,7 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_SEQUENCE_SMALL)
     {
         EXPECT_EQ(type_ids.type_identifier1().seq_sdefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().seq_sdefn().element_identifier());
-        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
+        EXPECT_TRUE(element_type_ids.type_identifier2()._d() == TK_NONE);
     }
     else
     {
@@ -1207,7 +1207,7 @@ else
     {
         EXPECT_EQ(type_ids.type_identifier1().seq_ldefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().seq_ldefn().element_identifier());
-        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
+        EXPECT_TRUE(element_type_ids.type_identifier2()._d() == TK_NONE);
     }
     else
     {
@@ -1264,7 +1264,7 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_MAP_SMALL)
         EXPECT_EQ(type_ids.type_identifier1().map_sdefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().element_identifier());
         EXPECT_TRUE(key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().key_identifier());
-        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
+        EXPECT_TRUE(element_type_ids.type_identifier2()._d() == TK_NONE && key_type_ids.type_identifier2()._d() == TK_NONE);
     }
     else
     {
@@ -1313,7 +1313,7 @@ else
         EXPECT_EQ(type_ids.type_identifier1().map_ldefn().header().equiv_kind(), EK_BOTH);
         EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().element_identifier());
         EXPECT_TRUE(key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().key_identifier());
-        EXPECT_TRUE(element_type_ids.type_identifier2() == TK_NONE);
+        EXPECT_TRUE(element_type_ids.type_identifier2()._d() == TK_NONE && key_type_ids.type_identifier2()._d() == TK_NONE);
     }
     else
     {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
@@ -692,7 +692,7 @@ else
         discriminator_type_ids.type_identifier2() == type_objects.complete_type_object.union_type().discriminator().common().type_id());
 }
 $check_type_detail_annotations(object=union.discriminator, type="union_type().discriminator()")$
-MemberId member_id = 0;
+MemberId member_id = 1;
 $union.members: { member | $check_union_member(member=member, parent=union)$}; separator="\n"$
 ASSERT_EQ($union.membersSize$, type_objects.minimal_type_object.union_type().member_seq().size());
 for (size_t i = 1; i < type_objects.minimal_type_object.union_type().member_seq().size(); ++i)

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
@@ -1096,8 +1096,7 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_ARRAY_SMALL)
     if (type_ids.type_identifier2()._d() == TK_NONE)
     {
         EXPECT_EQ(type_ids.type_identifier1().array_sdefn().header().equiv_kind(), EK_BOTH);
-        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().array_sdefn().element_identifier() ||
-            element_type_ids.type_identifier2() == *type_ids.type_identifier1().array_sdefn().element_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().array_sdefn().element_identifier());
     }
     else
     {
@@ -1123,8 +1122,7 @@ else
     if (type_ids.type_identifier2()._d() == TK_NONE)
     {
         EXPECT_EQ(type_ids.type_identifier1().array_ldefn().header().equiv_kind(), EK_BOTH);
-        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().array_ldefn().element_identifier() ||
-            element_type_ids.type_identifier2() == *type_ids.type_identifier1().array_ldefn().element_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().array_ldefn().element_identifier());
     }
     else
     {
@@ -1181,8 +1179,7 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_SEQUENCE_SMALL)
     if (type_ids.type_identifier2()._d() == TK_NONE)
     {
         EXPECT_EQ(type_ids.type_identifier1().seq_sdefn().header().equiv_kind(), EK_BOTH);
-        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().seq_sdefn().element_identifier() ||
-            element_type_ids.type_identifier2() == *type_ids.type_identifier1().seq_sdefn().element_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().seq_sdefn().element_identifier());
     }
     else
     {
@@ -1206,8 +1203,7 @@ else
     if (type_ids.type_identifier2()._d() == TK_NONE)
     {
         EXPECT_EQ(type_ids.type_identifier1().seq_ldefn().header().equiv_kind(), EK_BOTH);
-        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().seq_ldefn().element_identifier() ||
-            element_type_ids.type_identifier2() == *type_ids.type_identifier1().seq_ldefn().element_identifier());
+        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().seq_ldefn().element_identifier());
     }
     else
     {
@@ -1262,21 +1258,8 @@ if (type_ids.type_identifier1()._d() == TI_PLAIN_MAP_SMALL)
     if (type_ids.type_identifier2()._d() == TK_NONE)
     {
         EXPECT_EQ(type_ids.type_identifier1().map_sdefn().header().equiv_kind(), EK_BOTH);
-        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().element_identifier() ||
-            element_type_ids.type_identifier2() == *type_ids.type_identifier1().map_sdefn().element_identifier());
-        EXPECT_TRUE(key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().key_identifier() ||
-            key_type_ids.type_identifier2() == *type_ids.type_identifier1().map_sdefn().key_identifier());
-    }
-    else if (EK_BOTH == type_ids.type_identifier1().map_sdefn().header().equiv_kind())
-    {
-        EXPECT_EQ(type_ids.type_identifier1().map_sdefn().header().equiv_kind(),
-                type_ids.type_identifier2().map_sdefn().header().equiv_kind());
-        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().element_identifier() ||
-            element_type_ids.type_identifier2() == *type_ids.type_identifier1().map_sdefn().element_identifier());
-        EXPECT_TRUE((key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().key_identifier() &&
-                key_type_ids.type_identifier2() == *type_ids.type_identifier2().map_sdefn().key_identifier()) ||
-                (key_type_ids.type_identifier1() == *type_ids.type_identifier2().map_sdefn().key_identifier() &&
-                key_type_ids.type_identifier2() == *type_ids.type_identifier1().map_sdefn().key_identifier()));
+        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().element_identifier());
+        EXPECT_TRUE(key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_sdefn().key_identifier());
     }
     else
     {
@@ -1323,21 +1306,8 @@ else
     if (type_ids.type_identifier2()._d() == TK_NONE)
     {
         EXPECT_EQ(type_ids.type_identifier1().map_ldefn().header().equiv_kind(), EK_BOTH);
-        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().element_identifier() ||
-            element_type_ids.type_identifier2() == *type_ids.type_identifier1().map_ldefn().element_identifier());
-        EXPECT_TRUE(key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().key_identifier() ||
-            key_type_ids.type_identifier2() == *type_ids.type_identifier1().map_ldefn().key_identifier());
-    }
-    else if (EK_BOTH == type_ids.type_identifier1().map_ldefn().header().equiv_kind())
-    {
-        EXPECT_EQ(type_ids.type_identifier1().map_ldefn().header().equiv_kind(),
-                type_ids.type_identifier2().map_ldefn().header().equiv_kind());
-        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().element_identifier() ||
-            element_type_ids.type_identifier2() == *type_ids.type_identifier1().map_ldefn().element_identifier());
-        EXPECT_TRUE((key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().key_identifier() &&
-                key_type_ids.type_identifier2() == *type_ids.type_identifier2().map_ldefn().key_identifier()) ||
-                (key_type_ids.type_identifier1() == *type_ids.type_identifier2().map_ldefn().key_identifier() &&
-                key_type_ids.type_identifier2() == *type_ids.type_identifier1().map_ldefn().key_identifier()));
+        EXPECT_TRUE(element_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().element_identifier());
+        EXPECT_TRUE(key_type_ids.type_identifier1() == *type_ids.type_identifier1().map_ldefn().key_identifier());
     }
     else
     {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -675,7 +675,7 @@ else
     return;
 }
 EquivalenceKind equiv_kind_$map_name(map)$ = EK_BOTH;
-if (  (EK_COMPLETE == key_identifier_$map_name(map)$->_d() || EK_COMPLETE == element_identifier_$map_name(map)$->_d()) ||
+if ((EK_COMPLETE == key_identifier_$map_name(map)$->_d() || EK_COMPLETE == element_identifier_$map_name(map)$->_d()) ||
         (TI_PLAIN_SEQUENCE_SMALL == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->seq_sdefn().header().equiv_kind()) ||
         (TI_PLAIN_SEQUENCE_LARGE == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->seq_ldefn().header().equiv_kind()) ||
         (TI_PLAIN_ARRAY_SMALL == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->array_sdefn().header().equiv_kind()) ||

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -675,13 +675,13 @@ else
     return;
 }
 EquivalenceKind equiv_kind_$map_name(map)$ = EK_BOTH;
-if (EK_COMPLETE == element_identifier_$map_name(map)$->_d() ||
+if (  (EK_COMPLETE == key_identifier_$map_name(map)$->_d() || EK_COMPLETE == element_identifier_$map_name(map)$->_d()) ||
         (TI_PLAIN_SEQUENCE_SMALL == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->seq_sdefn().header().equiv_kind()) ||
         (TI_PLAIN_SEQUENCE_LARGE == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->seq_ldefn().header().equiv_kind()) ||
         (TI_PLAIN_ARRAY_SMALL == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->array_sdefn().header().equiv_kind()) ||
         (TI_PLAIN_ARRAY_LARGE == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->array_ldefn().header().equiv_kind()) ||
-        (TI_PLAIN_MAP_SMALL == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->map_sdefn().header().equiv_kind()) ||
-        (TI_PLAIN_MAP_LARGE == element_identifier_$map_name(map)$->_d() && EK_COMPLETE == element_identifier_$map_name(map)$->map_ldefn().header().equiv_kind()))
+        (TI_PLAIN_MAP_SMALL == element_identifier_$map_name(map)$->_d() && (EK_COMPLETE == element_identifier_$map_name(map)$->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_$map_name(map)$->map_sdefn().header().equiv_kind())) ||
+        (TI_PLAIN_MAP_LARGE == element_identifier_$map_name(map)$->_d() && (EK_COMPLETE == element_identifier_$map_name(map)$->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_$map_name(map)$->map_ldefn().header().equiv_kind())))
 {
     equiv_kind_$map_name(map)$ = EK_COMPLETE;
 }


### PR DESCRIPTION
This PR includes updates to the tests for indirect hash TypeIdentifiers. Now, maps consider the key when determining equiv_kind.
It updates the union tests to accommodate the member_id change. See more details at https://github.com/eProsima/IDL-Parser/pull/123.