### PR TITLE
[21380] Support setting value to an enumeration literal using annotation @value

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -558,7 +558,7 @@ enum_type(ctx, parent, enum) ::= <<
  */
 enum class $enum.name$ : int32_t
 {
-    $enum.members:{ member | $member.name$}; separator=",\n"$
+    $enum.members:{ member | $member.name$$if(member.annotationValue)$ = $member.annotationValueValue$$endif$}; separator=",\n"$
 };
 >>
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
@@ -245,7 +245,7 @@ TEST(TypeObjectTests, TestEnumTypeObject_$enum.name$)
     TypeIdentifierPair type_ids;
 
     // Register specific enum TypeObject
-    $if(enum.scope)$::$endif$$enum.scope$::register_$enum.name$_type_identifier(type_ids);
+    $if(!enum.scope.empty)$::$endif$$enum.scope$::register_$enum.name$_type_identifier(type_ids);
 
     $check_type_identifier_consistency(result="type_ids")$
     $check_direct_hash_type_identifier(typeid="type_ids")$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -725,7 +725,7 @@ $endif$
 enum_literal(literal, parent, name) ::= <<
 {
     EnumeratedLiteralFlag flags_$literal.name$ = TypeObjectUtils::build_enumerated_literal_flag($literal.annotationDefaultLiteral$);
-    CommonEnumeratedLiteral common_$literal.name$ = TypeObjectUtils::build_common_enumerated_literal($literal.index$, flags_$literal.name$);
+    CommonEnumeratedLiteral common_$literal.name$ = TypeObjectUtils::build_common_enumerated_literal($if(literal.annotationValue)$$literal.annotationValueValue$$else$$literal.index$$endif$, flags_$literal.name$);
     $empty_ann_builtin_complete_member_detail(member=literal, parent=parent, message=[parent.scopedname, " Enumerated ", literal.name, " literal: only @default_literal and @value builtin annotations apply to literals"], name=name)$
     CompleteEnumeratedLiteral literal_$literal.name$ = TypeObjectUtils::build_complete_enumerated_literal(common_$literal.name$, detail_$literal.name$);
     TypeObjectUtils::add_complete_enumerated_literal(literal_seq_$parent.name$, literal_$literal.name$);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

This PR adds support for settting a value to an enumeration literal. For example:
```omg-idl
enum MyEnum
{
    @value(-3)
    ENUM_VALUE1,
    @value(0)
    ENUM_VALUE2
};
```
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Depends on:
- eprosima/dds-types-test#36
- eprosima/fast-dds#5109
- eprosima/fast-dds-docs#917

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
