### PR TITLE
[20362] Changes for xtypes1.3 doc

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -586,8 +586,8 @@ public class fastddsgen
     private static final String python_bindings_arg = "-python";
     private static final String replace_arg = "-replace";
     private static final String temp_dir_arg = "-t";
-    private static final String cnames_arg = "-typesc";
     private static final String ros2_names_arg = "-typeros2";
+    private static final String cnames_arg = "-typesc";
     private static final String version_arg = "-version";
 
     /*
@@ -637,8 +637,8 @@ public class fastddsgen
         System.out.println("\t\t" + python_bindings_arg + ": generates python bindings for the generated types.");
         System.out.println("\t\t" + replace_arg + ": replaces existing generated files.");
         System.out.println("\t\t" + temp_dir_arg + " <temp dir>: sets a specific directory as a temporary directory.");
-        System.out.println("\t\t" + cnames_arg + ": generates string and sequence types compatible with C.");
         System.out.println("\t\t" + ros2_names_arg + ": generates type naming compatible with ROS2.");
+        System.out.println("\t\t" + cnames_arg + ": generates string and sequence types compatible with C.");
         System.out.println("\t\t" + version_arg + ": shows the current version of eProsima Fast DDS gen.");
         System.out.println("\tThe supported input files are:");
         System.out.println("\t* IDL files.");

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -586,8 +586,8 @@ public class fastddsgen
     private static final String python_bindings_arg = "-python";
     private static final String replace_arg = "-replace";
     private static final String temp_dir_arg = "-t";
-    private static final String ros2_names_arg = "-typeros2";
     private static final String cnames_arg = "-typesc";
+    private static final String ros2_names_arg = "-typeros2";
     private static final String version_arg = "-version";
 
     /*
@@ -601,7 +601,7 @@ public class fastddsgen
     {
         System.out.println(m_appName + " usage:");
         System.out.println("\t" + m_appName + " [options] <file> [<file> ...]");
-        System.out.println("\twhere the options are:");
+        System.out.println("\tThe available options are:");
         System.out.println("\t\t" + case_sensitive_arg + ": IDL grammar apply case sensitive matching.");
         System.out.println("\t\t" + output_path_arg + " <path>: sets an output directory for generated files.");
         System.out.print("\t\t" + default_container_prealloc_size + ": sets the default preallocated size for ");
@@ -621,10 +621,9 @@ public class fastddsgen
         }
         System.out.print("\t\t" + extra_template_arg + " <template file> <output file name>: specifies a custom ");
         System.out.println("template, template location must be in classpath.");
-        System.out.println("\t\t" + flat_output_directory_arg + ": ignore input files relative paths and place all generated files in the specified output directory.");
-        System.out.println("\t\t" + fusion_arg + ": activates fusion.");
         System.out.print("\t\t" + flat_output_directory_arg + ": ignore input files relative paths and place all ");
         System.out.println("generated files in the specified output directory.");
+        System.out.println("\t\t" + fusion_arg + ": activates fusion.");
         System.out.println("\t\t" + help_arg + ": shows this help");
         System.out.println("\t\t" + include_path_arg + " <path>: add directory to preprocessor include paths.");
         System.out.println("\t\t" + language_arg + " <lang>: chooses between <c++> or <java> languages.");
@@ -649,7 +648,7 @@ public class fastddsgen
     public static void printEnhacedHelp()
     {
         printHelp();
-        System.out.println("\tand the extra developer options are:");
+        System.out.println("\tThe extra developer options are:");
         System.out.println("\t\t" + generate_api_arg + ": apply rules to generate internal API.");
         System.out.println("\t\t" + execute_test_arg + ": executes FastDDSGen tests.");
     }

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -586,7 +586,6 @@ public class fastddsgen
     private static final String python_bindings_arg = "-python";
     private static final String replace_arg = "-replace";
     private static final String temp_dir_arg = "-t";
-    private static final String typeobject_arg = "-typeobject";
     private static final String ros2_names_arg = "-typeros2";
     private static final String cnames_arg = "-typesc";
     private static final String version_arg = "-version";
@@ -624,11 +623,13 @@ public class fastddsgen
         System.out.println("template, template location must be in classpath.");
         System.out.println("\t\t" + flat_output_directory_arg + ": ignore input files relative paths and place all generated files in the specified output directory.");
         System.out.println("\t\t" + fusion_arg + ": activates fusion.");
+        System.out.print("\t\t" + flat_output_directory_arg + ": ignore input files relative paths and place all ");
+        System.out.println("generated files in the specified output directory.");
         System.out.println("\t\t" + help_arg + ": shows this help");
         System.out.println("\t\t" + include_path_arg + " <path>: add directory to preprocessor include paths.");
         System.out.println("\t\t" + language_arg + " <lang>: chooses between <c++> or <java> languages.");
         System.out.println("\t\t" + no_typesupport_arg + ": avoid generating the type support files.");
-        System.out.println("\t\t" + no_typeobjectsupport_arg + ": avoid generating the TypeObject support specific files.");
+        System.out.println("\t\t" + no_typeobjectsupport_arg + ": avoid generating the TypeObject support files.");
         System.out.println("\t\t\tEnabled automatically if " + no_typesupport_arg + " argument is used.");
         System.out.println("\t\t" + no_dependencies_arg + ": avoid processing the dependent IDL files.");
         System.out.println("\t\t" + package_arg + ": default package used in Java files.");
@@ -640,7 +641,7 @@ public class fastddsgen
         System.out.println("\t\t" + cnames_arg + ": generates string and sequence types compatible with C.");
         System.out.println("\t\t" + ros2_names_arg + ": generates type naming compatible with ROS2.");
         System.out.println("\t\t" + version_arg + ": shows the current version of eProsima Fast DDS gen.");
-        System.out.println("\tand the supported input files are:");
+        System.out.println("\tThe supported input files are:");
         System.out.println("\t* IDL files.");
 
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR includes some minor fixes and removes the old **-typeobject** argument from the help description of Fast-DDS-Gen.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: Check CI results: changes do not issue any warning.
- _N/A_: Check CI results: failing tests are unrelated with the changes.
