### PR TITLE
[21758] Fix structs TypeObject registration with -typeros2 option

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -182,7 +182,11 @@ void register_$struct.name$_type_identifier(
     $if (struct.nonForwardedContent)$
 
     ReturnCode_t return_code_$struct.name$ {eprosima::fastdds::dds::RETCODE_OK};
+    $if (ctx.GenerateTypesROS2)$
+    $get_type_identifier_registry(typename=struct.ROS2Scopedname, name=struct.name)$
+    $else$
     $get_type_identifier_registry(typename=struct.scopedname, name=struct.name)$
+    $endif$
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_$struct.name$)
     {
         StructTypeFlag struct_flags_$struct.name$ = TypeObjectUtils::build_struct_type_flag($extensibility(object=struct)$
@@ -397,6 +401,8 @@ $elseif (type.isSequenceType)$
 $get_type_identifier_registry(typename=sequence_name(sequence=type), name=name)$
 $elseif (type.isMapType)$
 $get_type_identifier_registry(typename=map_name(map=type), name=name)$
+$elseif (type.isStructType && ctx.GenerateTypesROS2)$
+$get_type_identifier_registry(typename=type.ROS2Scopedname, name=name)$
 $else$
 $get_type_identifier_registry(typename=type.scopedname, name=name)$
 $endif$
@@ -796,7 +802,11 @@ $endif$
 >>
 
 complete_type_detail(type, type_kind, name) ::= <<
+$if (type.isStructType && ctx.GenerateTypesROS2)$
+QualifiedTypeName type_name_$type.name$ = "$type.ROS2Scopedname$";
+$else$
 QualifiedTypeName type_name_$type.name$ = "$type.scopedname$";
+$endif$
 eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_$type.name$;
 eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_$type.name$;
 $type_annotations(type=type, type_kind=type_kind, name=name)$


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Structs are currently registered in the type object registry with their scoped name, instead of using their ROS 2 scoped name when `typeros2` is provided. As a consequence, there is a discrepancy between the name with which the type is registered in the type object registry and the name embedded in the generated TypeSupport.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
