### PR TITLE
[22761] Add builtin @feed annotation

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Annotation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Annotation.java
@@ -1,0 +1,27 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.idl.parser.tree.AnnotationDeclaration;
+
+public class Annotation extends com.eprosima.idl.parser.tree.Annotation
+{
+    public static final String rpc_feed_str = "feed";
+
+    public Annotation(AnnotationDeclaration declaration)
+    {
+        super(declaration);
+    }
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -711,7 +711,15 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return operationObject;
     }
 
-
+    @Override
+    public Param createParam(
+            String name,
+            TypeCode typecode,
+            Param.Kind kind)
+    {
+        Param paramObject = new Param(name, typecode, kind);
+        return paramObject;
+    }
 
     //// Java block ////
     // Java package name.

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -702,6 +702,17 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return super.getAnnotationDeclaration(name);
     }
 
+    @Override
+    public Operation createOperation(
+            String name,
+            Token token)
+    {
+        Operation operationObject = new Operation(getScopeFile(), isInScopedFile(), null, name, token);
+        return operationObject;
+    }
+
+
+
     //// Java block ////
     // Java package name.
     private String m_package = "";

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -86,6 +86,9 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         AnnotationDeclaration keyann = this.createAnnotationDeclaration(Annotation.eprosima_key_str, null);
         keyann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
+        // Create default @feed annotation.
+        AnnotationDeclaration feed_ann = this.createAnnotationDeclaration(com.eprosima.fastdds.idl.grammar.Annotation.rpc_feed_str, null);
+        feed_ann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
     }
 
     public void setTypelimitation(

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -1,0 +1,48 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import org.antlr.v4.runtime.Token;
+
+public class Operation extends com.eprosima.idl.parser.tree.Operation
+{
+    public Operation(String scopeFile, boolean isInScope, String scope, String name, Token tk)
+    {
+        super(scopeFile, isInScope, scope, name, tk);
+    }
+
+    /**
+     * Return whether the operation has been annotated as feed
+     *
+     * @return true when the operation has been annotated as feed, false otherwise.
+     */
+    public boolean isAnnotationFeed()
+    {
+        com.eprosima.idl.parser.tree.Annotation ann = getAnnotations().get(Annotation.rpc_feed_str);
+        if (ann != null)
+        {
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @feed annotation has only one parameter
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Param.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Param.java
@@ -1,0 +1,51 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.typecode.TypeCode;
+
+import org.antlr.v4.runtime.Token;
+
+public class Param extends com.eprosima.idl.parser.tree.Param
+{
+    public Param(String name, TypeCode typecode, Kind kind)
+
+    {
+        super(name, typecode, kind);
+    }
+
+    /**
+     * Return whether the operation has been annotated as feed
+     *
+     * @return true when the operation has been annotated as feed, false otherwise.
+     */
+    public boolean isAnnotationFeed()
+    {
+        com.eprosima.idl.parser.tree.Annotation ann = getAnnotations().get(Annotation.rpc_feed_str);
+        if (ann != null)
+        {
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @feed annotation has only one parameter
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This adds @feed as a builtin annotation. Will be used to mark interface operations (and their parameters) as feeds.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- __NO__: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
    - Tests will be added for the full feature later
- __NO__: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Documentation will be added for the full feature later
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
