### PR TITLE
[21592] Test generation of types with `-python` in ci

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -212,3 +212,10 @@ jobs:
           source ${{ github.workspace }}/install/local_setup.bash
           cd ${{ github.workspace }}/src/fastddsgen
           ./gradlew test
+
+      - name: Test fastddsgen with python arg
+        if: ${{ inputs.run-tests == true }}
+        run: |
+          source ${{ github.workspace }}/install/local_setup.bash
+          cd ${{ github.workspace }}/src/fastddsgen/thirdparty/dds-types-test/IDL
+          find . -path "*.idl*" -exec fastddsgen -python {} +


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR introduces a new step in CI that generates the types defined in `dds-type-tests` with `-python` arg for checking failures.

Susccessfull generation (after the fix in #294): [here](https://github.com/eProsima/Fast-DDS-Gen/actions/runs/10722426227/attempts/1)
Failing run (before the fix in the previous PR): [here](https://github.com/eProsima/Fast-DDS-Gen/actions/runs/10880963120/job/30188905974)

*Note: we may add backports* 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 2.5.x 2.1.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
