### PR TITLE
[20569] Migrate DLL API exporter to fastdds

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -88,7 +88,7 @@ $definitions; separator="\n"$
 fast_macro_declarations() ::= <<
 // Macro declarations
 // Any macro used on the Fast DDS header files will give an error if it is not redefined here
-#define RTPS_DllAPI
+#define FASTDDS_EXPORTED_API
 #define eProsima_user_DllExport
 >>
 


### PR DESCRIPTION
This PR accounts for changes in:

* eprosima/fast-dds#4500