### PR TITLE
Installing python modules correctly [21071]

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -19,7 +19,15 @@ import "com/eprosima/fastdds/idl/templates/eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx, file=[ctx.filename, ".i"], description=["This header file contains the SWIG interface of the described types in the IDL file."])$
 
-%module $ctx.filename$
+%module(moduleimport="if __import__('os').name == 'nt': import win32api; win32api.LoadLibrary('$ctx.filename$.dll')\nif __package__ or '.' in __name__:\n    from . import _$ctx.filename$Wrapper\nelse:\n    import _$ctx.filename$Wrapper") $ctx.filename$
+
+// If using windows in debug, it would try to use python_d, which would not be found.
+%begin %{
+#ifdef _MSC_VER
+#define SWIG_PYTHON_INTERPRETER_NO_DEBUG
+#endif
+#include <exception>
+%}
 
 // SWIG helper modules
 %include "stdint.i"

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -96,8 +96,6 @@ SET_SOURCE_FILES_PROPERTIES(
     USE_TARGET_INCLUDE_DIRECTORIES TRUE
     )
 
-set_property(SOURCE \${PROJECT_NAME}.i PROPERTY OUTPUT_DIR "\${CMAKE_CURRENT_BINARY_DIR}/$project.context.lastStructure.typeCode.namespaces : { ns | $ns$}; separator="/"$")
-
 SWIG_ADD_LIBRARY(\${\${PROJECT_NAME}_MODULE}
     TYPE SHARED
     LANGUAGE python
@@ -114,11 +112,6 @@ target_link_libraries(\${\${PROJECT_NAME}_MODULE}
     \${PROJECT_NAME}
     )
 
-set_target_properties(\${\${PROJECT_NAME}_MODULE}
-    PROPERTIES LIBRARY_OUTPUT_DIRECTORY "\${CMAKE_CURRENT_BINARY_DIR}/$project.context.lastStructure.typeCode.namespaces : { ns | $ns$}; separator="/"$"
-    )
-
-
 # Find the installation path
 execute_process(COMMAND \${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(plat_specific=True, prefix='\${CMAKE_INSTALL_PREFIX}'))"
     OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
@@ -128,7 +121,7 @@ execute_process(COMMAND \${PYTHON_EXECUTABLE} -c "from distutils import sysconfi
 get_filename_component (_ABS_PYTHON_MODULE_PATH \${_ABS_PYTHON_MODULE_PATH} ABSOLUTE)
 file (RELATIVE_PATH _REL_PYTHON_MODULE_PATH \${CMAKE_INSTALL_PREFIX} \${_ABS_PYTHON_MODULE_PATH})
 SET (PYTHON_MODULE_PATH
-    \${_REL_PYTHON_MODULE_PATH}
+    \${_REL_PYTHON_MODULE_PATH}$project.context.lastStructure.typeCode.namespaces : { ns | /$ns$}$/\${PROJECT_NAME}
     )
 
 # Install
@@ -137,8 +130,8 @@ install(TARGETS \${PROJECT_NAME}
     LIBRARY DESTINATION lib/
     ARCHIVE DESTINATION lib/
     )
-install(TARGETS \${\${PROJECT_NAME}_MODULE} DESTINATION \${PYTHON_MODULE_PATH}/$project.context.lastStructure.typeCode.namespaces : { ns | $ns$}; separator="/"$)
+install(TARGETS \${\${PROJECT_NAME}_MODULE} DESTINATION \${PYTHON_MODULE_PATH})
 get_property(support_files TARGET \${\${PROJECT_NAME}_MODULE} PROPERTY SWIG_SUPPORT_FILES)
-install(FILES \${support_files} DESTINATION \${PYTHON_MODULE_PATH}/$project.context.lastStructure.typeCode.namespaces : { ns | $ns$}; separator="/"$)
+install(FILES \${support_files} DESTINATION \${PYTHON_MODULE_PATH} RENAME __init__.py)
 
 >>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

This PR changes the behaviour how generated python packages are installed, more Python style
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
