### PR TITLE
Bitsets according to standard IDL to C++11 2021 [21028]

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -66,6 +66,8 @@ $if(member.annotationDefault)$
 $elseif(!member.annotationOptional && !member.annotationExternal)$
 $if(member.typecode.initialValue)$
  {$member.typecode.initialValue$}
+$elseif(member.typecode.isBitsetType)$
+ {}
 $endif$
 $endif$
 %>

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -26,9 +26,6 @@ $fileHeader(ctx=ctx, file=[ctx.filename, ".hpp"], description=["This header file
 $if(ctx.thereIsArray)$
 #include <array>
 $endif$
-$if(ctx.thereIsBitset)$
-#include <bitset>
-$endif$
 #include <cstdint>
 $if(ctx.thereIsUnion)$
 #include <functional>
@@ -528,83 +525,14 @@ private:
 
 bitset_type(ctx, parent, bitset, extensions) ::= <<
 /*!
- * @brief This class represents the structure $bitset.name$ defined by the user in the IDL file.
+ * @brief This structure represents the bitset $bitset.name$ defined by the user in the IDL file.
  * @ingroup $ctx.trimfilename$
  */
-class $bitset.name$$if(bitset.inheritance)$ : public $public_bitset_inheritances(bitset.inheritance)$$endif$
+struct $bitset.name$
 {
-public:
-
-    /*!
-     * @brief Default constructor.
-     */
-    eProsima_user_DllExport $bitset.name$()
-    $if(bitset.inheritance)$
-    : $struct_inherit_default_init(bitset.inheritance)$
-    $endif$
-    {
-    }
-
-    /*!
-     * @brief Default destructor.
-     */
-    eProsima_user_DllExport ~$bitset.name$()
-    {
-    }
-
-    /*!
-     * @brief Copy constructor.
-     * @param x Reference to the object $bitset.scopedname$ that will be copied.
-     */
-    eProsima_user_DllExport $bitset.name$(
-            const $bitset.name$& x)
-    $if(bitset.inheritance)$
-    : $struct_inherit_copy_init(bitset.inheritance)$
-    $endif$
-    {
-        m_bitset = x.m_bitset;
-    }
-
-    /*!
-     * @brief Move constructor.
-     * @param x Reference to the object $bitset.scopedname$ that will be copied.
-     */
-    eProsima_user_DllExport $bitset.name$(
-            $bitset.name$&& x) noexcept
-    $if(bitset.inheritance)$
-    : $struct_inherit_move_init(bitset.inheritance)$
-    $endif$
-    {
-        m_bitset = x.m_bitset;
-    }
-
-    /*!
-     * @brief Copy assignment.
-     * @param x Reference to the object $bitset.scopedname$ that will be copied.
-     */
-    eProsima_user_DllExport $bitset.name$& operator =(
-            const $bitset.name$& x)
-    {
-        $if(bitset.inheritance)$    $bitset.inheritance.scopedname$::operator =(x);$endif$
-
-        m_bitset = x.m_bitset;
-
-        return *this;
-    }
-
-    /*!
-     * @brief Move assignment.
-     * @param x Reference to the object $bitset.scopedname$ that will be copied.
-     */
-    eProsima_user_DllExport $bitset.name$& operator =(
-            $bitset.name$&& x) noexcept
-    {
-        $if(bitset.inheritance)$    $bitset.inheritance.scopedname$::operator =(std::move(x));$endif$
-
-        m_bitset = x.m_bitset;
-
-        return *this;
-    }
+    $bitset.bitfields:{ bitfield |
+    $bitfield.spec.cppTypename$ $bitfield.name$ : $bitfield.spec.bitSize$;
+    }; separator="\n"$
 
     /*!
      * @brief Comparison operator.
@@ -613,9 +541,7 @@ public:
     eProsima_user_DllExport bool operator ==(
             const $bitset.name$& x) const
     {
-        $if(bitset.inheritance)$    if ($bitset.inheritance.scopedname$::operator !=(x)) return false;$endif$
-
-        return m_bitset == x.m_bitset;
+        return ($bitset.definedBitfields : { bitfield | $bitfield.name$ == x.$bitfield.name$}; separator=" &&\n           "$);
     }
 
     /*!
@@ -627,47 +553,6 @@ public:
     {
         return !(*this == x);
     }
-
-    $bitset.bitfields:{ bitset | $public_bitfield_declaration(bitset)$}; separator="\n"$
-
-    eProsima_user_DllExport std::bitset<$bitset.fullBitSize$> bitset() const
-    {
-        std::string str_value;
-
-        $if(bitset.inheritance)$
-        str_value = static_cast<const $bitset.inheritance.scopedname$*>(this)->bitset().to_string() + str_value;
-        $endif$
-
-        str_value = m_bitset.to_string() + str_value;
-
-        return std::bitset<$bitset.fullBitSize$>(str_value);
-    }
-
-    eProsima_user_DllExport void bitset(
-            const std::bitset<$bitset.fullBitSize$>& bitset)
-    {
-        std::string str_value {bitset.to_string()};
-        size_t base_diff {0};
-        size_t last_post {std::string::npos};
-
-        $if(bitset.inheritance)$
-        {
-            base_diff += $bitset.inheritance.fullBitSize$;
-            std::bitset<$bitset.inheritance.fullBitSize$> internal_bitset(str_value.substr(str_value.length() - base_diff, last_post));
-            static_cast<$bitset.inheritance.scopedname$*>(this)->bitset(internal_bitset);
-            last_post = base_diff;
-        }
-        $endif$
-
-        base_diff += $bitset.bitSize$;
-        m_bitset = std::bitset<$bitset.bitSize$>(str_value.substr(str_value.length() - base_diff, last_post));
-    }
-
-    $extensions : { extension | $extension$}; separator="\n"$
-
-private:
-
-    std::bitset<$bitset.bitSize$> m_bitset;
 };
 >>
 
@@ -702,8 +587,6 @@ class $type.name$;
 /***** Utils *****/
 
 public_struct_inheritances(parent) ::= <<$parent.scopedname$>>
-
-public_bitset_inheritances(parent) ::= <<$parent.scopedname$>>
 
 public_member_declaration(member) ::= <<
 $if(member.annotationOptional || member.annotationExternal)$
@@ -783,52 +666,6 @@ eProsima_user_DllExport $member_type_declaration(member)$& $member.name$()
 {
     return m_$member.name$;
 }
->>
-
-public_bitfield_declaration(member) ::= <<
-$if(member.name)$
-/*!
- * @brief This function sets a value in member $member.name$
- * @param _$member.name$ New value for member $member.name$
- */
-eProsima_user_DllExport void $member.name$(
-        $member.spec.cppTypename$ _$member.name$)
-{
-    int base = $member.basePosition$;
-$if(member.spec.typecode.isType_7)$
-    m_bitset.set(base, _$member.name$);
-$else$
-    int size = $member.spec.bitSize$;
-    for (int i = base; i < base + size; ++i)
-    {
-        m_bitset.set(i, !!(_$member.name$ & 0x01));
-        _$member.name$ = _$member.name$ \>> 1;
-    }
-$endif$
-
-}
-
-/*!
- * @brief This function returns the value of member $member.name$
- * @return Value of member $member.name$
- */
-eProsima_user_DllExport $member.spec.cppTypename$ $member.name$() const
-{
-    int base = $member.basePosition$;
-$if(member.spec.typecode.isType_7)$
-    return m_bitset.test(base);
-$else$
-    int size = $member.spec.bitSize$;
-    std::bitset<$member.spec.bitSize$> aux;
-    for (int i = 0; i < size; ++i)
-    {
-        aux.set(i, m_bitset.test(i + base));
-    }
-    return static_cast<$member.spec.cppTypename$>(aux.to_ullong());
-$endif$
-
-}
-$endif$
 >>
 
 private_member_declaration(member) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitsetTypeCode.java
+++ b/src/main/java/com/eprosima/fastdds/idl/parser/typecode/BitsetTypeCode.java
@@ -41,7 +41,7 @@ public class BitsetTypeCode extends com.eprosima.idl.parser.typecode.BitsetTypeC
     {
         long initial_alignment = current_alignment;
 
-        int full_bit_size = getFullBitSize();
+        int full_bit_size = getBitSize();
 
         if (9 > full_bit_size)
         {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
@@ -250,16 +250,19 @@ void $if(bitset.hasScope)$$bitset.scope$::$endif$print$bitset.name$(
         $bitset.name$* topic)
 {
     printf("$bitset.name$: { \n");
-    $bitset.allBitfields:{ bitfield |
-        $if(bitfield.name)$printf("$bitfield.name$: 0x%" PRIx64 "\n", (uint64_t)topic->$bitfield.name$());$endif$
-    }; separator="\n"$
+    $bitset.definedBitfields:{ bitfield | printf("$bitfield.name$: 0x%" PRIx64 "\n", (uint64_t)topic->$bitfield.name$); }; separator="\n"$
+    printf("} \n");
 }
 
 void $if(bitset.hasScope)$$bitset.scope$::$endif$initialize$bitset.name$(
         $bitset.name$* topic)
 {
-    $bitset.allBitfields:{ bitfield |
-        $if(bitfield.name)$$if(bitfield.spec.typecode.isType_7)$topic->$bitfield.name$(static_cast<$bitfield.spec.typecode.cppTypename$>(rand()%2==1));$elseif(bitfield.spec.typecode.primitive)$topic->$bitfield.name$(static_cast<$bitfield.spec.typecode.cppTypename$>(rand()));$endif$$endif$
+    $bitset.definedBitfields:{ bitfield |
+        $if(bitfield.spec.typecode.isType_7)$
+        topic->$bitfield.name$ = static_cast<$bitfield.spec.typecode.cppTypename$>(rand()%2==1);
+        $elseif(bitfield.spec.typecode.primitive)$
+        topic->$bitfield.name$ = static_cast<$bitfield.spec.typecode.cppTypename$>(rand());
+        $endif$
     }; separator="\n"$
 }
 
@@ -267,9 +270,7 @@ int $if(bitset.hasScope)$$bitset.scope$::$endif$compare$bitset.name$(
         $bitset.name$* topic_a,
         $bitset.name$* topic_b)
 {
-    $bitset.allBitfields:{ bitfield |
-        $if(bitfield.name)$if(topic_a->$bitfield.name$() != topic_b->$bitfield.name$()) return 0;$endif$
-    }; separator="\n"$
+    $bitset.definedBitfields:{ bitfield | if(topic_a->$bitfield.name$ != topic_b->$bitfield.name$) return 0; }; separator="\n"$
     return 1;
 }
 
@@ -619,7 +620,7 @@ $endif$
 $if(typecode.primitive)$
 printf("$name$: 0x%" PRIx64 "\n", (uint64_t)topic->$name$()$if(optional)$.value()$endif$);
 $elseif(typecode.isBitsetType)$
-printf("$name$: %s\n", topic->$name$()$if(optional)$.value()$endif$.bitset().to_string().c_str());
+printf("$name$: \n"); $if(typecode.hasScope)$$typecode.scope$::$endif$print$typecode.name$(&topic->$name$()$if(optional)$.value()$endif$);
 $elseif(typecode.isType_d)$
 $if(typecode.isWStringType)$
 printf("$name$: %ls\n", topic->$name$()$if(optional)$.value()$endif$$if(external)$->$else$.$endif$c_str());
@@ -656,7 +657,7 @@ array_member_print(ctx, typecode, name, originName, loopvar) ::= <<
 $if(typecode.primitive)$
 printf("$name$: 0x%" PRIx64 "\n", (uint64_t)topic->$name$);
 $elseif(typecode.isBitsetType)$
-printf("$name$: %s\n", topic->$name$.bitset().to_string().c_str());
+printf("$name$: \n"); $if(typecode.hasScope)$$typecode.scope$::$endif$print$typecode.name$(&topic->$name$);
 $elseif(typecode.isType_d)$
 $if(typecode.isWStringType)$
 printf("$name$: %ls\n", topic->$name$.c_str());

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
@@ -537,7 +537,7 @@ TEST(TypeObjectTests, TestStructureTypeObject_$struct.cScopedname$)
     $if (!struct.scope.empty)$$struct.scope$::$endif$register_$struct.CScopedname$_type_identifier(type_id);
     EXPECT_NE(TypeIdentifier(), type_id);
 
-    $check_struct_type(struct=struct)$ 
+    $check_struct_type(struct=struct)$
 }
 >>
 
@@ -658,7 +658,7 @@ TEST(TypeObjectTests, TestUnionTypeObject_$union.name$)
     $if (!union.scope.empty)$$union.scope$::$endif$register_$union.CScopedname$_type_identifier(type_id);
     EXPECT_NE(TypeIdentifier(), type_id);
 
-    $check_union_type(union=union)$ 
+    $check_union_type(union=union)$
 }
 >>
 
@@ -806,7 +806,7 @@ TEST(TypeObjectTests, TestEnumTypeObject_$enum.name$)
     // Enum Types does not have a specific register function: register every type in IDL file.
     register_$ctx.filename$_type_objects();
 
-    $check_enum_type(enum=enum)$ 
+    $check_enum_type(enum=enum)$
 }
 >>
 
@@ -878,7 +878,7 @@ TEST(TypeObjectTests, TestBitmaskTypeObject_$bitmask.name$)
     // Bitmask Types does not have a specific register function: register every type in IDL file.
     register_$ctx.filename$_type_objects();
 
-    $check_bitmask_type(bitmask=bitmask)$ 
+    $check_bitmask_type(bitmask=bitmask)$
 }
 >>
 
@@ -941,7 +941,7 @@ TEST(TypeObjectTests, TestBitsetTypeObject_$bitset.name$)
     // Bitset Types does not have a specific register function: register every type in IDL file.
     register_$ctx.filename$_type_objects();
 
-    $check_bitset_type(bitset=bitset)$ 
+    $check_bitset_type(bitset=bitset)$
 }
 >>
 
@@ -958,7 +958,7 @@ EXPECT_EQ(0u, type_objects.minimal_type_object.minimal().bitset_type().bitset_fl
 EXPECT_EQ(0u, type_objects.complete_type_object.complete().bitset_type().bitset_flags());
 $check_type_detail_annotations(object=bitset, type="bitset_type().header().detail()")$
 EXPECT_EQ("$bitset.scopedname$", type_objects.complete_type_object.complete().bitset_type().header().detail().type_name().to_string());
-$bitset.members: { member | $check_bitfield(bitfield=member, parent=bitset)$}; separator="\n"$
+$bitset.definedBitfields: { bitfield | $check_bitfield(bitfield=bitfield, parent=bitset)$}; separator="\n"$
 ASSERT_EQ($bitset.membersSize$, type_objects.minimal_type_object.minimal().bitset_type().field_seq().size());
 for (size_t i = 1; i < type_objects.minimal_type_object.minimal().bitset_type().field_seq().size(); ++i)
 {
@@ -975,7 +975,6 @@ for (size_t i = 1; i < type_objects.complete_type_object.complete().bitset_type(
 
 check_bitfield(bitfield, parent) ::= <<
 {
-    $if(bitfield.name)$
     size_t pos = 0;
     bool found = false;
     for (; pos < type_objects.complete_type_object.complete().bitset_type().field_seq().size(); ++pos)
@@ -998,7 +997,6 @@ check_bitfield(bitfield, parent) ::= <<
     EXPECT_EQ("$bitfield.name$", type_objects.complete_type_object.complete().bitset_type().field_seq()[pos].detail().name().to_string());
     EXPECT_EQ(TypeObjectUtils::name_hash("$bitfield.name$"), type_objects.minimal_type_object.minimal().bitset_type().field_seq()[pos].name_hash());
     $check_member_detail_annotations(member=bitfield, type="bitset_type().field_seq()[pos].detail()", parent=parent)$
-    $endif$
 }
 >>
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -183,14 +183,14 @@ $if(ctx.anyCdr)$
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const $bitset.scopedname$& data,
+        const $bitset.scopedname$&,
         size_t& current_alignment)
 {
     $if(!bitset.scope.empty)$
     using namespace $bitset.scope$;
     $endif$
 
-    return calculator.calculate_serialized_size(data.bitset(), current_alignment);
+    return calculator.calculate_serialized_size(std::bitset<$bitset.bitSize$>{}, current_alignment);
 }
 $endif$
 
@@ -204,7 +204,16 @@ eProsima_user_DllExport void serialize(
     using namespace $bitset.scope$;
     $endif$
 
-    scdr << data.bitset();
+    std::bitset<$bitset.bitSize$> bitset;
+
+    $reverse(bitset.bitfields):{ bitfield |
+    bitset <<= $bitfield.spec.bitSize$;
+    $if(bitfield.isDefined)$
+    bitset |= (data.$bitfield.name$ & $bitfield.bitmask$);
+    $endif$
+    }; separator="\n"$
+
+    scdr << bitset;
 }
 
 template<>
@@ -216,14 +225,18 @@ eProsima_user_DllExport void deserialize(
     using namespace $bitset.scope$;
     $endif$
 
-    std::bitset<$bitset.fullBitSize$> bitset;
+    std::bitset<$bitset.bitSize$> bitset;
     dcdr \>> bitset;
-    data.bitset(bitset);
+
+    $bitset.bitfields:{ bitfield |
+    $if(bitfield.isDefined)$
+    data.$bitfield.name$ = static_cast<$bitfield.spec.cppTypename$>(bitset.to_ullong() & $bitfield.bitmask$);
+    $endif$
+    bitset \>>= $bitfield.spec.bitSize$;
+    }; separator="\n"$
 }
 $endif$
 >>
-
-public_bitfield_definition(member) ::= <<>>
 
 union_type(ctx, parent, union, switch_type) ::= <<
 $switch_type$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -564,7 +564,7 @@ BitsetTypeFlag bitset_flags_$bitset.name$ = 0;
 $complete_type_detail(type=bitset, type_kind= " Bitset", name=name)$
 CompleteBitsetHeader header_$bitset.name$ = TypeObjectUtils::build_complete_bitset_header(detail_$bitset.name$);
 CompleteBitfieldSeq field_seq_$bitset.name$;
-$bitset.bitfields: { bitfield | $bitfield_member(bitfield=bitfield, parent=bitset, name=name)$}; separator="\n"$
+$bitset.allBitfields: { bitfield | $bitfield_member(bitfield=bitfield, parent=bitset, name=name)$}; separator="\n"$
 CompleteBitsetType bitset_type_$bitset.name$ = TypeObjectUtils::build_complete_bitset_type(bitset_flags_$bitset.name$, header_$bitset.name$, field_seq_$bitset.name$);
 if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
         TypeObjectUtils::build_and_register_bitset_type_object(bitset_type_$bitset.name$, type_name_$bitset.name$.to_string()))

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -564,7 +564,7 @@ BitsetTypeFlag bitset_flags_$bitset.name$ = 0;
 $complete_type_detail(type=bitset, type_kind= " Bitset", name=name)$
 CompleteBitsetHeader header_$bitset.name$ = TypeObjectUtils::build_complete_bitset_header(detail_$bitset.name$);
 CompleteBitfieldSeq field_seq_$bitset.name$;
-$bitset.allBitfields: { bitfield | $bitfield_member(bitfield=bitfield, parent=bitset, name=name)$}; separator="\n"$
+$bitset.definedBitfields: { bitfield | $bitfield_member(bitfield=bitfield, parent=bitset, name=name)$}; separator="\n"$
 CompleteBitsetType bitset_type_$bitset.name$ = TypeObjectUtils::build_complete_bitset_type(bitset_flags_$bitset.name$, header_$bitset.name$, field_seq_$bitset.name$);
 if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
         TypeObjectUtils::build_and_register_bitset_type_object(bitset_type_$bitset.name$, type_name_$bitset.name$.to_string()))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

Generate bitsets according to standard IDL to C++11 2021.

Depends on:

- #332 
- eprosima/idl-parser#145

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
