### PR TITLE
Fix typo in XTypesTypeObjectSource.stg

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -491,7 +491,7 @@ text_$name$ = "$verbatim_param.value$";
 $endif$
 }; separator="\n"$
 verbatim_$name$ = TypeObjectUtils::build_applied_verbatim_annotation(placement_$name$, language_$name$, text_$name$);
-type_ann_builtin_$annotation_name$ = TypeObjectUtils::build_applied_builtin_type_annotations(verbatim_$name$);
+type_ann_builtin_$name$ = TypeObjectUtils::build_applied_builtin_type_annotations(verbatim_$name$);
 >>
 
 annotation_parameter(param, parent) ::= <<


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

Changed in applied_verbatim_annotation the type_ann_builtin_$annotation_name$ -> type_ann_builtin_$name$ to fix the following error when not using `-no-typeobjectsupport` option:

`ERROR: context [/struct_type /complete_type_detail /type_annotations /_sub45 /applied_verbatim_annotation] 14:18 attribute annotation_name isn't defined`

e.g. for ros2 Header.idl file

Discussion: https://github.com/eProsima/Fast-DDS-Gen/discussions/406

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 4.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- __NO__: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
