### PR TITLE
[21129] Migrate fastrtps namespace to fastdds

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -113,18 +113,18 @@ public:
 
     eProsima_user_DllExport bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload) override
+            eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
             void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool deserialize(
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
@@ -139,7 +139,7 @@ public:
 
     eProsima_user_DllExport bool getKey(
             void* data,
-            eprosima::fastrtps::rtps::InstanceHandle_t* ihandle,
+            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
     eProsima_user_DllExport void* createData() override;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -29,8 +29,8 @@ $if (ctx.generateTypeObjectSupport)$
 #include "$ctx.filename$TypeObjectSupport.hpp"
 $endif$
 
-using SerializedPayload_t = eprosima::fastrtps::rtps::SerializedPayload_t;
-using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+using SerializedPayload_t = eprosima::fastdds::rtps::SerializedPayload_t;
+using InstanceHandle_t = eprosima::fastdds::rtps::InstanceHandle_t;
 using DataRepresentationId_t = eprosima::fastdds::dds::DataRepresentationId_t;
 
 $definitions; separator="\n"$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/JNISource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/JNISource.stg
@@ -33,8 +33,8 @@ $ctx.directIncludeDependencies : {include | #include "$include$PubSubJNII.h"}; s
 #include <fastcdr/FastBuffer.h>
 #include <fastcdr/Cdr.h>
 
-using namespace eprosima::fastrtps;
-using namespace eprosima::fastrtps::rtps;
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
 
 #ifndef JNIEXPORT
 #define JNIEXPORT

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
@@ -49,7 +49,7 @@ TEST_P($struct.formatedCppTypename$Test, encoding)
             << (true == test_empty_external ? " with an empty external" : "")
             << " using encoding " << (eprosima::fastdds::dds::DataRepresentationId_t::XCDR_DATA_REPRESENTATION == cdr_version ? "XCDRv1" : "XCDRv2") <<
             " ========================================" << std::endl;
-    using eprosima::fastrtps::rtps::SerializedPayload_t;
+    using eprosima::fastdds::rtps::SerializedPayload_t;
 
     $struct.name$PubSubType $struct.name$_type_support;
     $struct.name$ $struct.name$_serialization_topic;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR migrates fastrtps namespace to fastdds.
Related Fast DDS PR:
* https://github.com/eProsima/Fast-DDS/pull/4898
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
