### PR TITLE
[21128] Update guards and extenstion .h to .hpp in headers

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -20,8 +20,8 @@ import "FastCdrCommon.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx, file=[ctx.filename, ".hpp"], description=["This header file contains the declaration of the described types in the IDL file."])$
 
-#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_HPP_
-#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_HPP_
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_HPP
 
 $if(ctx.thereIsArray)$
 #include <array>

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -943,7 +943,7 @@ public class fastddsgen
                     project.addCommonTestingFile(relative_dir + ctx.getFilename() + "Serialization.cpp");
 
                     System.out.println("Generating Serialization Header file...");
-                    String fileNameH = output_dir + ctx.getFilename() + "Serialization.h";
+                    String fileNameH = output_dir + ctx.getFilename() + "Serialization.hpp";
                     returnedValue =
                             Utils.writeFile(fileNameH, maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/SerializationHeader.stg"), m_replace);
 
@@ -993,9 +993,9 @@ public class fastddsgen
                         }
                     }
                     returnedValue &=
-                        Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.h",
+                        Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.hpp",
                                 maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg"), m_replace);
-                    project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "PubSubTypes.h");
+                    project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "PubSubTypes.hpp");
                     if (ctx.existsLastStructure())
                     {
                         m_atLeastOneStructure = true;
@@ -1019,28 +1019,28 @@ public class fastddsgen
                         {
                             System.out.println("Generating Publisher files...");
                             if (returnedValue =
-                                    Utils.writeFile(output_dir + ctx.getFilename() + "Publisher.h",
+                                    Utils.writeFile(output_dir + ctx.getFilename() + "Publisher.hpp",
                                         maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg"), m_replace))
                             {
                                 if (returnedValue =
                                         Utils.writeFile(output_dir + ctx.getFilename() + "Publisher.cxx",
                                             maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPublisherSource.stg"), m_replace))
                                 {
-                                    project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "Publisher.h");
+                                    project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "Publisher.hpp");
                                     project.addProjectSrcFile(relative_dir + ctx.getFilename() + "Publisher.cxx");
                                 }
                             }
 
                             System.out.println("Generating Subscriber files...");
                             if (returnedValue =
-                                    Utils.writeFile(output_dir + ctx.getFilename() + "Subscriber.h",
+                                    Utils.writeFile(output_dir + ctx.getFilename() + "Subscriber.hpp",
                                         maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg"), m_replace))
                             {
                                 if (returnedValue =
                                         Utils.writeFile(output_dir + ctx.getFilename() + "Subscriber.cxx",
                                             maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg"), m_replace))
                                 {
-                                    project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "Subscriber.h");
+                                    project.addProjectIncludeFile(relative_dir + ctx.getFilename() + "Subscriber.hpp");
                                     project.addProjectSrcFile(relative_dir + ctx.getFilename() + "Subscriber.cxx");
                                 }
                             }
@@ -1103,11 +1103,11 @@ public class fastddsgen
                     }
                 }
 
-                if (Utils.writeFile(output_dir + ctx.getFilename() + "PubSubJNII.h",
+                if (Utils.writeFile(output_dir + ctx.getFilename() + "PubSubJNII.hpp",
                         maintemplates.getTemplate("JNIHeader"),
                         m_replace))
                 {
-                    project.addJniIncludeFile(relative_dir + ctx.getFilename() + "PubSubJNII.h");
+                    project.addJniIncludeFile(relative_dir + ctx.getFilename() + "PubSubJNII.hpp");
                 }
                 else
                 {
@@ -1490,7 +1490,7 @@ public class fastddsgen
         String javafile = (m_outputDir != null ? m_outputDir : "") +
                 (!m_package.isEmpty() ? m_package.replace('.', File.separatorChar) + File.separator : "") +
                 Util.getIDLFileNameOnly(idlFilename) + "PubSub.java";
-        String headerfile = m_outputDir + Util.getIDLFileNameOnly(idlFilename) + "PubSubJNI.h";
+        String headerfile = m_outputDir + Util.getIDLFileNameOnly(idlFilename) + "PubSubJNI.hpp";
         int exitVal = -1;
         String javac = null;
         String javah = null;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubMain.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubMain.stg
@@ -20,8 +20,8 @@ main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubMain.cpp"], description=["This file acts as a main entry point to the application."])$
 
 
-#include "$ctx.filename$Publisher.h"
-#include "$ctx.filename$Subscriber.h"
+#include "$ctx.filename$Publisher.hpp"
+#include "$ctx.filename$Subscriber.hpp"
 
 int main(
         int argc,

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -165,10 +165,10 @@ public:
     }
 
     eProsima_user_DllExport inline bool is_plain(
-        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
         $if(struct.isPlain)$
-        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        if (data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
         {
             return is_plain_xcdrv2_impl();
         }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -17,21 +17,21 @@ group ProtocolHeader;
 import "eprosima.stg"
 
 main(ctx, definitions) ::= <<
-$fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.h"], description=["This header file contains the declaration of the serialization functions."])$
+$fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.hpp"], description=["This header file contains the declaration of the serialization functions."])$
 
 
-#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBSUBTYPES_H_
-#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBSUBTYPES_H_
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_PUBSUBTYPES_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_PUBSUBTYPES_HPP
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/dds/topic/TopicDataType.hpp>
-#include <fastdds/rtps/common/InstanceHandle.h>
-#include <fastdds/rtps/common/SerializedPayload.h>
-#include <fastdds/utils/md5.h>
+#include <fastdds/rtps/common/InstanceHandle.hpp>
+#include <fastdds/rtps/common/SerializedPayload.hpp>
+#include <fastdds/utils/md5.hpp>
 
 #include "$ctx.filename$.hpp"
 
-$ctx.directIncludeDependencies : {include | #include "$include$PubSubTypes.h"}; separator="\n"$
+$ctx.directIncludeDependencies : {include | #include "$include$PubSubTypes.hpp"}; separator="\n"$
 
 #if !defined(GEN_API_VER) || (GEN_API_VER != 2)
 #error \
@@ -40,7 +40,7 @@ $ctx.directIncludeDependencies : {include | #include "$include$PubSubTypes.h"}; 
 
 $definitions; separator="\n"$
 
-#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBSUBTYPES_H_
+#endif // FAST_DDS_GENERATED__$ctx.headerGuardName$_PUBSUBTYPES_HPP
 $"\n"$
 >>
 
@@ -194,7 +194,7 @@ public:
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
 
-    MD5 m_md5;
+    eprosima::fastdds::MD5 m_md5;
     unsigned char* m_keyBuffer;
 
 $if(struct.isPlain)$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -19,7 +19,7 @@ import "eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.cpp"], description=["This header file contains the implementation of the serialization functions."])$
 
-#include "$ctx.filename$PubSubTypes.h"
+#include "$ctx.filename$PubSubTypes.hpp"
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/common/CdrSerialization.hpp>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg
@@ -22,11 +22,11 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.i"], description=["This h
 %import(module="fastdds") "fastdds/dds/topic/TopicDataType.hpp";
 
 %{
-#include "$ctx.filename$PubSubTypes.h"
+#include "$ctx.filename$PubSubTypes.hpp"
 %}
 
 #define GEN_API_VER 2
 
-%include "$ctx.filename$PubSubTypes.h"
+%include "$ctx.filename$PubSubTypes.hpp"
 
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg
@@ -17,11 +17,11 @@ group ProtocolHeader;
 import "eprosima.stg"
 
 main(ctx, definitions) ::= <<
-$fileHeader(ctx=ctx,  file=[ctx.filename, "Publisher.h"], description=["This header file contains the declaration of the publisher functions."])$
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Publisher.hpp"], description=["This header file contains the declaration of the publisher functions."])$
 
 
-#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBLISHER_H_
-#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBLISHER_H_
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_PUBLISHER_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_PUBLISHER_HPP
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
@@ -66,5 +66,5 @@ private:
     listener_;
 };
 
-#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_PUBLISHER_H_
+#endif // FAST_DDS_GENERATED__$ctx.headerGuardName$_PUBLISHER_HPP
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherSource.stg
@@ -20,8 +20,8 @@ main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Publisher.cpp"], description=["This file contains the implementation of the publisher functions."])$
 
 
-#include "$ctx.filename$Publisher.h"
-#include "$ctx.filename$PubSubTypes.h"
+#include "$ctx.filename$Publisher.hpp"
+#include "$ctx.filename$PubSubTypes.hpp"
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg
@@ -17,11 +17,11 @@ group ProtocolHeader;
 import "eprosima.stg"
 
 main(ctx, definitions) ::= <<
-$fileHeader(ctx=ctx,  file=[ctx.filename, "Subscriber.h"], description=["This header file contains the declaration of the subscriber functions."])$
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Subscriber.hpp"], description=["This header file contains the declaration of the subscriber functions."])$
 
 
-#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_SUBSCRIBER_H_
-#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_SUBSCRIBER_H_
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_SUBSCRIBER_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_SUBSCRIBER_HPP
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
@@ -69,5 +69,5 @@ private:
     listener_;
 };
 
-#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_SUBSCRIBER_H_
+#endif // FAST_DDS_GENERATED__$ctx.headerGuardName$_SUBSCRIBER_HPP
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg
@@ -25,8 +25,8 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "Subscriber.cpp"], description=["This 
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 
-#include "$ctx.filename$Subscriber.h"
-#include "$ctx.filename$PubSubTypes.h"
+#include "$ctx.filename$Subscriber.hpp"
+#include "$ctx.filename$PubSubTypes.hpp"
 
 using namespace eprosima::fastdds::dds;
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/JNISource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/JNISource.stg
@@ -19,8 +19,8 @@ import "eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "JNI.cxx"], description=[""])$
 
-$ctx.directIncludeDependencies : {include | #include "$include$PubSubJNII.h"}; separator="\n"$
-#include "$ctx.filename$PubSubJNII.h"
+$ctx.directIncludeDependencies : {include | #include "$include$PubSubJNII.hpp"}; separator="\n"$
+#include "$ctx.filename$PubSubJNII.hpp"
 
 #include <fastrtps/participant/Participant.h>
 #include <fastrtps/attributes/ParticipantAttributes.h>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationHeader.stg
@@ -17,10 +17,10 @@ group ProtocolHeader;
 import "eprosima.stg"
 
 main(ctx, definitions) ::= <<
-$fileHeader(ctx=ctx,  file=[ctx.filename, "Serialization.h"], description=["This file contains serialization definitions."])$
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Serialization.hpp"], description=["This file contains serialization definitions."])$
 
-#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_SERIALIZATION_H_
-#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_SERIALIZATION_H_
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_SERIALIZATION_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_SERIALIZATION_HPP
 
 #include "$ctx.filename$.hpp"
 
@@ -29,7 +29,7 @@ $definitions; separator="\n"$
 extern bool g_$ctx.filename$_test_null_opt;
 extern bool g_$ctx.filename$_test_empty_ext;
 
-#endif //_FAST_DDS_GENERATED_$ctx.headerGuardName$_SERIALIZATION_H_
+#endif //FAST_DDS_GENERATED__$ctx.headerGuardName$_SERIALIZATION_HPP
 >>
 
 struct_type(ctx, parent, struct, member_list) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
@@ -19,7 +19,7 @@ import "eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "SerializationSource.cpp"], description=["This file contains serialization code."])$
 
-#include "$ctx.filename$Serialization.h"
+#include "$ctx.filename$Serialization.hpp"
 
 #include <cassert>
 #include <cinttypes>
@@ -34,7 +34,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "SerializationSource.cpp"], descriptio
 bool g_$ctx.filename$_test_null_opt = false;
 bool g_$ctx.filename$_test_empty_ext = false;
 
-$ctx.directIncludeDependencies:{ header | #include "$header$Serialization.h"}; separator="\n"$
+$ctx.directIncludeDependencies:{ header | #include "$header$Serialization.hpp"}; separator="\n"$
 
 $definitions; separator="\n"$
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
@@ -28,10 +28,10 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "SerializationTest.cpp"], description=
 
 #include <gtest/gtest.h>
 
-#include "$ctx.filename$PubSubTypes.h"
-#include "$ctx.filename$Serialization.h"
+#include "$ctx.filename$PubSubTypes.hpp"
+#include "$ctx.filename$Serialization.hpp"
 #include <fastcdr/Cdr.h>
-#include <fastdds/rtps/common/SerializedPayload.h>
+#include <fastdds/rtps/common/SerializedPayload.hpp>
 
 $definitions; separator="\n"$
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
@@ -50,7 +50,7 @@ bool eprosima::fastcdr::external<eprosima::fastdds::dds::xtypes::TypeIdentifier>
 #include <fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp>
 #include <fastdds/dds/xtypes/type_representation/TypeObject.hpp>
 #include <fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp>
-#include <fastdds/utils/md5.h>
+#include <fastdds/utils/md5.hpp>
 #include <gtest/gtest.h>
 
 $ctx.directIncludeDependencies : {include | #include "$include$.hpp"}; separator="\n"$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg
@@ -19,8 +19,8 @@ import "eprosima.stg"
 main(ctx, definitions, extensions) ::= <<
 $fileHeader(ctx=ctx, file=[ctx.filename, "CdrAux.hpp"], description=["This source file contains some definitions of CDR related functions."])$
 
-#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$CDRAUX_HPP_
-#define _FAST_DDS_GENERATED_$ctx.headerGuardName$CDRAUX_HPP_
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_HPP
 
 #include "$ctx.filename$.hpp"
 
@@ -43,7 +43,7 @@ $definitions; separator="\n"$
 } // namespace fastcdr
 } // namespace eprosima
 
-#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$CDRAUX_HPP_
+#endif // FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_HPP
 $"\n"$
 >>
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -20,8 +20,8 @@ import "com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg"
 main(ctx, definitions, extensions) ::= <<
 $fileHeader(ctx=ctx, file=[ctx.filename, "CdrAux.ipp"], description=["This source file contains some declarations of CDR related functions."])$
 
-#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$CDRAUX_IPP_
-#define _FAST_DDS_GENERATED_$ctx.headerGuardName$CDRAUX_IPP_
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_IPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_IPP
 
 #include "$ctx.filename$CdrAux.hpp"
 
@@ -42,7 +42,7 @@ $definitions; separator="\n"$
 } // namespace fastcdr
 } // namespace eprosima
 
-#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$CDRAUX_IPP_
+#endif // FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_IPP
 $"\n"$
 >>
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectHeader.stg
@@ -19,8 +19,8 @@ import "eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx, file=[ctx.filename, "TypeObjectSupport.hpp"], description=["Header file containing the API required to register the TypeObject representation of the described types in the IDL file"])$
 
-#ifndef _FAST_DDS_GENERATED_$ctx.headerGuardName$_TYPE_OBJECT_SUPPORT_HPP_
-#define _FAST_DDS_GENERATED_$ctx.headerGuardName$_TYPE_OBJECT_SUPPORT_HPP_
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_TYPE_OBJECT_SUPPORT_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_TYPE_OBJECT_SUPPORT_HPP
 
 #include <fastdds/dds/xtypes/type_representation/TypeObject.hpp>
 
@@ -42,7 +42,7 @@ $definitions; separator=""$
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-#endif // _FAST_DDS_GENERATED_$ctx.headerGuardName$_TYPE_OBJECT_SUPPORT_HPP_
+#endif // FAST_DDS_GENERATED__$ctx.headerGuardName$_TYPE_OBJECT_SUPPORT_HPP
 
 >>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR is the FastDDS Gen counterpart of this FastDDS PR:
- #eProsima/Fast-DDS/pull/4958

This is part of the set of PRs preparing the new major version 3.x in FastDDS. Consequently, it cannot be backported
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
