### PR TITLE
[21623] Fix compilation warning in Ubuntu 24.04 with `-Werror`

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -296,23 +296,9 @@ public:
     eProsima_user_DllExport $union.name$()
     {
         $if(union.defaultAnnotatedMember)$
-        selected_member_ = $union.defaultAnnotatedMember.id$;
-        $if(union.defaultAnnotatedMember.typecode.primitive)$
-        member_destructor_ = nullptr;
-        m_$union.defaultAnnotatedMember.name$ = $member_default_init(union.defaultAnnotatedMember)$;
-        $else$
-        member_destructor_ = [&]() {$union_member_destroy_call(union.defaultAnnotatedMember)$\};
-        new(&m_$union.defaultAnnotatedMember.name$) $member_type_declaration(union.defaultAnnotatedMember)$();
-        $endif$;
+        $union_member_initialization(union.defaultAnnotatedMember)$
         $elseif(union.defaultMember)$
-        selected_member_ = $union.defaultMember.id$;
-        $if(union.defaultMember.typecode.primitive)$
-        member_destructor_ = nullptr;
-        m_$union.defaultMember.name$ = $member_default_init(union.defaultMember)$;
-        $else$
-        member_destructor_ = [&]() {$union_member_destroy_call(union.defaultMember)$\};
-        new(&m_$union.defaultMember.name$) $member_type_declaration(union.defaultMember)$();
-        $endif$;
+        $union_member_initialization(union.defaultMember)$
         $endif$
     }
 
@@ -512,14 +498,7 @@ private:
                     member_destructor_();
                 \}
 
-                selected_member_ = $member.id$;
-                $if(member.typecode.primitive)$
-                member_destructor_ = nullptr;
-                m_$member.name$ = $member_default_init(member)$;
-                $else$
-                member_destructor_ = [&]() {$union_member_destroy_call(member)$\};
-                new(&m_$member.name$) $member_type_declaration(member)$();
-                $endif$;
+                $union_member_initialization(member)$
             \}
 
             return m_$member.name$;
@@ -841,6 +820,17 @@ $if(const.typeCode.isFloat32Type)$
 f
 $endif$
 %>
+
+union_member_initialization(member) ::= <<
+selected_member_ = $member.id$;
+$if(member.typecode.primitive)$
+member_destructor_ = nullptr;
+m_$member.name$ = $member_default_init(member)$;
+$else$
+member_destructor_ = [&]() {$union_member_destroy_call(member)$\};
+new(&m_$member.name$) $member_type_declaration(member)$();
+$endif$
+>>
 
 //{ Fast DDS-Gen extensions
 module_conversion(ctx, parent, modules, definition_list) ::= <<

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -296,9 +296,23 @@ public:
     eProsima_user_DllExport $union.name$()
     {
         $if(union.defaultAnnotatedMember)$
-        $union.defaultAnnotatedMember.name$_();
+        selected_member_ = $union.defaultAnnotatedMember.id$;
+        $if(union.defaultAnnotatedMember.typecode.primitive)$
+        member_destructor_ = nullptr;
+        m_$union.defaultAnnotatedMember.name$ = $member_default_init(union.defaultAnnotatedMember)$;
+        $else$
+        member_destructor_ = [&]() {$union_member_destroy_call(union.defaultAnnotatedMember)$\};
+        new(&m_$union.defaultAnnotatedMember.name$) $member_type_declaration(union.defaultAnnotatedMember)$();
+        $endif$;
         $elseif(union.defaultMember)$
-        $union.defaultMember.name$_();
+        selected_member_ = $union.defaultMember.id$;
+        $if(union.defaultMember.typecode.primitive)$
+        member_destructor_ = nullptr;
+        m_$union.defaultMember.name$ = $member_default_init(union.defaultMember)$;
+        $else$
+        member_destructor_ = [&]() {$union_member_destroy_call(union.defaultMember)$\};
+        new(&m_$union.defaultMember.name$) $member_type_declaration(union.defaultMember)$();
+        $endif$;
         $endif$
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

Fix compilation warning in Ubuntu 24.04 with `-Werror`. The error is:

```
[ 32%] Building CXX object src/cpp/CMakeFiles/fastdds.dir/fastdds/xtypes/type_representation/TypeObjectUtils.cpp.o 

In file included from /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp:26, 

from /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:15: 

In member function ‘void eprosima::fastcdr::optional<T>::reset(bool) [with T = eprosima::fastdds::dds::xtypes::CompleteTypeDetail]’, 

inlined from ‘eprosima::fastcdr::optional<T>& eprosima::fastcdr::optional<T>::operator=(const eprosima::fastcdr::optional<T>&) [with T = eprosima::fastdds::dds::xtypes::CompleteTypeDetail]’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/install/fastcdr/include/fastcdr/xcdr/optional.hpp:205:14, 

inlined from ‘eprosima::fastdds::dds::xtypes::CompleteCollectionHeader& eprosima::fastdds::dds::xtypes::CompleteCollectionHeader::operator=(const eprosima::fastdds::dds::xtypes::CompleteCollectionHeader&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:14591:34, 

inlined from ‘eprosima::fastdds::dds::xtypes::CompleteMapType& eprosima::fastdds::dds::xtypes::CompleteMapType::operator=(const eprosima::fastdds::dds::xtypes::CompleteMapType&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:16264:34, 

inlined from ‘void eprosima::fastdds::dds::xtypes::CompleteTypeObject::map_type(const eprosima::fastdds::dds::xtypes::CompleteMapType&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:21499:23, 

inlined from ‘static eprosima::fastdds::dds::xtypes::ReturnCode_t eprosima::fastdds::dds::xtypes::TypeObjectUtils::build_and_register_map_type_object(const eprosima::fastdds::dds::xtypes::CompleteMapType&, const std::string&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:1776:25: 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/install/fastcdr/include/fastcdr/xcdr/optional.hpp:112:22: error: ‘*(eprosima::fastcdr::optional<eprosima::fastdds::dds::xtypes::CompleteTypeDetail>*)((char*)&type_object + offsetof(eprosima::fastdds::dds::xtypes::CompleteTypeObject, eprosima::fastdds::dds::xtypes::CompleteTypeObject::<unnamed>) + 16).eprosima::fastcdr::optional<eprosima::fastdds::dds::xtypes::CompleteTypeDetail>::storage_.eprosima::fastcdr::detail::optional_storage<eprosima::fastdds::dds::xtypes::CompleteTypeDetail, void>::engaged_’ may be used uninitialized [-Werror=maybe-uninitialized] 

112 | if (storage_.engaged_) 

| ~~~~~~~~~^~~~~~~~ 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp: In static member function ‘static eprosima::fastdds::dds::xtypes::ReturnCode_t eprosima::fastdds::dds::xtypes::TypeObjectUtils::build_and_register_map_type_object(const eprosima::fastdds::dds::xtypes::CompleteMapType&, const std::string&)’: 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:1775:24: note: ‘type_object’ declared here 

1775 | CompleteTypeObject type_object; 

| ^~~~~~~~~~~ 

In member function ‘void eprosima::fastcdr::optional<T>::reset(bool) [with T = eprosima::fastdds::dds::xtypes::CompleteTypeDetail]’, 

inlined from ‘eprosima::fastcdr::optional<T>& eprosima::fastcdr::optional<T>::operator=(const eprosima::fastcdr::optional<T>&) [with T = eprosima::fastdds::dds::xtypes::CompleteTypeDetail]’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/install/fastcdr/include/fastcdr/xcdr/optional.hpp:205:14, 

inlined from ‘eprosima::fastdds::dds::xtypes::CompleteCollectionHeader& eprosima::fastdds::dds::xtypes::CompleteCollectionHeader::operator=(const eprosima::fastdds::dds::xtypes::CompleteCollectionHeader&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:14591:34, 

inlined from ‘eprosima::fastdds::dds::xtypes::CompleteSequenceType& eprosima::fastdds::dds::xtypes::CompleteSequenceType::operator=(const eprosima::fastdds::dds::xtypes::CompleteSequenceType&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:14907:34, 

inlined from ‘void eprosima::fastdds::dds::xtypes::CompleteTypeObject::sequence_type(const eprosima::fastdds::dds::xtypes::CompleteSequenceType&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:21393:28, 

inlined from ‘static eprosima::fastdds::dds::xtypes::ReturnCode_t eprosima::fastdds::dds::xtypes::TypeObjectUtils::build_and_register_sequence_type_object(const eprosima::fastdds::dds::xtypes::CompleteSequenceType&, const std::string&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:1750:30: 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/install/fastcdr/include/fastcdr/xcdr/optional.hpp:112:22: error: ‘*(eprosima::fastcdr::optional<eprosima::fastdds::dds::xtypes::CompleteTypeDetail>*)((char*)&type_object + offsetof(eprosima::fastdds::dds::xtypes::CompleteTypeObject, eprosima::fastdds::dds::xtypes::CompleteTypeObject::<unnamed>) + 16).eprosima::fastcdr::optional<eprosima::fastdds::dds::xtypes::CompleteTypeDetail>::storage_.eprosima::fastcdr::detail::optional_storage<eprosima::fastdds::dds::xtypes::CompleteTypeDetail, void>::engaged_’ may be used uninitialized [-Werror=maybe-uninitialized] 

112 | if (storage_.engaged_) 

| ~~~~~~~~~^~~~~~~~ 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp: In static member function ‘static eprosima::fastdds::dds::xtypes::ReturnCode_t eprosima::fastdds::dds::xtypes::TypeObjectUtils::build_and_register_sequence_type_object(const eprosima::fastdds::dds::xtypes::CompleteSequenceType&, const std::string&)’: 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:1749:24: note: ‘type_object’ declared here 

1749 | CompleteTypeObject type_object; 

| ^~~~~~~~~~~ 

cc1plus: all warnings being treated as errors 

gmake[2]: *** [src/cpp/CMakeFiles/fastdds.dir/build.make:1168: src/cpp/CMakeFiles/fastdds.dir/fastdds/xtypes/type_representation/TypeObjectUtils.cpp.o] Error 1 

gmake[2]: *** Waiting for unfinished jobs.... 

gmake[1]: *** [CMakeFiles/Makefile2:1086: src/cpp/CMakeFiles/fastdds.dir/all] Error 2 

gmake: *** [Makefile:146: all] Error 2 

--- stderr: fastdds 

In file included from /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp:26, 

from /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:15: 

In member function ‘void eprosima::fastcdr::optional<T>::reset(bool) [with T = eprosima::fastdds::dds::xtypes::CompleteTypeDetail]’, 

inlined from ‘eprosima::fastcdr::optional<T>& eprosima::fastcdr::optional<T>::operator=(const eprosima::fastcdr::optional<T>&) [with T = eprosima::fastdds::dds::xtypes::CompleteTypeDetail]’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/install/fastcdr/include/fastcdr/xcdr/optional.hpp:205:14, 

inlined from ‘eprosima::fastdds::dds::xtypes::CompleteCollectionHeader& eprosima::fastdds::dds::xtypes::CompleteCollectionHeader::operator=(const eprosima::fastdds::dds::xtypes::CompleteCollectionHeader&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:14591:34, 

inlined from ‘eprosima::fastdds::dds::xtypes::CompleteMapType& eprosima::fastdds::dds::xtypes::CompleteMapType::operator=(const eprosima::fastdds::dds::xtypes::CompleteMapType&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:16264:34, 

inlined from ‘void eprosima::fastdds::dds::xtypes::CompleteTypeObject::map_type(const eprosima::fastdds::dds::xtypes::CompleteMapType&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:21499:23, 

inlined from ‘static eprosima::fastdds::dds::xtypes::ReturnCode_t eprosima::fastdds::dds::xtypes::TypeObjectUtils::build_and_register_map_type_object(const eprosima::fastdds::dds::xtypes::CompleteMapType&, const std::string&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:1776:25: 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/install/fastcdr/include/fastcdr/xcdr/optional.hpp:112:22: error: ‘*(eprosima::fastcdr::optional<eprosima::fastdds::dds::xtypes::CompleteTypeDetail>*)((char*)&type_object + offsetof(eprosima::fastdds::dds::xtypes::CompleteTypeObject, eprosima::fastdds::dds::xtypes::CompleteTypeObject::<unnamed>) + 16).eprosima::fastcdr::optional<eprosima::fastdds::dds::xtypes::CompleteTypeDetail>::storage_.eprosima::fastcdr::detail::optional_storage<eprosima::fastdds::dds::xtypes::CompleteTypeDetail, void>::engaged_’ may be used uninitialized [-Werror=maybe-uninitialized] 

112 | if (storage_.engaged_) 

| ~~~~~~~~~^~~~~~~~ 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp: In static member function ‘static eprosima::fastdds::dds::xtypes::ReturnCode_t eprosima::fastdds::dds::xtypes::TypeObjectUtils::build_and_register_map_type_object(const eprosima::fastdds::dds::xtypes::CompleteMapType&, const std::string&)’: 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:1775:24: note: ‘type_object’ declared here 

1775 | CompleteTypeObject type_object; 

| ^~~~~~~~~~~ 

In member function ‘void eprosima::fastcdr::optional<T>::reset(bool) [with T = eprosima::fastdds::dds::xtypes::CompleteTypeDetail]’, 

inlined from ‘eprosima::fastcdr::optional<T>& eprosima::fastcdr::optional<T>::operator=(const eprosima::fastcdr::optional<T>&) [with T = eprosima::fastdds::dds::xtypes::CompleteTypeDetail]’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/install/fastcdr/include/fastcdr/xcdr/optional.hpp:205:14, 

inlined from ‘eprosima::fastdds::dds::xtypes::CompleteCollectionHeader& eprosima::fastdds::dds::xtypes::CompleteCollectionHeader::operator=(const eprosima::fastdds::dds::xtypes::CompleteCollectionHeader&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:14591:34, 

inlined from ‘eprosima::fastdds::dds::xtypes::CompleteSequenceType& eprosima::fastdds::dds::xtypes::CompleteSequenceType::operator=(const eprosima::fastdds::dds::xtypes::CompleteSequenceType&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:14907:34, 

inlined from ‘void eprosima::fastdds::dds::xtypes::CompleteTypeObject::sequence_type(const eprosima::fastdds::dds::xtypes::CompleteSequenceType&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp:21393:28, 

inlined from ‘static eprosima::fastdds::dds::xtypes::ReturnCode_t eprosima::fastdds::dds::xtypes::TypeObjectUtils::build_and_register_sequence_type_object(const eprosima::fastdds::dds::xtypes::CompleteSequenceType&, const std::string&)’ at /home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:1750:30: 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/install/fastcdr/include/fastcdr/xcdr/optional.hpp:112:22: error: ‘*(eprosima::fastcdr::optional<eprosima::fastdds::dds::xtypes::CompleteTypeDetail>*)((char*)&type_object + offsetof(eprosima::fastdds::dds::xtypes::CompleteTypeObject, eprosima::fastdds::dds::xtypes::CompleteTypeObject::<unnamed>) + 16).eprosima::fastcdr::optional<eprosima::fastdds::dds::xtypes::CompleteTypeDetail>::storage_.eprosima::fastcdr::detail::optional_storage<eprosima::fastdds::dds::xtypes::CompleteTypeDetail, void>::engaged_’ may be used uninitialized [-Werror=maybe-uninitialized] 

112 | if (storage_.engaged_) 

| ~~~~~~~~~^~~~~~~~ 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp: In static member function ‘static eprosima::fastdds::dds::xtypes::ReturnCode_t eprosima::fastdds::dds::xtypes::TypeObjectUtils::build_and_register_sequence_type_object(const eprosima::fastdds::dds::xtypes::CompleteSequenceType&, const std::string&)’: 

/home/runner/work/Fast-DDS-docs/Fast-DDS-docs/src/fastdds/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp:1749:24: note: ‘type_object’ declared here 

1749 | CompleteTypeObject type_object; 

| ^~~~~~~~~~~ 

cc1plus: all warnings being treated as errors 

gmake[2]: *** [src/cpp/CMakeFiles/fastdds.dir/build.make:1168: src/cpp/CMakeFiles/fastdds.dir/fastdds/xtypes/type_representation/TypeObjectUtils.cpp.o] Error 1 

gmake[2]: *** Waiting for unfinished jobs.... 

gmake[1]: *** [CMakeFiles/Makefile2:1086: src/cpp/CMakeFiles/fastdds.dir/all] Error 2 

gmake: *** [Makefile:146: all] Error 2 

— 

Failed <<< fastdds [2min 10s, exited with code 2]
```
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

