### PR TITLE
[22917] Generate request / reply data structures

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -802,6 +802,7 @@ public class fastddsgen
             // Load Types common templates
             if (generate_typesupport_)
             {
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/InterfaceDetails.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg");
@@ -1011,6 +1012,14 @@ public class fastddsgen
                                 project.addCommonSrcFile(relative_dir + ctx.getFilename() + "TypeObjectSupport.cxx");
                             }
                         }
+                    }
+
+                    if (ctx.isThereIsInterface())
+                    {
+                        // Generate Interface details
+                        returnedValue &=
+                            Utils.writeFile(output_dir + ctx.getFilename() + "_details.hpp",
+                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/InterfaceDetails.stg"), m_replace);
                     }
 
                     if (ctx.isThereIsStructOrUnion() || ctx.isThereIsException())

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -478,6 +478,11 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return there_is_at_least_one_exception;
     }
 
+    public boolean isThereIsInterface()
+    {
+        return there_is_at_least_one_interface;
+    }
+
     public void setThereIsInputFeed(
             boolean value)
     {
@@ -761,6 +766,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     {
         Interface interfaceObject = new com.eprosima.fastdds.idl.grammar.Interface(
                 this, getScopeFile(), isInScopedFile(), null, name, token);
+        there_is_at_least_one_interface = true;
         return interfaceObject;
     }
 
@@ -827,4 +833,6 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     private boolean there_is_at_least_one_output_feed = false;
 
     private boolean there_is_at_least_one_non_feed_operation = false;
+
+    private boolean there_is_at_least_one_interface = false;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -765,7 +765,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             Token token)
     {
         Interface interfaceObject = new com.eprosima.fastdds.idl.grammar.Interface(
-                this, getScopeFile(), isInScopedFile(), null, name, token);
+                this, getScopeFile(), isInScopedFile(), getScope(), name, token);
         there_is_at_least_one_interface = true;
         return interfaceObject;
     }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -55,6 +55,7 @@ namespace detail {
 
 struct $interface.name$_Request
 {
+    $interface.all_operations : { operation | $operation_request_members(interface, operation)$ }; separator="\n"$
 };
 
 struct $interface.name$_Reply
@@ -68,6 +69,16 @@ struct $interface.name$_Reply
 //}  // $interface.name$ interface
 
 } // namespace detail
+>>
+
+operation_request_members(interface, operation) ::= <%
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_In> $operation.name$;
+$operation.parameters : { parameter | $if (parameter.annotationFeed)$$operation_request_feed(interface, operation, parameter)$$endif$ }$
+%>
+
+operation_request_feed(interface, operation, parameter) ::= <<
+
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_$parameter.name$_Feed\> $operation.name$_$parameter.name$;
 >>
 
 operation_reply_members(interface, operation) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -51,8 +51,6 @@ namespace detail {
 
 //{ $interface.name$ interface
 
-$export_list; separator="\n"$
-
 //{ top level
 
 struct $interface.name$_Request
@@ -61,6 +59,8 @@ struct $interface.name$_Request
 
 struct $interface.name$_Reply
 {
+    $interface.all_operations : { operation | $operation_reply_members(interface, operation)$ }; separator="\n"$
+    eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RemoteExceptionCode_t\> remoteEx;
 };
 
 //}  // top level
@@ -68,4 +68,8 @@ struct $interface.name$_Reply
 //}  // $interface.name$ interface
 
 } // namespace detail
+>>
+
+operation_reply_members(interface, operation) ::= <<
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_Result\> $operation.name$;
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -1,0 +1,71 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group InterfaceDetails;
+
+import "eprosima.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "_details.hpp"], description=["This header file contains support data structures for RPC communication."])$
+
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_DETAILS_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_DETAILS_HPP
+
+#include <fastcdr/xcdr/optional.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+
+#include "$ctx.filename$.hpp"
+
+$definitions; separator="\n"$
+
+#endif //FAST_DDS_GENERATED__$ctx.headerGuardName$_DETAILS_HPP
+>>
+
+struct_type(ctx, parent, struct, member_list) ::= <<>>
+
+union_type(ctx, parent, union, switch_type) ::= <<>>
+
+bitmask_type(ctx, parent, bitmask) ::= <<>>
+
+bitset_type(ctx, parent, bitset) ::= <<>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+    $definition_list$
+}  // namespace $module.name$
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+namespace detail {
+
+//{ $interface.name$ interface
+
+$export_list; separator="\n"$
+
+//{ top level
+
+struct $interface.name$_Request
+{
+};
+
+struct $interface.name$_Reply
+{
+};
+
+//}  // top level
+
+//}  // $interface.name$ interface
+
+} // namespace detail
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -24,6 +24,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "_details.hpp"], description=["This he
 
 #include <fastcdr/xcdr/optional.hpp>
 #include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcStatusCode.hpp>
 
 #include "$ctx.filename$.hpp"
 
@@ -51,6 +52,8 @@ namespace detail {
 
 //{ $interface.name$ interface
 
+$interface.all_operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
+
 //{ top level
 
 struct $interface.name$_Request
@@ -71,14 +74,75 @@ struct $interface.name$_Reply
 } // namespace detail
 >>
 
-operation_request_members(interface, operation) ::= <%
-eprosima::fastcdr::optional<$interface.name$_$operation.name$_In> $operation.name$;
-$operation.parameters : { parameter | $if (parameter.annotationFeed)$$operation_request_feed(interface, operation, parameter)$$endif$ }$
+operation_details(interface, operation) ::= <<
+//{ $operation.name$
+$operation_in_struct(interface, operation)$
+
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_feed_struct(interface, operation, param)$$endif$ }$
+
+$operation_out_struct(interface, operation)$
+
+$operation_result_struct(interface, operation)$
+
+//}  // $operation.name$
+
+>>
+
+operation_in_struct(interface, operation) ::= <<
+struct $interface.name$_$operation.name$_In
+{
+    $if(operation.inputparam)$
+    $operation.inputparam : { param | $if (!param.annotationFeed)$$parameter_declaration(param)$$endif$ }; separator="\n"$
+    $endif$
+};
+>>
+
+operation_feed_struct(interface, operation, param) ::= <<
+struct $interface.name$_$operation.name$_$param.name$_Feed
+{
+    eprosima::fastcdr::optional<$param.typecode.cppTypename$> value;
+    eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RpcStatusCode> finished_;
+};
+>>
+
+operation_out_struct(interface, operation) ::= <<
+struct $interface.name$_$operation.name$_Out
+{
+    $if(operation.annotationFeed)$
+    eprosima::fastcdr::optional<$operation.rettypeparam.typecode.cppTypename$\> $operation.rettypeparam.name$;
+    eprosima::fastcdr::optional<bool\> finished_;
+    $else$
+    $if([operation.outputparam, operation.rettypeparam])$
+    $[operation.outputparam, operation.rettypeparam]:{param | $parameter_declaration(param)$}; separator="\n"$
+    $endif$
+    $endif$
+};
+>>
+
+operation_result_struct(interface, operation) ::= <<
+struct $interface.name$_$operation.name$_Result
+{
+    eprosima::fastcdr::optional<$interface.name$_$operation.name$_Out\> result;
+    $operation.exceptions : { exception |$operation_result_exception(typename=exception.scopedname, name=[exception.formatedScopedname, "_ex"])$}; separator="\n"$
+};
+>>
+
+parameter_declaration(param) ::= <%
+$param.typecode.cppTypename$ $param.name$;
 %>
 
-operation_request_feed(interface, operation, parameter) ::= <<
+operation_result_exception(typename, name) ::= <%
+eprosima::fastcdr::optional<$typename$> $name$;
+%>
 
-eprosima::fastcdr::optional<$interface.name$_$operation.name$_$parameter.name$_Feed\> $operation.name$_$parameter.name$;
+operation_request_members(interface, operation) ::= <%
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_In> $operation.name$;
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_request_feed(interface, operation, param)$$endif$ }$
+%>
+
+operation_request_feed(interface, operation, param) ::= <<
+
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_$param.name$_Feed\> $operation.name$_$param.name$;
 >>
 
 operation_reply_members(interface, operation) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg
@@ -23,6 +23,9 @@ $fileHeader(ctx=ctx, file=[ctx.filename, "CdrAux.hpp"], description=["This sourc
 #define FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_HPP
 
 #include "$ctx.filename$.hpp"
+$if(ctx.thereIsInterface)$
+#include "$ctx.filename$_details.hpp"
+$endif$
 
 $if(ctx.anyCdr)$
 $ctx.types:{ type | $if(type.inScope)$$if(type.typeCode.isStructType)$


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR generates the request and reply data structures for an interface in the `<idl_name>_details.hpp`

From the following `calculator.idl` file:
<details>

```
module calculator_example
{
    // This exception will be thrown when an operation result cannot be represented in a long
    exception OverflowException
    {
    };
	
    // For the filter operation
    enum FilterKind
    {
	EVEN,  // return even numbers
        ODD,   // return odd numbers
        PRIME  // return positive prime numbers
    };

    interface Calculator
    {
        // Returns the minimum and maximum representable values
        void representation_limits(out long min_value, out long max_value);

        // Returns the result of value1 + value2
        long addition(in long value1, in long value2) raises (OverflowException);

        // Returns the result of value1 + value2
        long subtraction(in long value1, in long value2) raises (OverflowException);

        // Returns a feed of results with the n_results first elements of the Fibonacci sequence
        // E.g. for an input of 5, returns a feed with {1, 1, 2, 3, 5}
        @feed long fibonacci_seq(in unsigned long n_results) raises (OverflowException);

        // Waits for an input feed to finish and returns the sum of all the received values
        // E.g. for an input of {1, 2, 3, 4, 5} returns 15
        long sum_all(@feed in long value) raises (OverflowException);

        // Returns a feed of results with the sum of all received values
        // E.g. for an input of {1, 2, 3, 4, 5}, returns a feed with {1, 3, 6, 10, 15}
        @feed long accumulator(@feed in long value) raises (OverflowException);
		
        // Returns a feed of results with the received values that match the input filter kind
        @feed long filter(@feed in long value, in FilterKind filter_kind);
    };
};
```

</details>

it generates the following `calculator_details.hpp` file:
<details>

```
// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//     http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.

/*!
 * @file calculator_details.hpp
 * This header file contains support data structures for RPC communication.
 *
 * This file was generated by the tool fastddsgen.
 */

#ifndef FAST_DDS_GENERATED__CALCULATOR_DETAILS_HPP
#define FAST_DDS_GENERATED__CALCULATOR_DETAILS_HPP

#include <fastcdr/xcdr/optional.hpp>
#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
#include <fastdds/dds/rpc/interfaces/RpcStatusCode.hpp>

#include "calculator.hpp"

namespace calculator_example {
    namespace detail {

    //{ Calculator interface

    //{ representation_limits
    struct Calculator_representation_limits_In
    {
    };


    struct Calculator_representation_limits_Out
    {
        int32_t min_value;
        int32_t max_value;
    };

    struct Calculator_representation_limits_Result
    {
        eprosima::fastcdr::optional<Calculator_representation_limits_Out> result;
    };

    //}  // representation_limits
     
    //{ addition
    struct Calculator_addition_In
    {
        int32_t value1; 
        int32_t value2; 
    };

      

    struct Calculator_addition_Out
    {
        int32_t return_;
    };

    struct Calculator_addition_Result
    {
        eprosima::fastcdr::optional<Calculator_addition_Out> result;
        eprosima::fastcdr::optional<calculator_example::OverflowException> calculator_example_OverflowException_ex;
    };

    //}  // addition
     
    //{ subtraction
    struct Calculator_subtraction_In
    {
        int32_t value1; 
        int32_t value2; 
    };

      

    struct Calculator_subtraction_Out
    {
        int32_t return_;
    };

    struct Calculator_subtraction_Result
    {
        eprosima::fastcdr::optional<Calculator_subtraction_Out> result;
        eprosima::fastcdr::optional<calculator_example::OverflowException> calculator_example_OverflowException_ex;
    };

    //}  // subtraction
     
    //{ fibonacci_seq
    struct Calculator_fibonacci_seq_In
    {
        uint32_t n_results; 
    };

     

    struct Calculator_fibonacci_seq_Out
    {
        eprosima::fastcdr::optional<int32_t> return_;
        eprosima::fastcdr::optional<bool> finished_;
    };

    struct Calculator_fibonacci_seq_Result
    {
        eprosima::fastcdr::optional<Calculator_fibonacci_seq_Out> result;
        eprosima::fastcdr::optional<calculator_example::OverflowException> calculator_example_OverflowException_ex;
    };

    //}  // fibonacci_seq
     
    //{ sum_all
    struct Calculator_sum_all_In
    {
         
    };

    struct Calculator_sum_all_value_Feed
    {
        eprosima::fastcdr::optional<int32_t> value;
        eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RpcStatusCode> finished_;
    }; 

    struct Calculator_sum_all_Out
    {
        int32_t return_;
    };

    struct Calculator_sum_all_Result
    {
        eprosima::fastcdr::optional<Calculator_sum_all_Out> result;
        eprosima::fastcdr::optional<calculator_example::OverflowException> calculator_example_OverflowException_ex;
    };

    //}  // sum_all
     
    //{ accumulator
    struct Calculator_accumulator_In
    {
         
    };

    struct Calculator_accumulator_value_Feed
    {
        eprosima::fastcdr::optional<int32_t> value;
        eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RpcStatusCode> finished_;
    }; 

    struct Calculator_accumulator_Out
    {
        eprosima::fastcdr::optional<int32_t> return_;
        eprosima::fastcdr::optional<bool> finished_;
    };

    struct Calculator_accumulator_Result
    {
        eprosima::fastcdr::optional<Calculator_accumulator_Out> result;
        eprosima::fastcdr::optional<calculator_example::OverflowException> calculator_example_OverflowException_ex;
    };

    //}  // accumulator
     
    //{ filter
    struct Calculator_filter_In
    {
         
        calculator_example::FilterKind filter_kind; 
    };

    struct Calculator_filter_value_Feed
    {
        eprosima::fastcdr::optional<int32_t> value;
        eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RpcStatusCode> finished_;
    };  

    struct Calculator_filter_Out
    {
        eprosima::fastcdr::optional<int32_t> return_;
        eprosima::fastcdr::optional<bool> finished_;
    };

    struct Calculator_filter_Result
    {
        eprosima::fastcdr::optional<Calculator_filter_Out> result;
    };

    //}  // filter
     

    //{ top level

    struct Calculator_Request
    {
        eprosima::fastcdr::optional<Calculator_representation_limits_In> representation_limits; 
        eprosima::fastcdr::optional<Calculator_addition_In> addition;   
        eprosima::fastcdr::optional<Calculator_subtraction_In> subtraction;   
        eprosima::fastcdr::optional<Calculator_fibonacci_seq_In> fibonacci_seq;  
        eprosima::fastcdr::optional<Calculator_sum_all_In> sum_all;
        eprosima::fastcdr::optional<Calculator_sum_all_value_Feed> sum_all_value;  
        eprosima::fastcdr::optional<Calculator_accumulator_In> accumulator;
        eprosima::fastcdr::optional<Calculator_accumulator_value_Feed> accumulator_value;  
        eprosima::fastcdr::optional<Calculator_filter_In> filter;
        eprosima::fastcdr::optional<Calculator_filter_value_Feed> filter_value;   
    };

    struct Calculator_Reply
    {
        eprosima::fastcdr::optional<Calculator_representation_limits_Result> representation_limits; 
        eprosima::fastcdr::optional<Calculator_addition_Result> addition; 
        eprosima::fastcdr::optional<Calculator_subtraction_Result> subtraction; 
        eprosima::fastcdr::optional<Calculator_fibonacci_seq_Result> fibonacci_seq; 
        eprosima::fastcdr::optional<Calculator_sum_all_Result> sum_all; 
        eprosima::fastcdr::optional<Calculator_accumulator_Result> accumulator; 
        eprosima::fastcdr::optional<Calculator_filter_Result> filter; 
        eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RemoteExceptionCode_t> remoteEx;
    };

    //}  // top level

    //}  // Calculator interface

    } // namespace detail
}  // namespace calculator_example

#endif //FAST_DDS_GENERATED__CALCULATOR_DETAILS_HPP
```

</details>

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- __NO__: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Will do a final documentation PR for the whole feature
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
