### PR TITLE
[22850] Fix python code generation for bounded strings

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -189,13 +189,13 @@ $else$
 %ignore $struct_name$::$member.name$();
 %rename("%s") $struct_name$::$member.name$() const;
 
-$if(typecode.isStringType && typecode.isBounded)$
-%template($typecode.noScopedCppTypename$_fixed_string_$typecode.maxSize$) eprosima::fastcdr::fixed_string<$typecode.maxSize$>;
+$if(member.typecode.isStringType && member.typecode.isBounded)$
+%template($member.typecode.noScopedCppTypename$_fixed_string_$member.typecode.maxSize$) eprosima::fastcdr::fixed_string<$member.typecode.maxSize$>;
 %extend $struct_name$
 {
     void $member.name$(const std::string& value)
     {
-        eprosima::fastcdr::fixed_string<$typecode.maxSize$> tmp;
+        eprosima::fastcdr::fixed_string<$member.typecode.maxSize$> tmp;
         \$self->$member.name$(tmp);
     }
 }

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -190,6 +190,7 @@ $else$
 %rename("%s") $struct_name$::$member.name$() const;
 
 $if(typecode.isStringType && typecode.isBounded)$
+%template($typecode.noScopedCppTypename$_fixed_string_$typecode.maxSize$) eprosima::fastcdr::fixed_string<$typecode.maxSize$>;
 %extend $struct_name$
 {
     void $member.name$(const std::string& value)

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -53,6 +53,7 @@ $ctx.directIncludeDependencies : {include | %include "$include$.i"}; separator="
 
 %include <fastcdr/config.h>
 %import(module="fastdds") "fastcdr/xcdr/optional.hpp"
+%import(module="fastdds") "fastcdr/cdr/fixed_size_string.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"
@@ -187,6 +188,17 @@ $endif$
 $else$
 %ignore $struct_name$::$member.name$();
 %rename("%s") $struct_name$::$member.name$() const;
+
+$if(typecode.isStringType && typecode.isBounded)$
+%extend $struct_name$
+{
+    void $member.name$(const std::string& value)
+    {
+        eprosima::fastcdr::fixed_string<$typecode.maxSize$> tmp;
+        \$self->$member.name$(tmp);
+    }
+}
+$endif$
 
 $endif$
 

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -52,8 +52,12 @@ $ctx.directIncludeDependencies : {include | %include "$include$.i"}; separator="
 %}
 
 %include <fastcdr/config.h>
+$if(ctx.thereIsOptionalAnnotation)$
 %import(module="fastdds") "fastcdr/xcdr/optional.hpp"
+$endif$
+$if(ctx.thereIsString)$
 %import(module="fastdds") "fastcdr/cdr/fixed_size_string.hpp"
+$endif$
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -195,7 +195,7 @@ $if(member.typecode.isStringType && member.typecode.isBounded)$
 {
     void $member.name$(const std::string& value)
     {
-        eprosima::fastcdr::fixed_string<$member.typecode.maxsize$> tmp;
+        eprosima::fastcdr::fixed_string<$member.typecode.maxsize$> tmp(value);
         \$self->$member.name$(tmp);
     }
 }

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -190,12 +190,12 @@ $else$
 %rename("%s") $struct_name$::$member.name$() const;
 
 $if(member.typecode.isStringType && member.typecode.isBounded)$
-%template($member.typecode.noScopedCppTypename$_fixed_string_$member.typecode.maxSize$) eprosima::fastcdr::fixed_string<$member.typecode.maxSize$>;
+%template($member.typecode.noScopedCppTypename$_fixed_string_$member.typecode.maxsize$) eprosima::fastcdr::fixed_string<$member.typecode.maxsize$>;
 %extend $struct_name$
 {
     void $member.name$(const std::string& value)
     {
-        eprosima::fastcdr::fixed_string<$member.typecode.maxSize$> tmp;
+        eprosima::fastcdr::fixed_string<$member.typecode.maxsize$> tmp;
         \$self->$member.name$(tmp);
     }
 }

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -190,7 +190,7 @@ $else$
 %rename("%s") $struct_name$::$member.name$() const;
 
 $if(member.typecode.isStringType && member.typecode.isBounded)$
-%template($member.typecode.noScopedCppTypename$_fixed_string_$member.typecode.maxsize$) eprosima::fastcdr::fixed_string<$member.typecode.maxsize$>;
+%template(fixed_string_$member.typecode.maxsize$) eprosima::fastcdr::fixed_string<$member.typecode.maxsize$>;
 %extend $struct_name$
 {
     void $member.name$(const std::string& value)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR introduces the following improvements on the code generated for SWIG interfaces:
1. A setter for `fixed_string` members receiving a standard string is added.
2. A `%template` for each fixed_string member is generated.

This allows setting bounded string members with either of the following alternatives:
1. `struct_name.member_name("string value")`
2. ```
   fixed_str = fixed_string_16("string value")
   struct_name.member_name(fixed_str)
   ```

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 4.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
    - See https://github.com/eProsima/Fast-DDS-python/pull/209 for the added tests 
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
