### PR TITLE
[21605] Use @FINAL for ROS2 types by default

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -369,6 +369,7 @@ public class fastddsgen
             else if (arg.equals(ros2_names_arg))
             {
                 m_type_ros2 = true;
+                TypeCode.default_extensibility = TypeCode.ExtensibilityKind.FINAL;
             }
             else if (arg.equals(cnames_arg))
             {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -916,17 +916,7 @@ if (eprosima::fastdds::dds::RETCODE_OK != return_code_$name$)
 >>
 
 extensibility(object) ::= <%
-$if (object.annotationExtensibilityNotApplied)$
-    $if(object.isStructType)$
-    $if(object.inheritance)$
-    $extensibility(object.inheritance)$
-    $else$
-    eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-    $endif$
-    $else$
-    eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-    $endif$
-$elseif (object.annotationAppendable)$
+$if (object.annotationAppendable)$
     eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
 $elseif (object.annotationFinal)$
     eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

Use FINAL extensibility for ROS2 types by default.

Depends on:

- eprosima/idl-parser#157

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

