### PR TITLE
[21277] Support compilation against Ubuntu 24.04 swig4.1

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -71,7 +71,12 @@ target_link_libraries(\${PROJECT_NAME}
 ###############################################################################
 # Python bindings for type
 
-find_package(SWIG REQUIRED)
+find_package(SWIG)
+if (NOT SWIG_FOUND)
+    # Trick to find swig4.1 in Ubuntu noble.
+    find_program(SWIG_EXECUTABLE NAMES swig4.1 swig)
+    find_package(SWIG REQUIRED)
+endif()
 include(\${SWIG_USE_FILE})
 set(CMAKE_SWIG_FLAGS "")
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

Due to an error, fastdds_python doesn't compile with current SWIG version (4.2.0) on Ubuntu 24.04. The fix is in swig 4.2.1 but it's not accessible in ubuntu noble. This ubuntu also contains the package swig4.1 but CMake is not prepare to find its executable. This PR fixes this using a trick.

Related to:
- eprosima/fast-dds-python#153
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
