### PR TITLE
[20736] Set required CMake version to 3.20 in generated code

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -16,7 +16,7 @@ group SwigCMake;
 
 swig_cmake(solution) ::= <<
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 # SWIG: use standard target name.
 if(POLICY CMP0078)


### PR DESCRIPTION
This PR sets the minimum CMake version to 3.20 in the generated code.