### PR TITLE
[21351] Refactor `TopicDataType`

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -182,11 +182,12 @@ public:
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
 
+private:
+
     eprosima::fastdds::MD5 md5_;
     unsigned char* key_buffer_;
 
 $if(struct.isPlain)$
-private:
 
     static constexpr bool is_plain_xcdrv1_impl()
     {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -125,6 +125,11 @@ public:
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport bool compute_key(
             const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -33,10 +33,10 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.hpp"], description=["This
 
 $ctx.directIncludeDependencies : {include | #include "$include$PubSubTypes.hpp"}; separator="\n"$
 
-#if !defined(GEN_API_VER) || (GEN_API_VER != 2)
+#if !defined(FASTDDS_GEN_API_VER) || (FASTDDS_GEN_API_VER != 3)
 #error \
     Generated $ctx.filename$ is not compatible with current installed Fast DDS. Please, regenerate it with fastddsgen.
-#endif  // GEN_API_VER
+#endif  // FASTDDS_GEN_API_VER
 
 $definitions; separator="\n"$
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -113,11 +113,11 @@ public:
 
     eProsima_user_DllExport bool serialize(
             const void* const data,
-            eprosima::fastdds::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool deserialize(
-            eprosima::fastdds::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
             void* data) override;
 
     eProsima_user_DllExport uint32_t calculate_serialized_size(
@@ -125,13 +125,13 @@ public:
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool compute_key(
-            eprosima::fastdds::rtps::SerializedPayload_t* payload,
-            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
             bool force_md5 = false) override;
 
     eProsima_user_DllExport bool compute_key(
             const void* const data,
-            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
             bool force_md5 = false) override;
 
     eProsima_user_DllExport void* create_data() override;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -113,25 +113,12 @@ public:
 
     eProsima_user_DllExport bool serialize(
             const void* const data,
-            eprosima::fastdds::rtps::SerializedPayload_t* payload) override
-    {
-        return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
-    }
-
-    eProsima_user_DllExport bool serialize(
-            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool deserialize(
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
-
-    eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            const void* const data) override
-    {
-        return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
-    }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
             const void* const data,
@@ -159,10 +146,6 @@ public:
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
 
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
-    eProsima_user_DllExport inline bool is_plain() const override
-    {
-        return $if(struct.isPlain)$is_plain_xcdrv1_impl()$else$false$endif$;
-    }
 
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -120,18 +120,18 @@ public:
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
 
-    eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
             const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
-    eProsima_user_DllExport bool getKey(
+    eProsima_user_DllExport bool compute_key(
             const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
-    eProsima_user_DllExport void* createData() override;
+    eProsima_user_DllExport void* create_data() override;
 
-    eProsima_user_DllExport void deleteData(
+    eProsima_user_DllExport void delete_data(
             void* data) override;
 
     //Register TypeObject representation in Fast DDS TypeObjectRegistry
@@ -177,8 +177,8 @@ public:
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
 
-    eprosima::fastdds::MD5 m_md5;
-    unsigned char* m_keyBuffer;
+    eprosima::fastdds::MD5 md5_;
+    unsigned char* key_buffer_;
 
 $if(struct.isPlain)$
 private:

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -169,6 +169,25 @@ void $struct.name$PubSubType::delete_data(
 }
 
 bool $struct.name$PubSubType::compute_key(
+        SerializedPayload_t* payload,
+        InstanceHandle_t* handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    $struct.name$ data;
+    if (deserialize(payload, static_cast<void*>(&data)))
+    {
+        return compute_key(static_cast<void*>(&data), handle, force_md5);
+    }
+
+    return false;
+}
+
+bool $struct.name$PubSubType::compute_key(
         const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -53,26 +53,21 @@ struct_type(ctx, parent, struct, member_list) ::= <<
 $member_list$
 $struct.name$PubSubType::$struct.name$PubSubType()
 {
-    $if(ctx.GenerateTypesROS2)$setName("$struct.ROS2Scopedname$");$else$setName("$struct.scopedname$");$endif$
-    uint32_t type_size =
-#if FASTCDR_VERSION_MAJOR == 1
-        static_cast<uint32_t>($struct.name$::getMaxCdrSerializedSize());
-#else
-        $struct.cScopedname$_max_cdr_typesize;
-#endif
+    $if(ctx.GenerateTypesROS2)$set_name("$struct.ROS2Scopedname$");$else$set_name("$struct.scopedname$");$endif$
+    uint32_t type_size = $struct.cScopedname$_max_cdr_typesize;
     type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
-    m_typeSize = type_size + 4; /*encapsulation*/
-    m_isGetKeyDefined = $if(struct.hasKey)$true$else$false$endif$;
-    uint32_t keyLength = $struct.cScopedname$_max_key_cdr_typesize > 16 ? $struct.cScopedname$_max_key_cdr_typesize : 16;
-    m_keyBuffer = reinterpret_cast<unsigned char*>(malloc(keyLength));
-    memset(m_keyBuffer, 0, keyLength);
+    max_serialized_type_size = type_size + 4; /*encapsulation*/
+    is_compute_key_provided = $if(struct.hasKey)$true$else$false$endif$;
+    uint32_t key_length = $struct.cScopedname$_max_key_cdr_typesize > 16 ? $struct.cScopedname$_max_key_cdr_typesize : 16;
+    key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+    memset(key_buffer_, 0, key_length);
 }
 
 $struct.name$PubSubType::~$struct.name$PubSubType()
 {
-    if (m_keyBuffer != nullptr)
+    if (key_buffer_ != nullptr)
     {
-        free(m_keyBuffer);
+        free(key_buffer_);
     }
 }
 
@@ -90,12 +85,10 @@ bool $struct.name$PubSubType::serialize(
             data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
             eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
     payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-#if FASTCDR_VERSION_MAJOR > 1
     ser.set_encoding_flag(
         data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
         $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR $elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$ :
         $if(struct.annotationFinal)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2$elseif(struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2$endif$);
-#endif // FASTCDR_VERSION_MAJOR > 1
 
     try
     {
@@ -110,11 +103,7 @@ bool $struct.name$PubSubType::serialize(
     }
 
     // Get the serialized length
-#if FASTCDR_VERSION_MAJOR == 1
-    payload->length = static_cast<uint32_t>(ser.getSerializedDataLength());
-#else
     payload->length = static_cast<uint32_t>(ser.get_serialized_data_length());
-#endif // FASTCDR_VERSION_MAJOR == 1
     return true;
 }
 
@@ -131,11 +120,7 @@ bool $struct.name$PubSubType::deserialize(
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->length);
 
         // Object that deserializes the data.
-        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN
-#if FASTCDR_VERSION_MAJOR == 1
-                , eprosima::fastcdr::Cdr::CdrType::DDS_CDR
-#endif // FASTCDR_VERSION_MAJOR == 1
-                );
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
 
         // Deserialize encapsulation.
         deser.read_encapsulation();
@@ -152,52 +137,43 @@ bool $struct.name$PubSubType::deserialize(
     return true;
 }
 
-std::function<uint32_t()> $struct.name$PubSubType::getSerializedSizeProvider(
+uint32_t $struct.name$PubSubType::calculate_serialized_size(
         const void* const data,
         DataRepresentationId_t data_representation)
 {
-    return [data, data_representation]() -> uint32_t
-           {
-#if FASTCDR_VERSION_MAJOR == 1
-               static_cast<void>(data_representation);
-               return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<$struct.name$*>(data))) +
-                      4u /*encapsulation*/;
-#else
-               try
-               {
-                   eprosima::fastcdr::CdrSizeCalculator calculator(
-                       data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                       eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                   size_t current_alignment {0};
-                   return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<const $struct.name$*>(data), current_alignment)) +
-                           4u /*encapsulation*/;
-               }
-               catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-               {
-                   return 0;
-               }
-#endif // FASTCDR_VERSION_MAJOR == 1
-           };
+    try
+    {
+        eprosima::fastcdr::CdrSizeCalculator calculator(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+        size_t current_alignment {0};
+        return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                    *static_cast<const $struct.name$*>(data), current_alignment)) +
+                4u /*encapsulation*/;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return 0;
+    }
 }
 
-void* $struct.name$PubSubType::createData()
+void* $struct.name$PubSubType::create_data()
 {
     return reinterpret_cast<void*>(new $struct.name$());
 }
 
-void $struct.name$PubSubType::deleteData(
+void $struct.name$PubSubType::delete_data(
         void* data)
 {
     delete(reinterpret_cast<$struct.name$*>(data));
 }
 
-bool $struct.name$PubSubType::getKey(
+bool $struct.name$PubSubType::compute_key(
         const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
-    if (!m_isGetKeyDefined)
+    if (!is_compute_key_provided)
     {
         return false;
     }
@@ -205,35 +181,27 @@ bool $struct.name$PubSubType::getKey(
     const $struct.name$* p_type = static_cast<const $struct.name$*>(data);
 
     // Object that manages the raw buffer.
-    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
             $struct.cScopedname$_max_key_cdr_typesize);
 
     // Object that serializes the data.
     eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
-#if FASTCDR_VERSION_MAJOR == 1
-    p_type->serializeKey(ser);
-#else
     eprosima::fastcdr::serialize_key(ser, *p_type);
-#endif // FASTCDR_VERSION_MAJOR == 1
     if (force_md5 || $struct.cScopedname$_max_key_cdr_typesize > 16)
     {
-        m_md5.init();
-#if FASTCDR_VERSION_MAJOR == 1
-        m_md5.update(m_keyBuffer, static_cast<unsigned int>(ser.getSerializedDataLength()));
-#else
-        m_md5.update(m_keyBuffer, static_cast<unsigned int>(ser.get_serialized_data_length()));
-#endif // FASTCDR_VERSION_MAJOR == 1
-        m_md5.finalize();
+        md5_.init();
+        md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+        md5_.finalize();
         for (uint8_t i = 0; i < 16; ++i)
         {
-            handle->value[i] = m_md5.digest[i];
+            handle->value[i] = md5_.digest[i];
         }
     }
     else
     {
         for (uint8_t i = 0; i < 16; ++i)
         {
-            handle->value[i] = m_keyBuffer[i];
+            handle->value[i] = key_buffer_[i];
         }
     }
     return true;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -73,18 +73,18 @@ $struct.name$PubSubType::~$struct.name$PubSubType()
 
 bool $struct.name$PubSubType::serialize(
         const void* const data,
-        SerializedPayload_t* payload,
+        SerializedPayload_t& payload,
         DataRepresentationId_t data_representation)
 {
     const $struct.name$* p_type = static_cast<const $struct.name$*>(data);
 
     // Object that manages the raw buffer.
-    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
     // Object that serializes the data.
     eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
             data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
             eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
-    payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
     ser.set_encoding_flag(
         data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
         $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR $elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$ :
@@ -103,12 +103,12 @@ bool $struct.name$PubSubType::serialize(
     }
 
     // Get the serialized length
-    payload->length = static_cast<uint32_t>(ser.get_serialized_data_length());
+    payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
     return true;
 }
 
 bool $struct.name$PubSubType::deserialize(
-        SerializedPayload_t* payload,
+        SerializedPayload_t& payload,
         void* data)
 {
     try
@@ -117,14 +117,14 @@ bool $struct.name$PubSubType::deserialize(
         $struct.name$* p_type = static_cast<$struct.name$*>(data);
 
         // Object that manages the raw buffer.
-        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->length);
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
 
         // Object that deserializes the data.
         eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
 
         // Deserialize encapsulation.
         deser.read_encapsulation();
-        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
 
         // Deserialize the object.
         deser \>> *p_type;
@@ -169,8 +169,8 @@ void $struct.name$PubSubType::delete_data(
 }
 
 bool $struct.name$PubSubType::compute_key(
-        SerializedPayload_t* payload,
-        InstanceHandle_t* handle,
+        SerializedPayload_t& payload,
+        InstanceHandle_t& handle,
         bool force_md5)
 {
     if (!is_compute_key_provided)
@@ -189,7 +189,7 @@ bool $struct.name$PubSubType::compute_key(
 
 bool $struct.name$PubSubType::compute_key(
         const void* const data,
-        InstanceHandle_t* handle,
+        InstanceHandle_t& handle,
         bool force_md5)
 {
     if (!is_compute_key_provided)
@@ -213,14 +213,14 @@ bool $struct.name$PubSubType::compute_key(
         md5_.finalize();
         for (uint8_t i = 0; i < 16; ++i)
         {
-            handle->value[i] = md5_.digest[i];
+            handle.value[i] = md5_.digest[i];
         }
     }
     else
     {
         for (uint8_t i = 0; i < 16; ++i)
         {
-            handle->value[i] = key_buffer_[i];
+            handle.value[i] = key_buffer_[i];
         }
     }
     return true;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg
@@ -25,7 +25,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.i"], description=["This h
 #include "$ctx.filename$PubSubTypes.hpp"
 %}
 
-#define GEN_API_VER 2
+#define FASTDDS_GEN_API_VER 3
 
 %include "$ctx.filename$PubSubTypes.hpp"
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
@@ -64,30 +64,28 @@ TEST_P($struct.formatedCppTypename$Test, encoding)
 
     if (test_null_optional || !test_empty_external)
     {
-        uint32_t payloadSize = static_cast<uint32_t>(pst.getSerializedSizeProvider(&$struct.name$_serialization_topic,
-                    cdr_version)());
+        uint32_t payloadSize = pst.calculate_serialized_size(&$struct.name$_serialization_topic, cdr_version);
 
         SerializedPayload_t payload(payloadSize);
 
-        ASSERT_TRUE(pst.serialize(&$struct.name$_serialization_topic, &payload, cdr_version));
+        ASSERT_TRUE(pst.serialize(&$struct.name$_serialization_topic, payload, cdr_version));
 
-        ASSERT_TRUE(pst.deserialize(&payload, &$struct.name$_deserialization_topic));
+        ASSERT_TRUE(pst.deserialize(payload, &$struct.name$_deserialization_topic));
 
-        uint32_t payloadOutSize = static_cast<uint32_t>(pst.getSerializedSizeProvider(&$struct.name$_deserialization_topic,
-                    cdr_version)());
+        uint32_t payloadOutSize = pst.calculate_serialized_size(&$struct.name$_deserialization_topic, cdr_version);
 
         ASSERT_GT(compare$struct.name$(&$struct.name$_serialization_topic, &$struct.name$_deserialization_topic), 0);
         ASSERT_EQ(payloadOutSize, payloadSize);
-        ASSERT_GE($struct.name$_type_support.m_typeSize + 4, payloadSize);
+        ASSERT_GE($struct.name$_type_support.max_serialized_type_size + 4, payloadSize);
         ASSERT_EQ(payload.length, payloadSize);
     }
     else
     {
-        ASSERT_EQ(0, pst.getSerializedSizeProvider(&$struct.name$_serialization_topic, cdr_version)());
+        ASSERT_EQ(0, pst.calculate_serialized_size(&$struct.name$_serialization_topic, cdr_version));
 
         SerializedPayload_t payload(1000);
 
-        ASSERT_FALSE(pst.serialize(&$struct.name$_serialization_topic, &payload, cdr_version));
+        ASSERT_FALSE(pst.serialize(&$struct.name$_serialization_topic, payload, cdr_version));
     }
 
     $if((ctx.generateTypesC))$


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
Implementation of XCDR introduces new functions in `TopicDataType` class. But the old one remained. This PR removes them before launching the major version 3, and also performs additional refactorings:
- Change method names to `snake_case` and have more meaningful names.
- Change arguments from pointer to reference where applicable
- Use `std::string` instead of `char*` on name getters and setters

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

