### PR TITLE
[22996] Generate ServiceTypeSupport for interfaces

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -1038,11 +1038,8 @@ public class fastddsgen
                         Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.hpp",
                                 maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg"), m_replace);
                     project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "PubSubTypes.hpp");
-                    if (ctx.existsLastStructure())
+                    if (ctx.existsLastStructure() || ctx.isThereIsInterface())
                     {
-                        m_atLeastOneStructure = true;
-                        project.setHasStruct(true);
-
                         if (returnedValue &=
                                 Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.cxx",
                                     maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg"), m_replace))
@@ -1056,6 +1053,12 @@ public class fastddsgen
                                         maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg"), m_replace);
                             }
                         }
+                    }
+
+                    if (ctx.existsLastStructure())
+                    {
+                        m_atLeastOneStructure = true;
+                        project.setHasStruct(true);
 
                         if (m_exampleOption != null)
                         {

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -316,7 +316,9 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             there_is_at_least_one_exception = true;
         }
 
-        return super.createException(name, token);
+        Exception ex = new Exception(this, getScopeFile(), isInScopedFile(), getScope(), name, token);
+        addException(ex);
+        return ex;
     }
 
 

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Exception.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Exception.java
@@ -1,0 +1,68 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
+
+import com.eprosima.idl.parser.typecode.Kind;
+import com.eprosima.idl.parser.typecode.Member;
+import com.eprosima.idl.parser.typecode.PrimitiveTypeCode;
+import com.eprosima.idl.parser.typecode.TypeCode.ExtensibilityKind;
+
+import org.antlr.v4.runtime.Token;
+
+public class Exception extends com.eprosima.idl.parser.tree.Exception
+{
+    public Exception(Context ctx, String scopeFile, boolean isInScope, String scope, String name, Token token)
+    {
+        super(scopeFile, isInScope, scope, name, token);
+        m_context = ctx;
+    }
+
+    public StructTypeCode getTypeCode()
+    {
+        if (m_typecode == null)
+        {
+            m_typecode = new StructTypeCode(getScope(), getName());
+            // Add inheritance
+            m_typecode.addInheritance(m_context, getRpcOperationErrorTypeCode());
+            // Add annotations
+            getAnnotations().forEach((name, ann) -> m_typecode.addAnnotation(m_context, ann));
+            // Add members
+            getMembers().forEach(member -> m_typecode.addMember(member));
+            // Default to final extensibility
+            m_typecode.get_extensibility(ExtensibilityKind.FINAL);
+        }
+
+        return m_typecode;
+    }
+
+    private StructTypeCode getRpcOperationErrorTypeCode()
+    {
+        if (m_rpcOperationErrorTypeCode == null)
+        {
+            m_rpcOperationErrorTypeCode = new StructTypeCode("eprosima::fastdds::dds::rpc", "RpcOperationError");
+            m_rpcOperationErrorTypeCode.get_extensibility(ExtensibilityKind.FINAL);
+            int kind = com.eprosima.idl.parser.typecode.Kind.KIND_STRING;
+            Member msg_member = new Member(m_context.createStringTypeCode(kind, null), "_error_message_");
+            m_rpcOperationErrorTypeCode.addMember(msg_member);
+        }
+        return m_rpcOperationErrorTypeCode;
+    }
+
+    private Context m_context = null;
+    private StructTypeCode m_typecode = null;
+    static private StructTypeCode m_rpcOperationErrorTypeCode = null;
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
@@ -15,6 +15,11 @@
 package com.eprosima.fastdds.idl.grammar;
 
 import com.eprosima.fastdds.idl.grammar.Operation;
+import com.eprosima.fastdds.idl.parser.typecode.EnumTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
+import com.eprosima.idl.parser.typecode.Member;
+import com.eprosima.idl.parser.typecode.EnumMember;
+import com.eprosima.idl.parser.typecode.TypeCode.ExtensibilityKind;
 import org.antlr.v4.runtime.Token;
 
 public class Interface extends com.eprosima.idl.parser.tree.Interface
@@ -44,5 +49,58 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
         super.add(exp);
     }
 
+    /*!
+     * @brief This function is used in stringtemplates to generate the typesupport code for the interface.
+     *
+     * @return The typecode of the reply type.
+     */
+    public StructTypeCode getReplyTypeCode()
+    {
+        if (m_reply_type == null)
+        {
+            String scope = getHasScope() ? getScope() + "::detail" : "detail";
+            StructTypeCode reply_type = new StructTypeCode(scope, getName() + "_Reply");
+
+            // The reply type should be a `@choice`, which means that it should have MUTABLE extensibility,
+            // and also treat all fields as optional.
+            reply_type.get_extensibility(ExtensibilityKind.MUTABLE);
+
+            getAll_operations().forEach(operation -> {
+                Operation op = (Operation)operation;
+                Member member = new Member(op.getResultTypeCode(), op.getName());
+                // Add `@optional` and `@hashid` annotations
+                member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+                reply_type.addMember(member);
+            });
+
+            Member remoteEx = new Member(get_remoteExceptionCode_t_type(), "remoteEx");
+            remoteEx.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+            remoteEx.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+            reply_type.addMember(remoteEx);
+
+            m_reply_type = reply_type;
+        }
+        return m_reply_type;
+    }
+
+    private EnumTypeCode get_remoteExceptionCode_t_type()
+    {
+        if (m_remoteExceptionCode_t_type == null)
+        {
+            EnumTypeCode type = new EnumTypeCode("eprosima::fastdds::dds::rpc", "RemoteExceptionCode_t");
+            type.addMember(new EnumMember("REMOTE_EX_OK"));
+            type.addMember(new EnumMember("REMOTE_EX_UNSUPPORTED"));
+            type.addMember(new EnumMember("REMOTE_EX_INVALID_ARGUMENT"));
+            type.addMember(new EnumMember("REMOTE_EX_OUT_OF_RESOURCES"));
+            type.addMember(new EnumMember("REMOTE_EX_UNKNOWN_OPERATION"));
+            type.addMember(new EnumMember("REMOTE_EX_UNKNOWN_EXCEPTION"));
+            m_remoteExceptionCode_t_type = type;
+        }
+        return m_remoteExceptionCode_t_type;
+    }
+
     private Context m_context;
+    private StructTypeCode m_reply_type = null;
+    static private EnumTypeCode m_remoteExceptionCode_t_type = null;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -123,6 +123,31 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
         return m_in_type;
     }
 
+    public StructTypeCode createFeedTypeCode(Param p)
+    {
+        // Add feed typecode to the parameter
+        Interface iface = (Interface)getParent();
+        String scope = iface.getHasScope() ? iface.getScope() + "::detail" : "detail";
+
+        StructTypeCode feed_type = new StructTypeCode(
+            scope,
+            iface.getName() + "_" + getName() + "_" + p.getName() + "_Feed");
+
+        feed_type.get_extensibility(ExtensibilityKind.FINAL);
+
+        // Add optional value member
+        Member value_member = new Member(p.getTypecode(), "value");
+        value_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+        feed_type.addMember(value_member);
+
+        // Add optional finished_ member
+        Member finished_member = new Member(m_context.createPrimitiveTypeCode(Kind.KIND_LONG), "finished_");
+        finished_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+        feed_type.addMember(finished_member);
+
+        return feed_type;
+    }
+
     public StructTypeCode getOutTypeCode()
     {
         if (m_out_type == null)

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -165,7 +165,7 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
             // Add exceptions as optional members
             getExceptions().forEach(exception -> {
                 String member_name = exception.getFormatedScopedname() + "_ex";
-                Member member = new Member(null /* exception.getTypeCode()*/, member_name);
+                Member member = new Member(((Exception)exception).getTypeCode(), member_name);
                 member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
                 member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
                 result_type.addMember(member);

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -87,6 +87,42 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
         super.add(param);
     }
 
+    public StructTypeCode getInTypeCode()
+    {
+        if (m_in_type == null)
+        {
+            Interface parent = (Interface)getParent();
+            String scope = parent.getHasScope() ? parent.getScope() + "::detail" : "detail";
+
+            // Create In type
+            StructTypeCode in_type = new StructTypeCode(
+                scope,
+                parent.getName() + "_" + getName() + "_In");
+
+            // If the operation is marked as mutable, then the in type should be mutable as well
+            if (isAnnotationMutable())
+            {
+                in_type.get_extensibility(ExtensibilityKind.MUTABLE);
+            }
+            else
+            {
+                in_type.get_extensibility(ExtensibilityKind.FINAL);
+            }
+
+            // Add non-feed input parameters as members
+            getParameters().forEach(param -> {
+                if (param.isInput() && !((Param)param).isAnnotationFeed())
+                {
+                    Member member = new Member(param.getTypecode(), param.getName());
+                    in_type.addMember(member);
+                }
+            });
+
+            m_in_type = in_type;
+        }
+        return m_in_type;
+    }
+
     public StructTypeCode getOutTypeCode()
     {
         if (m_out_type == null)
@@ -178,6 +214,7 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
     }
 
     private Context m_context = null;
-    private StructTypeCode m_result_type = null;
+    private StructTypeCode m_in_type = null;
     private StructTypeCode m_out_type = null;
+    private StructTypeCode m_result_type = null;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -16,6 +16,7 @@ package com.eprosima.fastdds.idl.grammar;
 
 import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.exception.ParseException;
+import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
 import com.eprosima.fastdds.idl.grammar.Param;
 import org.antlr.v4.runtime.Token;
 
@@ -69,6 +70,12 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
         }
 
         super.add(param);
+    }
+
+    public StructTypeCode getResultTypeCode()
+    {
+        // TODO(MiguelCompany): Implement this function
+        return null;
     }
 
     private Context m_context;

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Param.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Param.java
@@ -14,6 +14,7 @@
 
 package com.eprosima.fastdds.idl.grammar;
 
+import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
 import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.typecode.TypeCode;
 
@@ -48,4 +49,15 @@ public class Param extends com.eprosima.idl.parser.tree.Param
         }
         return false;
     }
+
+    public StructTypeCode getFeedTypeCode()
+    {
+        if (m_feedTypeCode == null)
+        {
+            m_feedTypeCode = ((Operation) getParent()).createFeedTypeCode(this);
+        }
+        return m_feedTypeCode;
+    }
+
+    private StructTypeCode m_feedTypeCode = null;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -24,6 +24,9 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.hpp"], description=["This
 #define FAST_DDS_GENERATED__$ctx.headerGuardName$_PUBSUBTYPES_HPP
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+$if(ctx.thereIsInterface)$
+#include <fastdds/dds/rpc/ServiceTypeSupport.hpp>
+$endif$
 #include <fastdds/dds/topic/TopicDataType.hpp>
 #include <fastdds/rtps/common/InstanceHandle.hpp>
 #include <fastdds/rtps/common/SerializedPayload.hpp>
@@ -229,6 +232,10 @@ $if(struct.isPlain)$
 
 $endif$
 };
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+eProsima_user_DllExport eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_type_support();
 >>
 
 //{ Fast DDS-Gen extensions

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -35,7 +35,7 @@ using DataRepresentationId_t = eprosima::fastdds::dds::DataRepresentationId_t;
 
 $definitions; separator="\n"$
 
-$if(ctx.thereIsStructOrUnion)$
+$if(ctx.thereIsStructOrUnion || ctx.thereIsInterface)$
 // Include auxiliary functions like for serializing/deserializing.
 #include "$ctx.filename$CdrAux.ipp"
 $endif$
@@ -238,6 +238,30 @@ void $struct.name$PubSubType::register_type_object_representation()
     $endif$
 }
 
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+// { $interface.name$ interface
+
+class $interface.name$_RequestPubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+};
+
+class $interface.name$_ReplyPubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+};
+
+eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_type_support()
+{
+    eprosima::fastdds::dds::TypeSupport request_type(
+        new $interface.name$_RequestPubSubType());
+    eprosima::fastdds::dds::TypeSupport reply_type(
+        new $interface.name$_ReplyPubSubType());
+    return eprosima::fastdds::dds::rpc::ServiceTypeSupport(
+        request_type, reply_type);
+}
+
+// }  // $interface.name$ interface
 >>
 
 //{ Fast DDS-Gen extensions

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -243,13 +243,9 @@ void $struct.name$PubSubType::register_type_object_representation()
 interface(ctx, parent, interface, export_list) ::= <<
 // { $interface.name$ interface
 
-class $interface.name$_RequestPubSubType : public eprosima::fastdds::dds::TopicDataType
-{
-};
+$interface_generic_ser_code(ctx, parent, interface, "Request")$
 
-class $interface.name$_ReplyPubSubType : public eprosima::fastdds::dds::TopicDataType
-{
-};
+$interface_generic_ser_code(ctx, parent, interface, "Reply")$
 
 eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_type_support()
 {
@@ -262,6 +258,151 @@ eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_
 }
 
 // }  // $interface.name$ interface
+>>
+
+interface_generic_ser_code(ctx, parent, interface, suffix) ::= <<
+class $interface.name$_$suffix$PubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+    // Alias for the type to be serialized.
+    typedef detail::$interface.name$_$suffix$ type;
+
+    // Constructor
+    $interface.name$_$suffix$PubSubType()
+    {
+        set_name("$interface.scopedname$_$suffix$");
+        uint32_t type_size = $interface.requestTypeCode.maxSerializedSize$UL;
+        type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+        max_serialized_type_size = type_size + 4; /*encapsulation*/
+        is_compute_key_provided = false;
+    }
+
+    // Destructor
+    ~$interface.name$_$suffix$PubSubType() override = default;
+
+    // This function serializes the data.
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
+    {
+        const type* p_type = static_cast<const type*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+        payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        ser.set_encoding_flag(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2);
+
+        try
+        {
+            // Serialize encapsulation
+            ser.serialize_encapsulation();
+            // Serialize the object.
+            ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return false;
+        }
+
+        // Get the serialized length
+        payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+        return true;
+    }
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            void* data) override
+    {
+        try
+        {
+            // Convert DATA to pointer of your type
+            type* p_type = static_cast<type*>(data);
+    
+            // Object that manages the raw buffer.
+            eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+    
+            // Object that deserializes the data.
+            eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+    
+            // Deserialize encapsulation.
+            deser.read_encapsulation();
+            payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    
+            // Deserialize the object.
+            deser \>> *p_type;
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
+    {
+        try
+        {
+            eprosima::fastcdr::CdrSizeCalculator calculator(
+                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+            size_t current_alignment {0};
+            return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                        *static_cast<const type*>(data), current_alignment)) +
+                    4u /*encapsulation*/;
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return 0;
+        }
+    }
+
+    eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override
+    {
+        static_cast<void>(payload);
+        static_cast<void>(ihandle);
+        static_cast<void>(force_md5);
+        return false;
+    }
+
+    eProsima_user_DllExport bool compute_key(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override
+    {
+        static_cast<void>(data);
+        static_cast<void>(ihandle);
+        static_cast<void>(force_md5);
+        return false;
+    }
+
+    eProsima_user_DllExport void* create_data() override
+    {
+        return new type();
+    }
+
+    eProsima_user_DllExport void delete_data(
+            void* data) override
+    {
+        type* pData = static_cast<type*>(data);
+        delete pData;
+    }
+
+};
 >>
 
 //{ Fast DDS-Gen extensions

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -575,6 +575,7 @@ struct $interface.name$_$operation.name$_In
     $endif$
 };
 */
+$rpc_struct_serialization(operation.inTypeCode)$
 >>
 
 operation_feed_struct(interface, operation, param) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -587,6 +587,7 @@ struct $interface.name$_$operation.name$_$param.name$_Feed
     eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RpcStatusCode> finished_;
 };
 */
+$rpc_struct_serialization(param.feedTypeCode)$
 >>
 
 operation_out_struct(interface, operation) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -534,6 +534,7 @@ struct $interface.name$_Request
     $interface.all_operations : { operation | $operation_request_members(interface, operation)$ }; separator="\n"$
 };
 */
+$rpc_struct_serialization(interface.requestTypeCode)$
 
 // Serialization methods for $detail_scoped_name(interface)$_Reply
 /*

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -543,6 +543,7 @@ struct $interface.name$_Reply
     eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RemoteExceptionCode_t\> remoteEx;
 };
 */
+$rpc_struct_serialization(interface.replyTypeCode)$
 
 //}  // top level
 
@@ -602,6 +603,7 @@ struct $interface.name$_$operation.name$_Out
     $endif$
 };
 */
+$rpc_struct_serialization(operation.outTypeCode)$
 >>
 
 operation_result_struct(interface, operation) ::= <<
@@ -613,6 +615,7 @@ struct $interface.name$_$operation.name$_Result
     $operation.exceptions : { exception |$operation_result_exception(typename=exception.scopedname, name=[exception.formatedScopedname, "_ex"])$}; separator="\n"$
 };
 */
+$rpc_struct_serialization(operation.resultTypeCode)$
 >>
 
 parameter_declaration(param) ::= <%
@@ -643,3 +646,109 @@ $interface.scope$::
 $endif$
 detail::$interface.name$
 %>
+
+rpc_struct_serialization(struct) ::= <<
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const $struct.scopedname$& data,
+        size_t& current_alignment)
+{
+    $if(!struct.scope.empty)$
+    using namespace $struct.scope$;
+    $endif$
+
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                $if(struct.annotationFinal)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2$elseif(struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2$endif$ :
+                                $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$,
+                                current_alignment)};
+
+
+    $struct.allMembers : { member | $if(!member.annotationNonSerialized)$
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId($if(struct.annotationMutable)$$member.id$$else$$member.index$$endif$),
+            data.$member.name$, current_alignment);
+    $endif$}; separator="\n"$
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const $struct.scopedname$& data)
+{
+    $if(!struct.scope.empty)$
+    using namespace $struct.scope$;
+    $endif$
+
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            $if(struct.annotationFinal)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2$elseif(struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2$endif$ :
+            $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$);
+
+    $if(struct.allMembers)$
+    scdr$struct.allMembers : { member | $if(!member.annotationNonSerialized)$
+        << eprosima::fastcdr::MemberId($if(struct.annotationMutable)$$member.id$$else$$member.index$$endif$) << data.$member.name$
+    $endif$
+    }; separator=""$;
+    $else$
+    static_cast<void>(data);
+    $endif$
+
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        $struct.scopedname$& data)
+{
+    $if(!struct.scope.empty)$
+    using namespace $struct.scope$;
+    $endif$
+
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            $if(struct.annotationFinal)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2$elseif(struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2$endif$ :
+            $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                $if(struct.allMembers)$
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                    $struct.allMembers : { member |
+                    case $if(struct.annotationMutable)$$member.id$$else$$member.index$$endif$:
+                        $if(!member.annotationNonSerialized)$
+                            dcdr \>> data.$member.name$;
+                        $endif$
+                        break;
+                    }; separator="\n"$
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+                $else$
+                static_cast<void>(data);
+                static_cast<void>(dcdr);
+                static_cast<void>(mid);
+                return false;
+                $endif$
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const $struct.scopedname$& data)
+{
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+}
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -518,3 +518,128 @@ eProsima_user_DllExport void deserialize(
 }
 
 >>
+
+interface(ctx, parent, interface, export_list) ::= <<
+
+//{ $interface.scopedname$ interface
+
+$interface.all_operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
+
+//{ top level
+
+// Serialization methods for $detail_scoped_name(interface)$_Request
+/*
+struct $interface.name$_Request
+{
+    $interface.all_operations : { operation | $operation_request_members(interface, operation)$ }; separator="\n"$
+};
+*/
+
+// Serialization methods for $detail_scoped_name(interface)$_Reply
+/*
+struct $interface.name$_Reply
+{
+    $interface.all_operations : { operation | $operation_reply_members(interface, operation)$ }; separator="\n"$
+    eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RemoteExceptionCode_t\> remoteEx;
+};
+*/
+
+//}  // top level
+
+//}  // $interface.scopedname$ interface
+
+>>
+
+operation_details(interface, operation) ::= <<
+//{ $operation.name$
+$operation_in_struct(interface, operation)$
+
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_feed_struct(interface, operation, param)$$endif$ }$
+
+$operation_out_struct(interface, operation)$
+
+$operation_result_struct(interface, operation)$
+
+//}  // $operation.name$
+
+>>
+
+operation_in_struct(interface, operation) ::= <<
+// Serialization methods for $detail_scoped_name(interface)$_$operation.name$_In
+/*
+struct $interface.name$_$operation.name$_In
+{
+    $if(operation.inputparam)$
+    $operation.inputparam : { param | $if (!param.annotationFeed)$$parameter_declaration(param)$$endif$ }; separator="\n"$
+    $endif$
+};
+*/
+>>
+
+operation_feed_struct(interface, operation, param) ::= <<
+// Serialization methods for $detail_scoped_name(interface)$_$operation.name$_$param.name$_Feed
+/*
+struct $interface.name$_$operation.name$_$param.name$_Feed
+{
+    eprosima::fastcdr::optional<$param.typecode.cppTypename$> value;
+    eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RpcStatusCode> finished_;
+};
+*/
+>>
+
+operation_out_struct(interface, operation) ::= <<
+// Serialization methods for $detail_scoped_name(interface)$_$operation.name$_Out
+/*
+struct $interface.name$_$operation.name$_Out
+{
+    $if(operation.annotationFeed)$
+    eprosima::fastcdr::optional<$operation.rettypeparam.typecode.cppTypename$\> $operation.rettypeparam.name$;
+    eprosima::fastcdr::optional<bool\> finished_;
+    $else$
+    $if([operation.outputparam, operation.rettypeparam])$
+    $[operation.outputparam, operation.rettypeparam]:{param | $parameter_declaration(param)$}; separator="\n"$
+    $endif$
+    $endif$
+};
+*/
+>>
+
+operation_result_struct(interface, operation) ::= <<
+// Serialization methods for $detail_scoped_name(interface)$_$operation.name$_Result
+/*
+struct $interface.name$_$operation.name$_Result
+{
+    eprosima::fastcdr::optional<$interface.name$_$operation.name$_Out\> result;
+    $operation.exceptions : { exception |$operation_result_exception(typename=exception.scopedname, name=[exception.formatedScopedname, "_ex"])$}; separator="\n"$
+};
+*/
+>>
+
+parameter_declaration(param) ::= <%
+$param.typecode.cppTypename$ $param.name$;
+%>
+
+operation_result_exception(typename, name) ::= <%
+eprosima::fastcdr::optional<$typename$> $name$;
+%>
+
+operation_request_members(interface, operation) ::= <%
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_In> $operation.name$;
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_request_feed(interface, operation, param)$$endif$ }$
+%>
+
+operation_request_feed(interface, operation, param) ::= <<
+
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_$param.name$_Feed\> $operation.name$_$param.name$;
+>>
+
+operation_reply_members(interface, operation) ::= <<
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_Result\> $operation.name$;
+>>
+
+detail_scoped_name(interface) ::= <%
+$if(interface.hasScope)$
+$interface.scope$::
+$endif$
+detail::$interface.name$
+%>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds ServiceTypeSupport code generation for interfaces:
* [x] Generate serialization code in `xxxCdrAux.ipp`
  * [x] Generate serialization code for requests
    * [x] `xxx_operation_In`
    * [x] `xxx_operation_param_Feed`
    * [x] `xxx_Request`
  * [x] Generate serialization code for replies
    * [x] `xxx_operation_Out`
    * [x] `xxx_operation_Result`
    * [x] `xxx_Reply`
* [x] Generate ServiceTypeSupport in `xxxPubSubTypes.hpp/cxx`
  * [x] Generate TopicDataType for requests
  * [x] Generate TopicDataType for replies

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- __NO__: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Will do a final documentation PR for the whole feature
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
