### PR TITLE
Fix windows warning with an union with boolean discriminator [20975]

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -473,7 +473,7 @@ public:
 
     $union.members: { member | $public_union_member_declaration(union, member)$}; separator="\n"$
 
-    $if(!union.defaultMember)$
+    $if(union.needDefaultCase)$
     void _default()
     {
         if (member_destructor_)

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -259,7 +259,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                         data.$member.name$(), current_alignment);
             break;
         }; separator="\n"$
-        $if(!union.defaultMember)$
+        $if(union.needDefaultCase)$
         default:
             break;
         $endif$
@@ -298,7 +298,7 @@ eProsima_user_DllExport void serialize(
             scdr << eprosima::fastcdr::MemberId($if(union.annotationMutable)$$member.id$$else$$member.index$$endif$) << data.$member.name$();
             break;
         }; separator="\n"$
-        $if(!union.defaultMember)$
+        $if(union.needDefaultCase)$
         default:
             break;
         $endif$
@@ -339,7 +339,7 @@ eProsima_user_DllExport void deserialize(
                                 break;
                             \}
                         }; separator="\n"$
-                        $if(!union.defaultMember)$
+                        $if(union.needDefaultCase)$
                         default:
                             data._default();
                             break;
@@ -362,7 +362,7 @@ eProsima_user_DllExport void deserialize(
                             dcdr \>> data.$member.name$();
                             break;
                         }; separator="\n"$
-                        $if(!union.defaultMember)$
+                        $if(union.needDefaultCase)$
                         default:
                             break;
                         $endif$


### PR DESCRIPTION
Depends on:
- eprosima/idl-parser#138