### PR TITLE
[22909] Generate code for interfaces in header files

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -28,7 +28,7 @@ $typecode.cppTypename$&
 
 paramTypeByValue(typecode, feed) ::= <%
 $if(feed)$
-std::shared_ptr<RpcClientWriter<$typecode.cppTypename$> >&
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientWriter<$typecode.cppTypename$> >&
 $else$
 $if(typecode.primitive)$
 $typecode.cppTypename$

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -14,6 +14,34 @@
 
 group FastCdrCommon;
 
+paramRetType(typecode) ::= <%
+$if(typecode)$
+$typecode.cppTypename$
+$else$
+void
+$endif$
+%>
+
+paramTypeByRef(typecode) ::= <%
+$typecode.cppTypename$&
+%>
+
+paramTypeByValue(typecode, feed) ::= <%
+$if(feed)$
+std::shared_ptr<RpcClientWriter<$typecode.cppTypename$> >&
+$else$
+$if(typecode.primitive)$
+$typecode.cppTypename$
+$else$
+const $typecode.cppTypename$&
+$endif$
+$endif$
+%>
+
+paramDeclarations(params, initialSeparator="") ::= <<
+$if(params)$$initialSeparator$$endif$$params : {param | /*$param.comment$*/ $if(param.output)$$paramTypeByRef(typecode=param.typecode)$$else$$paramTypeByValue(typecode=param.typecode, feed=param.annotationFeed)$$endif$ $param.name$}; anchor, separator=",\n"$
+>>
+
 object_serialization(ctx, object) ::= <<
 scdr << eprosima::fastcdr::MemberId($object.id$) << $object.name$();
 >>

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -201,14 +201,6 @@ public:
 };
 >>
 
-operationRetType(operation) ::= <%
-$if(operation.annotationFeed)$
-std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$> >
-$else$
-eprosima::fastdds::dds::rpc::RpcFuture<$paramRetType(operation.rettype)$>
-$endif$
-%>
-
 operation(ctx, parent, operation, param_list, operation_type) ::= <<
 virtual $operationRetType(operation)$ $operation.name$(
         $paramDeclarations(params=operation.parameters)$) = 0;
@@ -942,6 +934,14 @@ member_destructor_ = [&]()
 new(&m_$member.name$) $member_type_declaration(member)$();
 $endif$
 >>
+
+operationRetType(operation) ::= <%
+$if(operation.annotationFeed)$
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$> >
+$else$
+eprosima::fastdds::dds::rpc::RpcFuture<$paramRetType(operation.rettype)$>
+$endif$
+%>
 
 //{ Fast DDS-Gen extensions
 module_conversion(ctx, parent, modules, definition_list) ::= <<

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -66,6 +66,9 @@ $endif$
 $if(ctx.thereIsInputFeed)$
 #include <fastdds/dds/rpc/interfaces/RpcClientWriter.hpp>
 $endif$
+$if(ctx.thereIsNonFeedOperation)$
+#include <fastdds/dds/rpc/interfaces/RpcFuture.hpp>
+$endif$
 
 $ctx.directIncludeDependencies : {include | #include "$include$.hpp"}; separator="\n"$
 

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -33,6 +33,9 @@ $endif$
 $if(ctx.thereIsMap)$
 #include <map>
 $endif$
+$if(ctx.thereIsInputFeed)$
+#include <memory>
+$endif$
 $if(ctx.thereIsString)$
 #include <string>
 $endif$
@@ -56,6 +59,9 @@ $endif$
 
 $if(ctx.thereIsException)$
 #include <fastdds/dds/rpc/exceptions/RpcOperationError.hpp>
+$endif$
+$if(ctx.thereIsInputFeed)$
+#include <fastdds/dds/rpc/interfaces/RpcClientWriter.hpp>
 $endif$
 
 $ctx.directIncludeDependencies : {include | #include "$include$.hpp"}; separator="\n"$

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -33,7 +33,7 @@ $endif$
 $if(ctx.thereIsMap)$
 #include <map>
 $endif$
-$if(ctx.thereIsInputFeed)$
+$if(ctx.thereIsInputFeed || ctx.thereIsOutputFeed)$
 #include <memory>
 $endif$
 $if(ctx.thereIsString)$
@@ -59,6 +59,9 @@ $endif$
 
 $if(ctx.thereIsException)$
 #include <fastdds/dds/rpc/exceptions/RpcOperationError.hpp>
+$endif$
+$if(ctx.thereIsOutputFeed)$
+#include <fastdds/dds/rpc/interfaces/RpcClientReader.hpp>
 $endif$
 $if(ctx.thereIsInputFeed)$
 #include <fastdds/dds/rpc/interfaces/RpcClientWriter.hpp>

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -189,6 +189,20 @@ public:
 };
 >>
 
+operationRetType(operation) ::= <%
+$if(operation.annotationFeed)$
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$> >
+$else$
+eprosima::fastdds::dds::rpc::RpcFuture<$paramRetType(operation.rettype)$>
+$endif$
+%>
+
+operation(ctx, parent, operation, param_list, operation_type) ::= <<
+virtual $operationRetType(operation)$ $operation.name$(
+        $paramDeclarations(params=operation.parameters)$) = 0;
+
+>>
+
 const_decl(ctx, parent, const, const_type) ::= <<
 $const_type$
 const $const.typeCode.cppTypename$ $const.name$ = $const.value$$const_value_prefix(const)$;

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -500,6 +500,17 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return there_is_at_least_one_output_feed;
     }
 
+    public boolean setThereIsNonFeedOperation(
+            boolean value)
+    {
+        return there_is_at_least_one_non_feed_operation = value;
+    }
+
+    public boolean isThereIsNonFeedOperation()
+    {
+        return there_is_at_least_one_non_feed_operation;
+    }
+
     /*** Functions inherited from FastCDR Context ***/
 
     @Override
@@ -814,4 +825,6 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     private boolean there_is_at_least_one_input_feed = false;
 
     private boolean there_is_at_least_one_output_feed = false;
+
+    private boolean there_is_at_least_one_non_feed_operation = false;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -478,6 +478,17 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return there_is_at_least_one_exception;
     }
 
+    public void setThereIsInputFeed(
+            boolean value)
+    {
+        there_is_at_least_one_input_feed = value;
+    }
+
+    public boolean isThereIsInputFeed()
+    {
+        return there_is_at_least_one_input_feed;
+    }
+
     /*** Functions inherited from FastCDR Context ***/
 
     @Override
@@ -726,7 +737,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             String name,
             Token token)
     {
-        Operation operationObject = new Operation(getScopeFile(), isInScopedFile(), null, name, token);
+        Operation operationObject = new Operation(this, getScopeFile(), isInScopedFile(), null, name, token);
         return operationObject;
     }
 
@@ -778,4 +789,6 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     private boolean there_is_at_least_one_union = false;
 
     private boolean there_is_at_least_one_exception = false;
+
+    private boolean there_is_at_least_one_input_feed = false;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -489,6 +489,17 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return there_is_at_least_one_input_feed;
     }
 
+    public boolean setThereIsOutputFeed(
+            boolean value)
+    {
+        return there_is_at_least_one_output_feed = value;
+    }
+
+    public boolean isThereIsOutputFeed()
+    {
+        return there_is_at_least_one_output_feed;
+    }
+
     /*** Functions inherited from FastCDR Context ***/
 
     @Override
@@ -733,6 +744,16 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     }
 
     @Override
+    public Interface createInterface(
+            String name,
+            Token token)
+    {
+        Interface interfaceObject = new com.eprosima.fastdds.idl.grammar.Interface(
+                this, getScopeFile(), isInScopedFile(), null, name, token);
+        return interfaceObject;
+    }
+
+    @Override
     public Operation createOperation(
             String name,
             Token token)
@@ -791,4 +812,6 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     private boolean there_is_at_least_one_exception = false;
 
     private boolean there_is_at_least_one_input_feed = false;
+
+    private boolean there_is_at_least_one_output_feed = false;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
@@ -1,0 +1,44 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.fastdds.idl.grammar.Operation;
+import org.antlr.v4.runtime.Token;
+
+public class Interface extends com.eprosima.idl.parser.tree.Interface
+{
+    public Interface(Context ctx, String scopeFile, boolean isInScope, String scope, String name, Token tk)
+    {
+        super(scopeFile, isInScope, scope, name, tk);
+        m_context = ctx;
+    }
+
+    @Override
+    public void add(com.eprosima.idl.parser.tree.Export exp)
+    {
+        if (exp instanceof Operation)
+        {
+            Operation op = (Operation)exp;
+            if (op.isAnnotationFeed())
+            {
+                m_context.setThereIsOutputFeed(true);
+            }
+        }
+
+        super.add(exp);
+    }
+
+    private Context m_context;
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
@@ -35,6 +35,10 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
             {
                 m_context.setThereIsOutputFeed(true);
             }
+            else
+            {
+                m_context.setThereIsNonFeedOperation(true);
+            }
         }
 
         super.add(exp);

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -15,6 +15,8 @@
 package com.eprosima.fastdds.idl.grammar;
 
 import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.exception.ParseException;
+import com.eprosima.fastdds.idl.grammar.Param;
 import org.antlr.v4.runtime.Token;
 
 public class Operation extends com.eprosima.idl.parser.tree.Operation
@@ -44,5 +46,18 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
             }
         }
         return false;
+    }
+
+    @Override
+    public void add(com.eprosima.idl.parser.tree.Param param)
+    {
+        Param p = (Param)param;
+        // Fail if para is out and feed
+        if (p.isAnnotationFeed() && p.isOutput())
+        {
+            throw new ParseException(null, "Output parameter " + p.getName() + " has '@feed' annotation.");
+        }
+
+        super.add(param);
     }
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -21,9 +21,10 @@ import org.antlr.v4.runtime.Token;
 
 public class Operation extends com.eprosima.idl.parser.tree.Operation
 {
-    public Operation(String scopeFile, boolean isInScope, String scope, String name, Token tk)
+    public Operation(Context ctx, String scopeFile, boolean isInScope, String scope, String name, Token tk)
     {
         super(scopeFile, isInScope, scope, name, tk);
+        m_context = ctx;
     }
 
     /**
@@ -52,12 +53,23 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
     public void add(com.eprosima.idl.parser.tree.Param param)
     {
         Param p = (Param)param;
-        // Fail if para is out and feed
-        if (p.isAnnotationFeed() && p.isOutput())
+        // Process feed annotation
+        if (p.isAnnotationFeed())
         {
-            throw new ParseException(null, "Output parameter " + p.getName() + " has '@feed' annotation.");
+            if (p.isOutput())
+            {
+                // Fail if parameter is out and feed
+                throw new ParseException(null, "Output parameter " + p.getName() + " has '@feed' annotation.");
+            }
+            else
+            {
+                // Take note that there is at least one input feed
+                m_context.setThereIsInputFeed(true);
+            }
         }
 
         super.add(param);
     }
+
+    private Context m_context;
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the necessary changes for Fast DDS Gen to generate code in the header files for interface constructs.

From the following `calculator.idl` file:
<details>

```
module calculator_example
{
    // This exception will be thrown when an operation result cannot be represented in a long
    exception OverflowException
    {
    };

    // For the filter operation
    enum FilterKind
    {
        EVEN,  // return even numbers
        ODD,   // return odd numbers
        PRIME  // return prime numbers
    };

    interface Calculator
    {
        // Returns the minimum and maximum representable values
        void representation_limits(out long min_value, out long max_value);

        // Returns the result of value1 + value2
        long addition(in long value1, in long value2) raises (OverflowException);

        // Returns the result of value1 + value2
        long subtraction(in long value1, in long value2) raises (OverflowException);

        // Returns a feed of results with the n_results first elements of the Fibonacci sequence
        // E.g. for an input of 5, returns a feed with {1, 1, 2, 3, 5}
        @feed long fibonacci_seq(in long n_results) raises (OverflowException);

        // Waits for an input feed to finish and returns the sum of all the received values
        // E.g. for an input of {1, 2, 3, 4, 5} returns 15
        long sum_all(@feed in long value) raises (OverflowException);

        // Returns a feed of results with the sum of all received values
        // E.g. for an input of {1, 2, 3, 4, 5}, returns a feed with {1, 3, 6, 10, 15}
        @feed long accumulator(@feed in long value) raises (OverflowException);

        // Returns a feed of results with the received values that match the input filter kind
        @feed long filter(@feed in long value, in FilterKind filter_kind);
    };
};
```

</details>

it generates the following `calculator.hpp` file:
<details>

```
// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//     http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.

/*!
 * @file calculator.hpp
 * This header file contains the declaration of the described types in the IDL file.
 *
 * This file was generated by the tool fastddsgen.
 */

#ifndef FAST_DDS_GENERATED__CALCULATOR_HPP
#define FAST_DDS_GENERATED__CALCULATOR_HPP

#include <cstdint>
#include <memory>
#include <utility>
#include <fastdds/dds/rpc/exceptions/RpcOperationError.hpp>
#include <fastdds/dds/rpc/interfaces/RpcClientReader.hpp>
#include <fastdds/dds/rpc/interfaces/RpcClientWriter.hpp>
#include <fastdds/dds/rpc/interfaces/RpcFuture.hpp>


#if defined(_WIN32)
#if defined(EPROSIMA_USER_DLL_EXPORT)
#define eProsima_user_DllExport __declspec( dllexport )
#else
#define eProsima_user_DllExport
#endif  // EPROSIMA_USER_DLL_EXPORT
#else
#define eProsima_user_DllExport
#endif  // _WIN32

#if defined(_WIN32)
#if defined(EPROSIMA_USER_DLL_EXPORT)
#if defined(CALCULATOR_SOURCE)
#define CALCULATOR_DllAPI __declspec( dllexport )
#else
#define CALCULATOR_DllAPI __declspec( dllimport )
#endif // CALCULATOR_SOURCE
#else
#define CALCULATOR_DllAPI
#endif  // EPROSIMA_USER_DLL_EXPORT
#else
#define CALCULATOR_DllAPI
#endif // _WIN32

namespace calculator_example {

/*!
 * @brief This class implements the user exception calculator_example::OverflowException
 * @ingroup calculator
 */
class CALCULATOR_DllAPI OverflowException : public eprosima::fastdds::dds::rpc::RpcOperationError
{
public:

    /**
     * Default constructor.
     */
    OverflowException()
        : OverflowException("OverflowException")
    {
    }

    /**
     * Constructor.
     */
    OverflowException(
            const std::string& message)
        : eprosima::fastdds::dds::rpc::RpcOperationError(message)
    {
    }

    /**
     * Constructor.
     */
    OverflowException(
            const char* message)
        : eprosima::fastdds::dds::rpc::RpcOperationError(message)
    {
    }

    /**
     * Copy constructor.
     */
    OverflowException(
            const OverflowException& other) noexcept = default;

    /**
     * Copy assignment.
     */
    OverflowException& operator =(
            const OverflowException& other) noexcept = default;

    /**
     * Destructor.
     */
    virtual ~OverflowException() noexcept = default;



private:


};

/*!
 * @brief This class represents the enumeration FilterKind defined by the user in the IDL file.
 * @ingroup calculator
 */
enum class FilterKind : int32_t
{
    EVEN,
    ODD,
    PRIME
};
/*!
 * @brief This class represents the interface Calculator defined by the user in the IDL file.
 * @ingroup calculator
 */
class CALCULATOR_DllAPI Calculator 
{
public:

    virtual eprosima::fastdds::dds::rpc::RpcFuture<void> representation_limits(
            /*out*/ int32_t& min_value,
            /*out*/ int32_t& max_value) = 0;

    virtual eprosima::fastdds::dds::rpc::RpcFuture<int32_t> addition(
            /*in*/ int32_t value1,
            /*in*/ int32_t value2) = 0;

    virtual eprosima::fastdds::dds::rpc::RpcFuture<int32_t> subtraction(
            /*in*/ int32_t value1,
            /*in*/ int32_t value2) = 0;

    virtual std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<int32_t> > fibonacci_seq(
            /*in*/ int32_t n_results) = 0;

    virtual eprosima::fastdds::dds::rpc::RpcFuture<int32_t> sum_all(
            /*in*/ std::shared_ptr<RpcClientWriter<int32_t> >& value) = 0;

    virtual std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<int32_t> > accumulator(
            /*in*/ std::shared_ptr<RpcClientWriter<int32_t> >& value) = 0;

    virtual std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<int32_t> > filter(
            /*in*/ std::shared_ptr<RpcClientWriter<int32_t> >& value,
            /*in*/ calculator_example::FilterKind filter_kind) = 0;

};

} // namespace calculator_example

#endif // _FAST_DDS_GENERATED_CALCULATOR_HPP_
```

</details>

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
This PR depends on:
* https://github.com/eProsima/dds-types-test/pull/42

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- __NO__: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Will do a final documentation PR for the whole feature
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
