### PR TITLE
Fix non flat output directory

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/context/Context.java
+++ b/src/main/java/com/eprosima/fastcdr/idl/context/Context.java
@@ -43,6 +43,8 @@ public interface Context
 
     public boolean isGenerateTypeObjectSupport();
 
+    public boolean isGenerateFlatOutputDir();
+
     public boolean isCdr();
 
     public boolean isFastcdr();

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -406,6 +406,12 @@ public class fastddsgen
             throw new BadArgumentException("No input files given");
         }
 
+        if (m_includePaths.isEmpty() && !m_flat_output_dir)
+        {
+            // Forcing flat output directory as no include path given so relative output directory can't be determined
+            m_flat_output_dir = true;
+        }
+
     }
 
     /*
@@ -759,17 +765,18 @@ public class fastddsgen
             TemplateManager tmanager = new TemplateManager();
 
             Context ctx = new Context(tmanager, idlFilename, m_includePaths, m_subscribercode, m_publishercode,
-                            m_localAppProduct, m_typesc, m_type_ros2, gen_api_, generate_typeobjectsupport_);
+                            m_localAppProduct, m_typesc, m_type_ros2, gen_api_, generate_typeobjectsupport_, m_flat_output_dir);
 
-            String relative_dir = ctx.getRelativeDir(dependant_idl_dir);
+            String relative_dir = ctx.getRelativeDir();
             String output_dir;
-            if (!m_flat_output_dir)
+            if (m_flat_output_dir)
             {
-                output_dir = m_outputDir + relative_dir;
+                relative_dir = "";
+                output_dir = m_outputDir;
             }
             else
             {
-                output_dir = m_outputDir;
+                output_dir = m_outputDir + relative_dir;
             }
 
             // Check the output directory exists or create it.

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -64,10 +64,11 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             boolean generate_typesc,
             boolean generate_type_ros2,
             boolean is_generating_api,
-            boolean generate_typeobjectsupport
+            boolean generate_typeobjectsupport,
+            boolean flat_output_dir
             )
     {
-        super(tmanager, file, includePaths, generate_typesc);
+        super(tmanager, file, includePaths, generate_typesc, flat_output_dir);
         m_fileNameUpper = getFilename().toUpperCase();
         m_subscribercode = subscribercode;
         m_publishercode = publishercode;
@@ -81,6 +82,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         m_type_ros2 = generate_type_ros2;
         is_generating_api_ = is_generating_api;
         generate_typeobject_support_ = generate_typeobjectsupport;
+        flat_output_dir_ = flat_output_dir;
 
         // Create default @Key annotation.
         AnnotationDeclaration keyann = this.createAnnotationDeclaration(Annotation.eprosima_key_str, null);
@@ -569,6 +571,8 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
 
     private boolean generate_typeobject_support_ = true;
 
+    private boolean flat_output_dir_ = false;
+
     @Override
     public boolean isGenerateTypesROS2()
     {
@@ -579,6 +583,12 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     public boolean isGenerateTypeObjectSupport()
     {
         return generate_typeobject_support_;
+    }
+
+    @Override
+    public boolean isGenerateFlatOutputDir()
+    {
+        return flat_output_dir_;
     }
 
     public String getHeaderGuardName ()

--- a/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
@@ -68,6 +68,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 $endif$
 
+include_directories(\${CMAKE_CURRENT_SOURCE_DIR})
 $solution.projects : { project | $pub_sub_execs(project=project, libraries=solution.libraries, test=test)$}; separator="\n"$
 
 $if (test)$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSApplicationSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSApplicationSource.stg
@@ -19,10 +19,22 @@ import "eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Application.cxx"], description=["This file contains the implementation of the application functions."])$
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$Application.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$Application.hpp"
+$endif$
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$PublisherApp.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$PublisherApp.hpp"
+$endif$
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$SubscriberApp.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$SubscriberApp.hpp"
+$endif$
 
 //! Factory method to create a publisher or subscriber
 std::shared_ptr<$ctx.filename$Application> $ctx.filename$Application::make_app(

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubMain.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubMain.stg
@@ -28,7 +28,11 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "main.cxx"], description=["This file a
 
 #include <fastdds/dds/log/Log.hpp>
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$Application.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$Application.hpp"
+$endif$
 
 using eprosima::fastdds::dds::Log;
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -29,7 +29,11 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.hpp"], description=["This
 #include <fastdds/rtps/common/SerializedPayload.hpp>
 #include <fastdds/utils/md5.hpp>
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$.hpp"
+$endif$
 
 $ctx.directIncludeDependencies : {include | #include "$include$PubSubTypes.hpp"}; separator="\n"$
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -17,16 +17,28 @@ group ProtocolHeader;
 import "eprosima.stg"
 
 main(ctx, definitions) ::= <<
-$fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.cpp"], description=["This header file contains the implementation of the serialization functions."])$
+$fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.cxx"], description=["This header file contains the implementation of the serialization functions."])$
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$PubSubTypes.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$PubSubTypes.hpp"
+$endif$
 
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/common/CdrSerialization.hpp>
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$CdrAux.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$CdrAux.hpp"
+$endif$
 $if (ctx.generateTypeObjectSupport)$
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$TypeObjectSupport.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$TypeObjectSupport.hpp"
+$endif$
 $endif$
 
 using SerializedPayload_t = eprosima::fastdds::rtps::SerializedPayload_t;
@@ -37,7 +49,11 @@ $definitions; separator="\n"$
 
 $if(ctx.thereIsStructOrUnion)$
 // Include auxiliary functions like for serializing/deserializing.
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$CdrAux.ipp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$CdrAux.ipp"
+$endif$
 $endif$
 
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherHeader.stg
@@ -29,7 +29,11 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PublisherApp.hpp"], description=["Thi
 #include <fastdds/dds/publisher/DataWriterListener.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$Application.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$Application.hpp"
+$endif$
 
 class $ctx.filename$PublisherApp : public $ctx.filename$Application,
         public eprosima::fastdds::dds::DataWriterListener

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPublisherSource.stg
@@ -19,7 +19,11 @@ import "eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "PublisherApp.cxx"], description=["This file contains the implementation of the publisher functions."])$
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$PublisherApp.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$PublisherApp.hpp"
+$endif$
 
 #include <condition_variable>
 #include <csignal>
@@ -33,7 +37,11 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PublisherApp.cxx"], description=["Thi
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$PubSubTypes.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$PubSubTypes.hpp"
+$endif$
 
 using namespace eprosima::fastdds::dds;
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberHeader.stg
@@ -29,8 +29,16 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "SubscriberApp.hpp"], description=["Th
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$.hpp"
+$endif$
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$Application.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$Application.hpp"
+$endif$
 
 class $ctx.filename$SubscriberApp : public $ctx.filename$Application,
         public eprosima::fastdds::dds::DataReaderListener

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSSubscriberSource.stg
@@ -19,7 +19,11 @@ import "eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "SubscriberApp.cxx"], description=["This file contains the implementation of the subscriber functions."])$
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$SubscriberApp.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$SubscriberApp.hpp"
+$endif$
 
 #include <condition_variable>
 #include <stdexcept>
@@ -32,7 +36,11 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "SubscriberApp.cxx"], description=["Th
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$PubSubTypes.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$PubSubTypes.hpp"
+$endif$
 
 using namespace eprosima::fastdds::dds;
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg
@@ -22,7 +22,11 @@ $fileHeader(ctx=ctx, file=[ctx.filename, "CdrAux.hpp"], description=["This sourc
 #ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_HPP
 #define FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_HPP
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$.hpp"
+$endif$
 
 $if(ctx.anyCdr)$
 $ctx.types:{ type | $if(type.inScope)$$if(type.typeCode.isStructType)$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -23,7 +23,11 @@ $fileHeader(ctx=ctx, file=[ctx.filename, "CdrAux.ipp"], description=["This sourc
 #ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_IPP
 #define FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_IPP
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$CdrAux.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$CdrAux.hpp"
+$endif$
 
 $if(ctx.cdr)$
 #include <fastcdr/Cdr.h>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -19,7 +19,11 @@ import "eprosima.stg"
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx, file=[ctx.filename, "TypeObjectSupport.cxx"], description=["Source file containing the implementation to register the TypeObject representation of the described types in the IDL file"])$
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$TypeObjectSupport.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$TypeObjectSupport.hpp"
+$endif$
 
 #include <mutex>
 #include <string>
@@ -33,7 +37,11 @@ $fileHeader(ctx=ctx, file=[ctx.filename, "TypeObjectSupport.cxx"], description=[
 #include <fastdds/dds/xtypes/type_representation/TypeObject.hpp>
 #include <fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp>
 
+$if(ctx.generateFlatOutputDir)$
 #include "$ctx.filename$.hpp"
+$else$
+#include "$ctx.relativeDirectory$$ctx.filename$.hpp"
+$endif$
 
 $ctx.directIncludeDependencies : {include | #include "$include$.hpp"}; separator="\n"$
 

--- a/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
+++ b/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
@@ -39,66 +39,57 @@ public class FastDDSGenTest
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), "Prueba.idl", new ArrayList<String>(), false);
-
-            assertEquals("", ctx.getRelativeDir(null));
+                    new TemplateManager(), "Prueba.idl", new ArrayList<String>(), false, false);
+            System.out.println("'" + ctx.getRelativeDir() + "'");
+            assertEquals("", ctx.getRelativeDir());
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), "dir/Prueba.idl", new ArrayList<String>(), false);
-
-            assertEquals("dir/", ctx.getRelativeDir(null));
+                    new TemplateManager(), "dir/Prueba.idl", new ArrayList<String>(), false, false);
+            System.out.println("'" + ctx.getRelativeDir() + "'");
+            assertEquals("dir/", ctx.getRelativeDir());
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), "../../dir/Prueba.idl", new ArrayList<String>(), false);
-
-            assertEquals("../../dir/", ctx.getRelativeDir(null));
+                    new TemplateManager(), "../../dir/Prueba.idl", new ArrayList<String>(), false, false);
+            System.out.println("'" + ctx.getRelativeDir() + "'");
+            assertEquals("../../dir/", ctx.getRelativeDir());
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), System.getProperty("user.dir") + "Prueba.idl", new ArrayList<String>(), false);
+                    new TemplateManager(), System.getProperty("user.dir") + "/Prueba.idl", new ArrayList<String>(), false, false);
+            System.out.println("'" + ctx.getRelativeDir() + "'");
+            assertEquals(System.getProperty("user.dir") + "/", ctx.getRelativeDir());
+        }
 
-            assertEquals("", ctx.getRelativeDir(null));
+        {
+            ArrayList<String> includeDirs = new ArrayList<String>();
+            includeDirs.add(System.getProperty("user.dir"));
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    new TemplateManager(), System.getProperty("user.dir") + "/dir/Prueba.idl", includeDirs, false, false);
+            System.out.println("'" + ctx.getRelativeDir() + "'");
+            assertEquals("dir/", ctx.getRelativeDir());
+        }
+
+        {
+            ArrayList<String> includeDirs = new ArrayList<String>();
+            includeDirs.add(System.getProperty("user.dir"));
+            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
+                    new TemplateManager(), System.getProperty("user.dir") + "/../../dir/Prueba.idl", includeDirs, false, false);
+            System.out.println("'" + ctx.getRelativeDir() + "'");
+            assertEquals("../../dir/", ctx.getRelativeDir());
         }
 
         {
             com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), System.getProperty("user.dir") + "dir/Prueba.idl", new ArrayList<String>(), false);
-
-            assertEquals("dir/", ctx.getRelativeDir(null));
+                    new TemplateManager(), absolute_idl_dir, new ArrayList<String>(), false, false);
+            System.out.println("'" + ctx.getRelativeDir() + "'");
+            assertEquals("/home/testing/", ctx.getRelativeDir());
         }
 
-        {
-            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), System.getProperty("user.dir") + "../../dir/Prueba.idl", new ArrayList<String>(), false);
-
-            assertEquals("../../dir/", ctx.getRelativeDir(null));
-        }
-
-        {
-            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), absolute_idl_dir, new ArrayList<String>(), false);
-
-            assertEquals("", ctx.getRelativeDir(null));
-        }
-
-        {
-            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), absolute_idl_dir, new ArrayList<String>(), false);
-
-            assertEquals("", ctx.getRelativeDir(absolute_dir));
-        }
-
-        {
-            com.eprosima.idl.context.Context ctx = new com.eprosima.idl.context.Context(
-                    new TemplateManager(), absolute_idl_dir, new ArrayList<String>(), false);
-
-            assertEquals("testing/", ctx.getRelativeDir(absolute_root_dir));
-        }
     }
 
     @Test
@@ -132,7 +123,7 @@ public class FastDDSGenTest
                 "share/fastddsgen/java/fastddsgen",
                 INPUT_PATH,
                 OUTPUT_PATH,
-                "CMake",
+                "CMake -I .",
                 list_tests,
                 blacklist_tests);
         tests.addCMakeArguments("-DCMAKE_BUILD_TYPE=Debug");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

Currently, the generated files will be on most cases on flat output directory structure even if `-flat-output-dir` is not used or the relative path can't be controlled properly.

For example:
`fastddsgen -no-typeobjectsupport -replace -example CMake -typeros2 -cs -I ~/path/to/idl/ros2 -t ~/tmp -d ~/generated ~/path/to/idl/ros2/sensor_msgs/msg/PointCloud2.idl`

will generate the files as flat:
.
├── CMakeLists.txt
├── Header.hpp
├── HeaderApplication.cxx
├── HeaderApplication.hpp
├── HeaderCdrAux.hpp
├── HeaderCdrAux.ipp
├── HeaderPubSubTypes.cxx
├── HeaderPubSubTypes.hpp
├── HeaderPublisherApp.cxx
├── HeaderPublisherApp.hpp
├── HeaderSubscriberApp.cxx
├── HeaderSubscriberApp.hpp
├── Headermain.cxx
├── PointCloud2.hpp
├── PointCloud2Application.cxx
├── PointCloud2Application.hpp
├── PointCloud2CdrAux.hpp
├── PointCloud2CdrAux.ipp
├── PointCloud2PubSubTypes.cxx
├── PointCloud2PubSubTypes.hpp
├── PointCloud2PublisherApp.cxx
├── PointCloud2PublisherApp.hpp
├── PointCloud2SubscriberApp.cxx
├── PointCloud2SubscriberApp.hpp
├── PointCloud2main.cxx
├── PointField.hpp
├── PointFieldApplication.cxx
├── PointFieldApplication.hpp
├── PointFieldCdrAux.hpp
├── PointFieldCdrAux.ipp
├── PointFieldPubSubTypes.cxx
├── PointFieldPubSubTypes.hpp
├── PointFieldPublisherApp.cxx
├── PointFieldPublisherApp.hpp
├── PointFieldSubscriberApp.cxx
├── PointFieldSubscriberApp.hpp
├── PointFieldmain.cxx
├── Time.hpp
├── TimeApplication.cxx
├── TimeApplication.hpp
├── TimeCdrAux.hpp
├── TimeCdrAux.ipp
├── TimePubSubTypes.cxx
├── TimePubSubTypes.hpp
├── TimePublisherApp.cxx
├── TimePublisherApp.hpp
├── TimeSubscriberApp.cxx
├── TimeSubscriberApp.hpp
└── Timemain.cxx

With this change (and the change in idl-parser https://github.com/eProsima/IDL-Parser/pull/174) the output will be:
.
├── CMakeLists.txt
├── builtin_interfaces
│ └── msg
│ ├── Time.hpp
│ ├── TimeApplication.cxx
│ ├── TimeApplication.hpp
│ ├── TimeCdrAux.hpp
│ ├── TimeCdrAux.ipp
│ ├── TimePubSubTypes.cxx
│ ├── TimePubSubTypes.hpp
│ ├── TimePublisherApp.cxx
│ ├── TimePublisherApp.hpp
│ ├── TimeSubscriberApp.cxx
│ ├── TimeSubscriberApp.hpp
│ └── Timemain.cxx
├── sensor_msgs
│ └── msg
│ ├── PointCloud2.hpp
│ ├── PointCloud2Application.cxx
│ ├── PointCloud2Application.hpp
│ ├── PointCloud2CdrAux.hpp
│ ├── PointCloud2CdrAux.ipp
│ ├── PointCloud2PubSubTypes.cxx
│ ├── PointCloud2PubSubTypes.hpp
│ ├── PointCloud2PublisherApp.cxx
│ ├── PointCloud2PublisherApp.hpp
│ ├── PointCloud2SubscriberApp.cxx
│ ├── PointCloud2SubscriberApp.hpp
│ ├── PointCloud2main.cxx
│ ├── PointField.hpp
│ ├── PointFieldApplication.cxx
│ ├── PointFieldApplication.hpp
│ ├── PointFieldCdrAux.hpp
│ ├── PointFieldCdrAux.ipp
│ ├── PointFieldPubSubTypes.cxx
│ ├── PointFieldPubSubTypes.hpp
│ ├── PointFieldPublisherApp.cxx
│ ├── PointFieldPublisherApp.hpp
│ ├── PointFieldSubscriberApp.cxx
│ ├── PointFieldSubscriberApp.hpp
│ └── PointFieldmain.cxx
└── std_msgs
└── msg
├── Header.hpp
├── HeaderApplication.cxx
├── HeaderApplication.hpp
├── HeaderCdrAux.hpp
├── HeaderCdrAux.ipp
├── HeaderPubSubTypes.cxx
├── HeaderPubSubTypes.hpp
├── HeaderPublisherApp.cxx
├── HeaderPublisherApp.hpp
├── HeaderSubscriberApp.cxx
├── HeaderSubscriberApp.hpp
└── Headermain.cxx

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
