### PR TITLE
[21186] Fix minor uncrustify issues for simple type regeneration

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -174,9 +174,7 @@ public:
         $endif$
     {
         $if(struct.members)$
-        $struct.members:{ member |
-            m_$member.name$ = x.m_$member.name$;
-        }; separator="\n"$
+        $struct.members:{ member | m_$member.name$ = x.m_$member.name$;}; separator="\n"$
         $else$
         static_cast<void>(x);
         $endif$
@@ -210,9 +208,7 @@ public:
         $if(struct.inheritance)$$struct.inheritance.scopedname$::operator =(x);$endif$
 
         $if(struct.members)$
-        $struct.members:{ member |
-            m_$member.name$ = x.m_$member.name$;
-        }; separator="\n"$
+        $struct.members:{ member | m_$member.name$ = x.m_$member.name$;}; separator="\n"$
         $else$
         static_cast<void>(x);
         $endif$
@@ -255,7 +251,7 @@ public:
         static_cast<void>(x);
         return true;
         $else$
-        return ($struct.members:{ member | m_$member.name$ == x.m_$member.name$}; separator=" &&\n           "$);
+        return ($struct.members:{ member | m_$member.name$ == x.m_$member.name$}; separator=" &&\n               "$);
         $endif$
     }
 
@@ -272,7 +268,6 @@ public:
     $struct.members:{ member | $public_member_declaration(member)$}; separator="\n"$
 
     $extensions : { extension | $extension$}; separator="\n"$
-
 private:
 
     $struct.members:{ member | $private_member_declaration(member=member)$}; separator="\n"$
@@ -485,7 +480,6 @@ public:
     $endif$
 
     $extensions : {extension | $extension$}; separator="\n"$
-
 private:
 
     $union.members: { member |
@@ -592,12 +586,9 @@ public_struct_inheritances(parent) ::= <<$parent.scopedname$>>
 
 public_member_declaration(member) ::= <<
 $if(member.annotationOptional || member.annotationExternal)$
-$public_member_common_declaration(member=member)$
-$elseif(member.typecode.primitive)$
-$public_member_primitive_declaration(member=member)$
-$else$
-$public_member_common_declaration(member=member)$
-$endif$
+$public_member_common_declaration(member=member)$$elseif(member.typecode.primitive)$
+$public_member_primitive_declaration(member=member)$$else$
+$public_member_common_declaration(member=member)$$endif$
 >>
 
 public_member_primitive_declaration(member) ::= <<
@@ -669,7 +660,6 @@ eProsima_user_DllExport $member_type_declaration(member)$& $member.name$()
     return m_$member.name$;
 }
 >>
-
 private_member_declaration(member) ::= <<
 $member_type_declaration(member)$ m_$member.name$$member_default_init(member)$;
 >>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes uncrustify issues for simple type generation
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
