### PR TITLE
[21980] Fix sequence of alias of primitives inside modules

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/eprosima.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/eprosima.stg
@@ -144,7 +144,7 @@ $definition_list$
 
 //{ Anonymous collections generator name
 sequence_name(sequence) ::= <%
-$if(sequence.contentTypeCode.primitive && !sequence.contentTypeCode.isEnumType)$
+$if(sequence.contentTypeCode.primitive && !sequence.contentTypeCode.isEnumType && !sequence.contentTypeCode.isAliasType)$
 anonymous_sequence_$sequence.contentTypeCode.cppTypenameForTypeId$_$if(sequence.unbound)$unbounded$else$$sequence.evaluatedMaxsize$$endif$
 $elseif (sequence.contentTypeCode.isStringType)$
 anonymous_sequence_$string_name(string=sequence.contentTypeCode)$_$if(sequence.unbound)$unbounded$else$$sequence.evaluatedMaxsize$$endif$


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes a corner case with sequences of alias of primitives inside modules. The generated code doesn't compile due to how the type name is generated.

```omg-idl
module Common_Module
{
   typedef char My_Char;
   typedef sequence<My_Char, 20> My_String;
};

module NoCommon_Module
{
   typedef Common_Module::My_String My_AliasString;
   typedef sequence<My_AliasString> My_SequenceString;

   struct My_Structure
   {
       My_SequenceString list;
   };
};
```

Depends on:
- eprosima/dds-types-test#40

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

