### PR TITLE
[21625] Fix warning on Windows

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -123,7 +123,7 @@ public:
 
 const_decl(ctx, parent, const, const_type) ::= <<
 $const_type$
-const $const.typeCode.cppTypename$ $const.name$ = $const.value$;
+const $const.typeCode.cppTypename$ $const.name$ = $const.value$$const_value_prefix(const)$;
 >>
 
 typedef_decl(ctx, parent, typedefs, typedefs_type, declarator_type) ::= <<
@@ -819,6 +819,12 @@ $if(member.default)$
 m__d = $defaultvalue$;
 $else$
 m__d = $first(member.labels)$;
+$endif$
+%>
+
+const_value_prefix(const) ::= <%
+$if(const.typeCode.isFloat32Type)$
+f
 $endif$
 %>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

This PR fixes next warning:

```
constantsPubSubTypes.cxx
  D:\a\Fast-DDS\Fast-DDS\src\fastdds\test\dds-types-test\constants.hpp(60,31): error C2220: the following warning is treated as an error (compiling source file D:\a\Fast-DDS\Fast-DDS\src\fastdds\test\dds-types-test\constantsPubSubTypes.cxx) [D:\a\Fast-DDS\Fast-DDS\build\fastdds\test\dds\xtypes\DDSXtypesCommunication.vcxproj]
  [Processing: fastdds]
  D:\a\Fast-DDS\Fast-DDS\src\fastdds\test\dds-types-test\constants.hpp(60,31): warning C4305: 'initializing': truncation from 'double' to 'float' (compiling source file D:\a\Fast-DDS\Fast-DDS\src\fastdds\test\dds-types-test\constantsPubSubTypes.cxx) [D:\a\Fast-DDS\Fast-DDS\build\fastdds\test\dds\xtypes\DDSXtypesCommunication.vcxproj]
    constantsTypeObjectSupport.cxx
    declarationsPubSubTypes.cxx
  D:\a\Fast-DDS\Fast-DDS\src\fastdds\test\dds-types-test\constants.hpp(60,31): error C2220: the following warning is treated as an error (compiling source file D:\a\Fast-DDS\Fast-DDS\src\fastdds\test\dds-types-test\constantsTypeObjectSupport.cxx) [D:\a\Fast-DDS\Fast-DDS\build\fastdds\test\dds\xtypes\DDSXtypesCommunication.vcxproj]
  D:\a\Fast-DDS\Fast-DDS\src\fastdds\test\dds-types-test\constants.hpp(60,31): warning C4305: 'initializing': truncation from 'double' to 'float' (compiling source file D:\a\Fast-DDS\Fast-DDS\src\fastdds\test\dds-types-test\constantsTypeObjectSupport.cxx) [D:\a\Fast-DDS\Fast-DDS\build\fastdds\test\dds\xtypes\DDSXtypesCommunication.vcxproj]
```

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

