### PR TITLE
[20651] Correct exported macro template in 4.0.x-devel

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -88,7 +88,7 @@ $definitions; separator="\n"$
 fast_macro_declarations() ::= <<
 // Macro declarations
 // Any macro used on the Fast DDS header files will give an error if it is not redefined here
-#define RTPS_DllAPI
+#define FASTDDS_EXPORTED_API
 #define eProsima_user_DllExport
 >>
 


### PR DESCRIPTION
This PR replaces the `RTPS_DllAPI` old macro with `FASTDDS_EXPORTED_API`
THis PR should be merged before #317 is merged