### PR TITLE
[20741] Bump version to 2.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'java-library'
 apply plugin: 'eclipse' // Eclipse integration
 
 description = """"""
-def version_str = "2.5.1"
+def version_str = "2.5.2"
 
 import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.tasks.options.Option;

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ repositories {
 }
 
 dependencies {
-    implementation files('thirdparty/idl-parser/build/libs/idlparser-1.6.0.jar')
+    implementation files('thirdparty/idl-parser/build/libs/idlparser-1.6.1.jar')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.5.2')
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.5.2')
 }


### PR DESCRIPTION
This PR:

1. Upgrades IDL-Parser to v1.6.1
2. Bumps the project version to 2.5.2