### PR TITLE
[20677] Use correct script to generate Fast DDS Python scripts

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yaml
+++ b/.github/workflows/reusable-ubuntu-ci.yaml
@@ -112,11 +112,10 @@ jobs:
           cd src/Fast-DDS
           ./utils/scripts/update_generated_code_from_idl.sh
           cd -
-          cd src/Fast-DDS-python/fastdds_python/test/types
-          ./generate.sh
+
+          cd src/Fast-DDS-python
+          ./utils/scripts/update_generated_code_from_idl.sh
           cd -
-          cd src/Fast-DDS-python/fastdds_python_examples/HelloWorldExample
-          fastddsgen -cdr both -python -replace HelloWorld.idl
 
       - name: Build workspace
         run: |


### PR DESCRIPTION
This PR fixes the Fast DDS Python type generation on Github CI, which was broken since the Fast DDS Python generation script changed name and location in:

* eprosima/fast-dds-python#108