### PR TITLE
[20566] Update fastrtps migrated headers 

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeaderv1.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeaderv1.stg
@@ -35,8 +35,6 @@ $endif$
 
 $ctx.directIncludeDependencies : {include | #include "$include$.h"}; separator="\n"$
 
-#include <fastrtps/utils/fixed_size_string.hpp>
-
 #include <array>
 #include <bitset>
 #include <cstdint>
@@ -44,6 +42,8 @@ $ctx.directIncludeDependencies : {include | #include "$include$.h"}; separator="
 #include <stdint.h>
 #include <string>
 #include <vector>
+
+#include <fastcdr/cdr/fixed_size_string.hpp>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StringTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/StringTypeCode.java
@@ -65,7 +65,7 @@ public class StringTypeCode extends com.eprosima.idl.parser.typecode.StringTypeC
     {
         if (Kind.KIND_STRING == getKind() && isIsBounded() && ctx instanceof com.eprosima.fastcdr.idl.context.Context && ((com.eprosima.fastcdr.idl.context.Context)ctx).isCdrv1TemplatesEnabled())
         {
-            return "eprosima::fastrtps::fixed_string<" + getMaxsize() + ">";
+            return "eprosima::fastcdr::fixed_string<" + getMaxsize() + ">";
         }
 
         return super.getCppTypename();

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -27,7 +27,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.h"], description=["This h
 #include <fastdds/dds/topic/TopicDataType.hpp>
 #include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/common/SerializedPayload.h>
-#include <fastrtps/utils/md5.h>
+#include <fastdds/utils/md5.h>
 
 #include "$ctx.filename$.h"
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
@@ -1051,11 +1051,8 @@ external_suffix(p, external) ::= <<$p$$if(external)$->$else$.$endif$>>
 cppTypenameBetweenCdrVersions(typecode) ::= <<
 $if(typecode.isStringType && typecode.isBounded)$
 $! Avoid error with namespace when generated fixed_string depending on CDR version !$
-#if FASTCDR_VERSION_MAJOR == 1
-eprosima::fastrtps::fixed_string<$typecode.maxsize$>
-#else
 eprosima::fastcdr::fixed_string<$typecode.maxsize$>
-#endif
+
 
 $else$
 $typecode.cppTypename$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectSource.stg
@@ -26,12 +26,14 @@ namespace { char dummy; }
 
 #include "$ctx.filename$.h"
 #include "$ctx.filename$TypeObject.h"
+
 #include <mutex>
 #include <utility>
 #include <sstream>
+
 #include <fastdds/rtps/common/CdrSerialization.hpp>
-#include <fastrtps/rtps/common/SerializedPayload.h>
-#include <fastrtps/utils/md5.h>
+#include <fastdds/rtps/common/SerializedPayload.h>
+#include <fastdds/utils/md5.h>
 #include <fastrtps/types/TypeObjectFactory.h>
 #include <fastrtps/types/TypeNamesGenerator.h>
 #include <fastrtps/types/AnnotationParameterValue.h>


### PR DESCRIPTION
This PR updates fastrtps migrated headers:

`fixed_size_string.hpp` 

`md5.h` 

`SerializedPayload.h`

Related PR:
* https://github.com/eProsima/Fast-DDS/pull/4518