### PR TITLE
[22815] Branch out 4.1.x

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->
+<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         dest_branch:
-          - '4.0.x'
+          - '4.1.x'
           - '4.x'
     steps:
     - name: Mirror action step

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ repositories {
 }
 
 dependencies {
-    implementation files('thirdparty/idl-parser/build/libs/idlparser-4.0.3.jar')
+    implementation files('thirdparty/idl-parser/build/libs/idlparser-4.1.0.jar')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.5.2')
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.5.2')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'java-library'
 apply plugin: 'eclipse' // Eclipse integration
 
 description = """"""
-def version_str = "4.0.3"
+def version_str = "4.1.0"
 
 import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.tasks.options.Option;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR bumps version to 4.1.0, and changes mirror and PR template for 4.1.x
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
