### PR TITLE
[21183] Adjust for `const` qualification of all data related inputs in DataWriter APIs

### DIFF
--- a/.github/actions/fetch-fastddsgen-repos/action.yml
+++ b/.github/actions/fetch-fastddsgen-repos/action.yml
@@ -1,5 +1,6 @@
 name: 'fetch-fastddsgen-repos'
 description: 'Fetch Fast DDS dependencies'
+
 inputs:
   foonathan-memory-vendor-branch:
     description: 'foonathan_memory_vendor branch to be used'
@@ -13,6 +14,10 @@ inputs:
   fastdds-python-branch:
     description: 'Fast-DDS-Python branch to be used'
     required: true
+  discovery-server-branch:
+    description: 'Discovery Server branch to be used'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -24,5 +29,6 @@ runs:
         git clone https://github.com/eProsima/Fast-CDR.git --branch ${{ inputs.fastcdr-branch }}
         git clone https://github.com/eProsima/Fast-DDS.git --branch ${{ inputs.fastdds-branch }}
         git clone https://github.com/eProsima/Fast-DDS-python.git --branch ${{ inputs.fastdds-python-branch }}
+        git clone https://github.com/eProsima/Discovery-Server.git --branch ${{ inputs.discovery-server-branch }}
         cd ..
       shell: bash

--- a/.github/workflows/reusable-ubuntu-ci.yaml
+++ b/.github/workflows/reusable-ubuntu-ci.yaml
@@ -11,29 +11,9 @@ on:
         description: 'The Java version to be used'
         required: true
         type: string
-      foonathan_memory_vendor_branch:
-        description: 'foonathan_memory_vendor branch to be used'
-        required: true
-        type: string
-      fastcdr_branch:
-        description: 'Fast CDR branch to be used'
-        required: true
-        type: string
-      fastdds_branch:
-        description: 'Fast DDS branch to be used'
-        required: true
-        type: string
-      fastdds_python_branch:
-        description: 'Fast DDS Python branch to be used'
-        required: true
-        type: string
       fastddsgen_branch:
         description: 'Fast DDS Gen branch to be used'
         required: true
-        type: string
-      fastdds_fallback_branch:
-        description: 'Fast DDS fallback branch in case `fastdds_branch` does not exist (e.g. master or 3.0.x-devel)'
-        required: false
         type: string
 
 defaults:
@@ -76,32 +56,48 @@ jobs:
       - name: Install python packages
         uses: eProsima/eProsima-CI/multiplatform/install_colcon@v0
 
-      - name: Determine the Fast DDS branch to be used
-        run: |
-          FASTDDS_REPO=https://github.com/eProsima/Fast-DDS.git
-          # Attempt to use PR's source branch
-          TEMP_BRANCH=${{ inputs.fastdds_branch }}
-          RESPONSE_CODE=$(git ls-remote --heads $FASTDDS_REPO $TEMP_BRANCH | wc -l)
-          if [[ ${RESPONSE_CODE} == "0" ]]
-          then
-            echo "PR source branch '$TEMP_BRANCH' branch DOES NOT exist using default branch '${{ inputs.fastdds_fallback_branch }}'"
-            # Attempt to use PR's fallback branch
-            TEMP_BRANCH=${{ inputs.fastdds_fallback_branch }}
-            RESPONSE_CODE=$(git ls-remote --heads $FASTDDS_REPO $TEMP_BRANCH | wc -l)
-            if [[ ${RESPONSE_CODE} == "0" ]]
-            then
-              echo "PR fallback branch '$TEMP_BRANCH' branch DOES NOT exist"
-              exit 1
-            fi
-          fi
-          echo "FASTDDS_BRANCH=$TEMP_BRANCH" >> $GITHUB_ENV
+      - name: Get Foonathan Memory Vendor branch
+        id: get_foonathan_memory_vendor_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/foonathan_memory_vendor
+          fallback_branch: master
+
+      - name: Get Fast CDR branch
+        id: get_fastcdr_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Fast-CDR
+          fallback_branch: master
+
+      - name: Get Fast DDS branch
+        id: get_fastdds_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Fast-DDS
+          fallback_branch: master
+
+      - name: Get Fast DDS Python branch
+        id: get_fastdds_python_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Fast-DDS-python
+          fallback_branch: main
+
+      - name: Get Discovery Server branch
+        id: get_discovery_server_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Discovery-Server
+          fallback_branch: master
 
       - uses: ./src/fastddsgen/.github/actions/fetch-fastddsgen-repos
         with:
-          foonathan-memory-vendor-branch: ${{ inputs.foonathan_memory_vendor_branch }}
-          fastcdr-branch: ${{ inputs.fastcdr_branch }}
-          fastdds-branch: ${{ env.FASTDDS_BRANCH }}
-          fastdds-python-branch: ${{ inputs.fastdds_python_branch }}
+          foonathan-memory-vendor-branch: ${{ steps.get_foonathan_memory_vendor_branch.outputs.deduced_branch }}
+          fastcdr-branch: ${{ steps.get_fastcdr_branch.outputs.deduced_branch }}
+          fastdds-branch: ${{ steps.get_fastdds_branch.outputs.deduced_branch }}
+          fastdds-python-branch: ${{ steps.get_fastdds_python_branch.outputs.deduced_branch }}
+          discovery-server-branch: ${{ steps.get_discovery_server_branch.outputs.deduced_branch }}
 
       - name: Build fastddsgen
         run: |
@@ -109,13 +105,17 @@ jobs:
           ./gradlew assemble
           echo "$(pwd)/scripts" >> ${{ github.path }}
 
-      - name: Regenerate IDL files for Fast-DDS and Fast-DDS-python
+      - name: Regenerate IDL files for Fast DDS, Fast DDS Python, and Discovery Server
         run: |
           cd src/Fast-DDS
           ./utils/scripts/update_generated_code_from_idl.sh
           cd -
 
           cd src/Fast-DDS-python
+          ./utils/scripts/update_generated_code_from_idl.sh
+          cd -
+
+          cd src/Discovery-Server
           ./utils/scripts/update_generated_code_from_idl.sh
           cd -
 

--- a/.github/workflows/ubuntu-ci.yaml
+++ b/.github/workflows/ubuntu-ci.yaml
@@ -3,22 +3,6 @@ name: Fast DDS Gen Ubuntu CI
 on:
   workflow_dispatch:
     inputs:
-      foonathan_memory_vendor_branch:
-        description: 'foonathan_memory_vendor branch to be used'
-        required: true
-        type: string
-      fastcdr_branch:
-        description: 'Fast CDR branches to be used'
-        required: true
-        type: string
-      fastdds_branch:
-        description: 'Fast-DDS branch to be used'
-        required: true
-        type: string
-      fastdds_python_branch:
-        description: 'Fast-DDS-Python branch to be used'
-        required: true
-        type: string
       fastddsgen_branch:
         description: 'Fast-DDS-Gen branch to be used'
         required: true
@@ -45,9 +29,4 @@ jobs:
     with:
       os_image: ${{ matrix.os_image }}
       java_version: ${{ matrix.java_version }}
-      foonathan_memory_vendor_branch: ${{ inputs.foonathan_memory_vendor_branch || 'master' }}
-      fastcdr_branch: ${{ inputs.fastcdr_branch || 'master' }}
-      fastdds_branch: ${{ inputs.fastdds_branch || github.head_ref }}
-      fastdds_python_branch: ${{ inputs.fastdds_python_branch || 'main' }}
       fastddsgen_branch: ${{ inputs.fastddsgen_branch || github.ref || 'master' }}
-      fastdds_fallback_branch: ${{ 'master' }}

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -112,14 +112,14 @@ public:
     eProsima_user_DllExport ~$struct.name$PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -128,17 +128,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -77,11 +77,11 @@ $struct.name$PubSubType::~$struct.name$PubSubType()
 }
 
 bool $struct.name$PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    $struct.name$* p_type = static_cast<$struct.name$*>(data);
+    const $struct.name$* p_type = static_cast<const $struct.name$*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -153,7 +153,7 @@ bool $struct.name$PubSubType::deserialize(
 }
 
 std::function<uint32_t()> $struct.name$PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -170,7 +170,7 @@ std::function<uint32_t()> $struct.name$PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<$struct.name$*>(data), current_alignment)) +
+                               *static_cast<const $struct.name$*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -193,7 +193,7 @@ void $struct.name$PubSubType::deleteData(
 }
 
 bool $struct.name$PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -202,7 +202,7 @@ bool $struct.name$PubSubType::getKey(
         return false;
     }
 
-    $struct.name$* p_type = static_cast<$struct.name$*>(data);
+    const $struct.name$* p_type = static_cast<const $struct.name$*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/src/main/java/com/eprosima/fastdds/idl/templates/JNISource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/JNISource.stg
@@ -183,7 +183,7 @@ class $struct.name$PubSubJNI : public TopicDataType, public SubscriberListener
                 Domain::removeSubscriber(subscriber_);
         }
 
-        bool serialize(void *data, SerializedPayload_t *payload)
+        bool serialize(const void* const data, SerializedPayload_t *payload)
         {
             $struct.scopedname$ *p_type = ($struct.scopedname$*) data;
             eprosima::fastcdr::FastBuffer fastbuffer((char*) payload->data, payload->max_size);
@@ -220,7 +220,7 @@ class $struct.name$PubSubJNI : public TopicDataType, public SubscriberListener
             delete(($struct.scopedname$*)data);
         }
 
-        bool getKey(void *data, InstanceHandle_t* handle, bool force_md5)
+        bool getKey(const void* const data, InstanceHandle_t* handle, bool force_md5)
         {
             if(!m_isGetKeyDefined)
                 return false;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adjusts Fast DDS Gen for:

* eProsima/Fast-DDS#4960

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
