### PR TITLE
[23017] Generate code for interface clients

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -28,7 +28,7 @@ $typecode.cppTypename$&
 
 paramTypeByValue(typecode, feed) ::= <%
 $if(feed)$
-std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientWriter<$typecode.cppTypename$> >&
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientWriter<$typecode.cppTypename$>>&
 $else$
 $if(typecode.primitive)$
 $typecode.cppTypename$

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -196,6 +196,7 @@ interface(ctx, parent, interface, export_list) ::= <<
 class $ctx.fileNameUpper$_DllAPI $interface.name$ $if(interface.bases)$: $interface.bases : {base |public $base.scopedname$}; separator=", "$$endif$
 {
 public:
+    virtual ~$interface.name$() = default;
 
     $export_list$
 };

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -807,6 +807,8 @@ public class fastddsgen
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg");
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/ClientHeader.stg");
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/ClientSource.stg");
 
                 if (generate_typeobjectsupport_)
                 {
@@ -1052,6 +1054,23 @@ public class fastddsgen
                                         output_dir + ctx.getFilename() + "PubSubTypes.i",
                                         maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg"), m_replace);
                             }
+                        }
+                    }
+
+                    // Generate client code for interfaces
+                    if (ctx.isThereIsInterface())
+                    {
+                        if (returnedValue &=
+                                Utils.writeFile(output_dir + ctx.getFilename() + "Client.hpp",
+                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/ClientHeader.stg"), m_replace))
+                        {
+                            project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "Client.hpp");
+                        }
+                        if (returnedValue &=
+                                Utils.writeFile(output_dir + ctx.getFilename() + "Client.cxx",
+                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/ClientSource.stg"), m_replace))
+                        {
+                            project.addCommonSrcFile(relative_dir + ctx.getFilename() + "Client.cxx");
                         }
                     }
 

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
@@ -38,6 +38,7 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
             Operation op = (Operation)exp;
             if (op.isAnnotationFeed())
             {
+                m_hasOutputFeeds = true;
                 m_context.setThereIsOutputFeed(true);
             }
             else
@@ -47,6 +48,16 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
         }
 
         super.add(exp);
+    }
+
+    /*!
+     * @brief This function is used to check if the interface has output feeds.
+     *
+     * @return True if the interface has output feeds, false otherwise.
+     */
+    public boolean isWithOutputFeeds()
+    {
+        return m_hasOutputFeeds;
     }
 
     /*!
@@ -84,6 +95,16 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
                     }
                 });
             });
+
+            if (m_hasOutputFeeds)
+            {
+                // Optional boolean to indicate if the feed is cancelled
+                Member feed_cancel = new Member(m_context.createPrimitiveTypeCode(
+                    com.eprosima.idl.parser.typecode.Kind.KIND_BOOLEAN), "feed_cancel_");
+                feed_cancel.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                feed_cancel.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+                request_type.addMember(feed_cancel);
+            }
 
             m_request_type = request_type;
         }
@@ -142,6 +163,7 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
     }
 
     private Context m_context = null;
+    private boolean m_hasOutputFeeds = false;
     private StructTypeCode m_request_type = null;
     private StructTypeCode m_reply_type = null;
     static private EnumTypeCode m_remoteExceptionCode_t_type = null;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientHeader.stg
@@ -1,0 +1,52 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group ProtocolHeader;
+
+import "eprosima.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Client.hpp"], description=["Client implementation for interfaces"])$
+
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_CLIENT_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_CLIENT_HPP
+
+#include <memory>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/qos/RequesterQos.hpp>
+
+#include "$ctx.filename$.hpp"
+
+$definitions; separator="\n"$
+
+#endif  // FAST_DDS_GENERATED__$ctx.headerGuardName$_CLIENT_HPP
+
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+
+$definition_list$
+
+} // namespace $module.name$
+
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+extern $ctx.fileNameUpper$_DllAPI std::shared_ptr<$interface.name$> create_$interface.name$Client(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::RequesterQos& qos);
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -547,9 +547,11 @@ $else$
         }
 
     };
+
 $endif$
 
-$operation.inputparam:{param | $if(param.annotationFeed)$$input_feed_writer(operation, param)$$endif$}$
+    $operation.inputparam:{param | $if(param.annotationFeed)$$input_feed_writer(operation, param)$$endif$}$
+
     //} operation $operation.name$
 
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -364,7 +364,7 @@ public:
     {
 $if(operation.annotationFeed)$
         // Create a reader to hold the result
-        auto result = std::make_shared<$operation.name$_reader>();
+        auto result = std::make_shared<$operation.name$_reader>(requester_);
 $else$
         // Create a promise to hold the result
         auto result = std::make_shared<$operation.name$_promise>();
@@ -395,6 +395,12 @@ $if(operation.annotationFeed)$
         , public IReplyProcessor
         , public IExceptionHolder
     {
+        $operation.name$_reader(
+                frpc::Requester* requester)
+            : requester_(requester)
+        {
+        }
+
         void process_reply(
                 const ReplyType& reply,
                 const frpc::RequestInfo& req_info,
@@ -506,7 +512,29 @@ $if(operation.annotationFeed)$
                 // Notify read calls that the operation was cancelled
                 cv_.notify_all();
 
-                // TODO: Communicate the cancellation to the server and wait for it to be acknowledged
+                // Communicate the cancellation to the server and wait for it to be acknowledged
+                RequestType request;
+                request.feed_cancel_ = true;
+                frpc::RequestInfo req_info = info;
+                auto ret = requester_->send_request((void*)&request, req_info);
+                if (ret != fdds::RETCODE_OK)
+                {
+                    if (ret == fdds::RETCODE_TIMEOUT)
+                    {
+                        throw frpc::RpcTimeoutException();
+                    }
+                    else
+                    {
+                        throw frpc::RpcBrokenPipeException(false);
+                    }
+                }
+
+                // Wait for the server to acknowledge the cancellation
+                std::unique_lock<std::mutex> lock(mtx_);
+                while (!finished_)
+                {
+                    cv_.wait(lock);
+                }
             }
         }
 
@@ -551,6 +579,7 @@ $if(operation.annotationFeed)$
             return false;
         }
 
+        frpc::Requester* requester_ = nullptr;
         std::atomic<bool> cancelled_ = false;
         std::exception_ptr exception_;
         std::queue<$paramRetType(operation.rettype)$> queue_;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -512,14 +512,6 @@ $if(operation.annotationFeed)$
                 $paramRetType(operation.rettype)$& value,
                 bool& ret_val)
         {
-            // Throw the exception if it was set
-            if (exception_)
-            {
-                auto ex = exception_;
-                exception_ = nullptr;
-                std::rethrow_exception(ex);
-            }
-
             // Early exit if the operation was cancelled
             if (cancelled_)
             {
@@ -534,6 +526,14 @@ $if(operation.annotationFeed)$
                 queue_.pop();
                 ret_val = true;
                 return true;
+            }
+
+            // Throw the exception if it was set
+            if (exception_)
+            {
+                auto ex = exception_;
+                exception_ = nullptr;
+                std::rethrow_exception(ex);
             }
 
             // Check if the operation was finished

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -34,6 +34,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "Client.cxx"], description=["Client im
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/qos/RequesterQos.hpp>
+#include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/rpc/exceptions.hpp>
 #include <fastdds/dds/rpc/interfaces.hpp>
 #include <fastdds/dds/rpc/RequestInfo.hpp>
@@ -41,6 +42,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "Client.cxx"], description=["Client im
 #include <fastdds/dds/rpc/Service.hpp>
 #include <fastdds/dds/rpc/ServiceTypeSupport.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
+#include <fastdds/rtps/common/WriteParams.hpp>
 
 #include "$ctx.filename$.hpp"
 #include "$ctx.filename$_details.hpp"
@@ -453,6 +455,7 @@ $else$
     };
 $endif$
 
+$operation.inputparam:{param | $if(param.annotationFeed)$$input_feed_writer(operation, param)$$endif$}$
     //} operation $operation.name$
 
 >>
@@ -467,11 +470,77 @@ $endif$
 
 fill_input_param(operation, param) ::= <%
 $if(param.annotationFeed)$
-// TODO: Create RpcClientWriter for '$param.name$'
+$param.name$ = std::make_shared<$operation.name$_$param.name$_writer>(requester_, result);
 $else$
 request.$operation.name$->$param.name$ = $param.name$;
 $endif$
 %>
+
+input_feed_writer(operation, param) ::= <<
+struct $operation.name$_$param.name$_writer : public frpc::RpcClientWriter<$paramRetType(param.typecode)$>
+{
+    using FeedType = $operation.parent.name$_$operation.name$_$param.name$_Feed;
+
+    $operation.name$_$param.name$_writer(
+            frpc::Requester* requester,
+            std::shared_ptr<IReplyProcessor> result)
+        : requester_(requester)
+        , result_(result)
+    {
+    }
+
+    void write(
+            const $paramRetType(param.typecode)$& value) override
+    {
+        RequestType request;
+        request.$operation.name$_$param.name$ = FeedType{};
+        request.$operation.name$_$param.name$->value = value;
+        send_request(request);
+    }
+
+    void write(
+            $paramRetType(param.typecode)$&& value) override
+    {
+        RequestType request;
+        request.$operation.name$_$param.name$ = FeedType{};
+        request.$operation.name$_$param.name$->value = value;
+        send_request(request);
+    }
+
+    void finish(
+            frpc::RpcStatusCode reason = frpc::RPC_STATUS_CODE_OK) override
+    {
+        RequestType request;
+        request.$operation.name$_$param.name$ = FeedType{};
+        request.$operation.name$_$param.name$->finished_ = reason;
+        send_request(request);
+    }
+
+private:
+
+    void send_request(
+            const RequestType& request)
+    {
+        frpc::RequestInfo req_info = result_->info;
+        auto ret = requester_->send_request((void*)&request, req_info);
+        if (ret != fdds::RETCODE_OK)
+        {
+            if (ret == fdds::RETCODE_TIMEOUT)
+            {
+                throw frpc::RpcTimeoutException();
+            }
+            else
+            {
+                throw frpc::RpcBrokenPipeException(false);
+            }
+        }
+    }
+
+    frpc::Requester* requester_ = nullptr;
+    std::shared_ptr<IReplyProcessor> result_;
+};
+
+>>
 
 operation_result_exception(name) ::= <<
 if (result.$name$.has_value())

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -380,6 +380,7 @@ private:
                     promise.set_value($if(operation.rettype)$out.return_$endif$);
                     return;
                 }
+                $operation.exceptions : { exception |$operation_result_exception(name=[exception.formatedScopedname, "_ex"])$}; separator="\n"$
             }
 
             // If we reach this point, the reply is for another operation
@@ -408,3 +409,12 @@ $else$
 request.$operation.name$->$param.name$ = $param.name$;
 $endif$
 %>
+
+operation_result_exception(name) ::= <<
+if (result.$name$.has_value())
+{
+    promise.set_exception(
+        std::make_exception_ptr(result.$name$.value()));
+    return;
+}
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -68,7 +68,11 @@ namespace frtps = eprosima::fastdds::rtps;
 
 class $interface.name$Client : public $interface.name$
 {
+
+   using ReplyType = $interface.name$_Reply;
+
 public:
+
     $interface.name$Client(
             fdds::DomainParticipant& part,
             const char* service_name,
@@ -97,10 +101,16 @@ public:
         {
             throw std::runtime_error("Error creating requester");
         }
+
+        // Start the processing thread
+        start_thread();
     }
 
     ~$interface.name$Client() override
     {
+        // Stop the processing thread
+        stop_thread();
+
         // Destroy the requester
         if (nullptr != requester_)
         {
@@ -120,9 +130,53 @@ public:
 
 private:
 
+    void start_thread()
+    {
+        stop_thread_ = false;
+        processing_thread_ = std::thread(&$interface.name$Client::run, this);
+    }
+
+    void stop_thread()
+    {
+        stop_thread_ = true;
+        if (processing_thread_.joinable())
+        {
+            processing_thread_.join();
+        }
+    }
+
+    void run()
+    {
+        while (!stop_thread_)
+        {
+            // Wait for a reply
+            if (requester_->get_requester_reader()->wait_for_unread_message({ 0, 100000000 }))
+            {
+                // Take and process the reply
+                frpc::RequestInfo req_info;
+                ReplyType reply;
+                auto ret = requester_->take_reply(&reply, req_info);
+                if (ret == fdds::RETCODE_OK)
+                {
+                    process_reply(reply_, req_info);
+                }
+            }
+        }
+    }
+
+    void process_reply(
+            const ReplyType& reply,
+            const frpc::RequestInfo& req_info)
+    {
+        static_cast<void>(reply);
+        static_cast<void>(req_info);
+    }
+
     fdds::DomainParticipant& participant_;
     frpc::Service* service_ = nullptr;
     frpc::Requester* requester_ = nullptr;
+    std::atomic<bool> stop_thread_ = false;
+    std::thread processing_thread_;
 };
 
 }  // namespace detail

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -69,7 +69,8 @@ namespace frtps = eprosima::fastdds::rtps;
 class $interface.name$Client : public $interface.name$
 {
 
-   using ReplyType = $interface.name$_Reply;
+    using RequestType = $interface.name$_Request;
+    using ReplyType = $interface.name$_Reply;
 
 public:
 
@@ -158,7 +159,7 @@ private:
                 auto ret = requester_->take_reply(&reply, req_info);
                 if (ret == fdds::RETCODE_OK)
                 {
-                    process_reply(reply_, req_info);
+                    process_reply(reply, req_info);
                 }
             }
         }
@@ -168,15 +169,42 @@ private:
             const ReplyType& reply,
             const frpc::RequestInfo& req_info)
     {
-        static_cast<void>(reply);
-        static_cast<void>(req_info);
+        auto sample_id = req_info.related_sample_identity;
+        {
+            std::lock_guard<std::mutex> _(mtx_);
+            auto it = pending_results_.find(sample_id);
+            if (it != pending_results_.end())
+            {
+                bool should_erase = false;
+                it->second->process_reply(reply, req_info, should_erase);
+                if (should_erase)
+                {
+                    pending_results_.erase(it);
+                }
+            }
+        }
     }
+
+    struct IReplyProcessor
+    {
+        frpc::RequestInfo info;
+
+        virtual ~IReplyProcessor() = default;
+
+        virtual void process_reply(
+                const ReplyType& reply,
+                const frpc::RequestInfo& req_info,
+                bool& should_remove) = 0;
+
+    };
 
     fdds::DomainParticipant& participant_;
     frpc::Service* service_ = nullptr;
     frpc::Requester* requester_ = nullptr;
     std::atomic<bool> stop_thread_ = false;
     std::thread processing_thread_;
+    std::mutex mtx_;
+    std::map<frtps::SampleIdentity, std::shared_ptr<IReplyProcessor> > pending_results_;
 };
 
 }  // namespace detail

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -203,7 +203,7 @@ private:
     std::atomic<bool> stop_thread_ = false;
     std::thread processing_thread_;
     std::mutex mtx_;
-    std::map<frtps::SampleIdentity, std::shared_ptr<IReplyProcessor> > pending_results_;
+    std::map<frtps::SampleIdentity, std::shared_ptr<IReplyProcessor\>> pending_results_;
 
     //{ request helpers
 
@@ -247,7 +247,8 @@ std::shared_ptr<$interface.name$> create_$interface.name$Client(
 >>
 
 operation(ctx, parent, operation, param_list, operation_type) ::= <<
-//{ operation $operation.name$
+    //{ operation $operation.name$
+
 $if(operation.annotationFeed)$
 public:
 
@@ -256,6 +257,7 @@ public:
     {
         throw frpc::RemoteUnsupportedError("Not implemented");
     }
+
 $else$
 public:
 
@@ -302,16 +304,17 @@ private:
             promise.set_exception(
                 std::make_exception_ptr(frpc::RemoteUnsupportedError("Not implemented")));
         }
+
     };
 $endif$
 
-//} operation $operation.name$
+    //} operation $operation.name$
 
 >>
 
 operationRetType(operation) ::= <%
 $if(operation.annotationFeed)$
-std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$> >
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$>>
 $else$
 eprosima::fastdds::dds::rpc::RpcFuture<$paramRetType(operation.rettype)$>
 $endif$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -456,11 +456,11 @@ $if(operation.annotationFeed)$
         void set_exception(
                 std::exception_ptr exception)
         {
-            bool was_cancelled = cancelled_.exchange(true);
-            if (!was_cancelled)
+            std::lock_guard<std::mutex> _(mtx_);
+            if (!finished_)
             {
-                std::lock_guard<std::mutex> _(mtx_);
                 exception_ = exception;
+                finished_ = true;
                 cv_.notify_all();
             }
         }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -460,12 +460,13 @@ $if(operation.annotationFeed)$
         void cancel() override
         {
             bool old_cancelled = cancelled_.exchange(true);
-            if (old_cancelled)
+            if (!old_cancelled)
             {
-                return;
-            }
+                // Notify read calls that the operation was cancelled
+                cv_.notify_all();
 
-            // TODO: Communicate the cancellation to the server and wait for it to be acknowledged
+                // TODO: Communicate the cancellation to the server and wait for it to be acknowledged
+            }
         }
 
     private:

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -452,6 +452,9 @@ $if(operation.annotationFeed)$
                 }
                 $operation.exceptions : { exception |$operation_result_exception(name=[exception.formatedScopedname, "_ex"], receiver="(*this)")$}; separator="\n"$
             }
+
+            // If we reach this point, the reply is for another operation
+            set_invalid_reply(*this);
         }
 
         void set_exception(

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -383,6 +383,11 @@ $if(operation.annotationFeed)$
         bool read(
                 $paramRetType(operation.rettype)$& value) override
         {
+            if (cancelled_)
+            {
+                return false;
+            }
+
             // TODO: Read the value
             static_cast<void>(value);
             return false;
@@ -392,6 +397,11 @@ $if(operation.annotationFeed)$
                 $paramRetType(operation.rettype)$& value,
                 const fdds::Duration_t& timeout) override
         {
+            if (cancelled_)
+            {
+                return false;
+            }
+
             // TODO: Read the value
             static_cast<void>(value);
             static_cast<void>(timeout);
@@ -400,8 +410,18 @@ $if(operation.annotationFeed)$
 
         void cancel() override
         {
-            // TODO: Cancel the stream
+            bool old_cancelled = cancelled_.exchange(true);
+            if (old_cancelled)
+            {
+                return;
+            }
+
+            // TODO: Communicate the cancellation to the server and wait for it to be acknowledged
         }
+
+    private:
+
+        std::atomic<bool> cancelled_ = false;
 
     };
 $else$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -203,7 +203,7 @@ private:
     fdds::DomainParticipant& participant_;
     frpc::Service* service_ = nullptr;
     frpc::Requester* requester_ = nullptr;
-    std::atomic<bool> stop_thread_ = false;
+    std::atomic<bool> stop_thread_{false};
     std::thread processing_thread_;
     std::mutex mtx_;
     std::map<frtps::SampleIdentity, std::shared_ptr<IReplyProcessor\>> pending_results_;
@@ -580,7 +580,7 @@ $if(operation.annotationFeed)$
         }
 
         frpc::Requester* requester_ = nullptr;
-        std::atomic<bool> cancelled_ = false;
+        std::atomic<bool> cancelled_{false};
         std::exception_ptr exception_;
         std::queue<$paramRetType(operation.rettype)$> queue_;
         bool finished_ = false;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -422,36 +422,39 @@ $if(operation.annotationFeed)$
             bool was_cancelled = cancelled_.exchange(true);
             if (!was_cancelled)
             {
+                std::lock_guard<std::mutex> _(mtx_);
                 exception_ = exception;
+                cv_.notify_all();
             }
         }
 
         bool read(
                 $paramRetType(operation.rettype)$& value) override
         {
-            if (cancelled_)
+            bool ret_val = false;
+            std::unique_lock<std::mutex> lock(mtx_);
+            while (!try_read(value, ret_val))
             {
-                return false;
+                cv_.wait(lock);
             }
-
-            // TODO: Read the value
-            static_cast<void>(value);
-            return false;
+            return ret_val;
         }
 
         bool read(
                 $paramRetType(operation.rettype)$& value,
                 const fdds::Duration_t& timeout) override
         {
-            if (cancelled_)
+            bool ret_val = false;
+            std::unique_lock<std::mutex> lock(mtx_);
+            std::chrono::steady_clock::time_point end_time =
+                std::chrono::steady_clock::now() +
+                std::chrono::seconds(timeout.seconds) +
+                std::chrono::nanoseconds(timeout.nanosec);
+            while (!try_read(value, ret_val))
             {
-                return false;
+                cv_.wait_until(lock, end_time);
             }
-
-            // TODO: Read the value
-            static_cast<void>(value);
-            static_cast<void>(timeout);
-            return false;
+            return ret_val;
         }
 
         void cancel() override
@@ -467,10 +470,34 @@ $if(operation.annotationFeed)$
 
     private:
 
+        bool try_read(
+                $paramRetType(operation.rettype)$& value,
+                bool& ret_val)
+        {
+            if (exception_)
+            {
+                auto ex = exception_;
+                exception_ = nullptr;
+                std::rethrow_exception(ex);
+            }
+
+            if (cancelled_)
+            {
+                ret_val = false;
+                return true;
+            }
+
+            // TODO: Retrieve one value from the queue
+            return false;
+        }
+
         std::atomic<bool> cancelled_ = false;
         std::exception_ptr exception_;
+        std::mutex mtx_;
+        std::condition_variable cv_;
 
     };
+
 $else$
     struct $operation.name$_promise : public IReplyProcessor
     {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -23,6 +23,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "Client.cxx"], description=["Client im
 #include "$ctx.filename$Client.hpp"
 
 #include <atomic>
+#include <exception>
 #include <future>
 #include <map>
 #include <memory>
@@ -127,8 +128,6 @@ public:
         }
     }
 
-    $export_list$
-
 private:
 
     void start_thread()
@@ -205,6 +204,32 @@ private:
     std::thread processing_thread_;
     std::mutex mtx_;
     std::map<frtps::SampleIdentity, std::shared_ptr<IReplyProcessor> > pending_results_;
+
+    //{ request helpers
+
+    template<typename T>
+    auto send_request_with_promise(
+            const RequestType& request,
+            std::shared_ptr<T> result)
+    {
+        if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
+        {
+            std::lock_guard<std::mutex> _ (mtx_);
+            pending_results_[result->info.related_sample_identity] = result;
+        }
+        else
+        {
+            result->promise.set_exception(
+                std::make_exception_ptr(frpc::RpcBrokenPipeException(false)));
+        }
+
+        return result->promise.get_future();
+    }
+
+    //} request helpers
+
+$export_list$
+
 };
 
 }  // namespace detail
@@ -222,11 +247,65 @@ std::shared_ptr<$interface.name$> create_$interface.name$Client(
 >>
 
 operation(ctx, parent, operation, param_list, operation_type) ::= <<
-$operationRetType(operation)$ $operation.name$(
-        $paramDeclarations(params=operation.parameters)$) override
-{
-    throw frpc::RemoteUnsupportedError("Not implemented");
-}
+//{ operation $operation.name$
+$if(operation.annotationFeed)$
+public:
+
+    $operationRetType(operation)$ $operation.name$(
+            $paramDeclarations(params=operation.parameters)$) override
+    {
+        throw frpc::RemoteUnsupportedError("Not implemented");
+    }
+$else$
+public:
+
+    $operationRetType(operation)$ $operation.name$(
+            $paramDeclarations(params=operation.parameters)$) override
+    {
+        // Create a promise to hold the result
+        auto result = std::make_shared<$operation.name$_promise>();
+        $if(operation.outputparam)$
+        $operation.outputparam:{param | result->$param.name$ = &$param.name$;}; separator="\n"$
+        $endif$
+
+        // Create and send the request
+        RequestType request;
+        request.$operation.name$ = $parent.name$_$operation.name$_In{};
+        $if(operation.inputparam)$
+        $operation.inputparam:{param | $fill_input_param(operation, param)$}; separator="\n"$
+        $endif$
+
+        return send_request_with_promise(request, result);
+    }
+
+private:
+
+    struct $operation.name$_promise : public IReplyProcessor
+    {
+        std::promise<$paramRetType(operation.rettype)$> promise;
+        $if(operation.outputparam)$
+        $operation.outputparam:{param | $param.typecode.cppTypename$* $param.name$ = nullptr;}; separator="\n"$
+        $endif$
+
+        void process_reply(
+                const ReplyType& reply,
+                const frpc::RequestInfo& req_info,
+                bool& should_remove) override
+        {
+            should_remove = false;
+            if (req_info.related_sample_identity != info.related_sample_identity)
+            {
+                return;
+            }
+
+            should_remove = true;
+            promise.set_exception(
+                std::make_exception_ptr(frpc::RemoteUnsupportedError("Not implemented")));
+        }
+    };
+$endif$
+
+//} operation $operation.name$
 
 >>
 
@@ -235,5 +314,13 @@ $if(operation.annotationFeed)$
 std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$> >
 $else$
 eprosima::fastdds::dds::rpc::RpcFuture<$paramRetType(operation.rettype)$>
+$endif$
+%>
+
+fill_input_param(operation, param) ::= <%
+$if(param.annotationFeed)$
+// TODO: Create RpcClientWriter for '$param.name$'
+$else$
+request.$operation.name$->$param.name$ = $param.name$;
 $endif$
 %>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -240,7 +240,8 @@ private:
         }
         else
         {
-            // TODO: Add broken pipe to the reader queue
+            result->set_exception(
+                std::make_exception_ptr(frpc::RpcBrokenPipeException(false)));
         }
 
         return result;
@@ -252,10 +253,46 @@ private:
 
     template<typename T>
     static void set_invalid_reply(
-            std::promise<T>& promise)
+            T& exception_receiver)
     {
-        promise.set_exception(
+        exception_receiver.set_exception(
             std::make_exception_ptr(frpc::RemoteInvalidArgumentError("An invalid reply was received")));
+    }
+
+    template<typename T>
+    static void set_remote_exception(
+            T& exception_receiver,
+            const frpc::RemoteExceptionCode_t& exception)
+    {
+        switch (exception)
+        {
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_OK:
+                set_invalid_reply(exception_receiver);
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_UNSUPPORTED:
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteUnsupportedError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT:
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteInvalidArgumentError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_OUT_OF_RESOURCES:
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteOutOfResourcesError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION:
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteUnknownOperationError()));
+                break;
+            default: // REMOTE_EX_UNKNOWN_EXCEPTION
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteUnknownExceptionError()));
+                break;
+        }
+    }
+
+    static size_t count_reply_fields(
+            const ReplyType& reply)
+    {
+        size_t n_fields = 0;
+        $interface.replyTypeCode.members:{member | n_fields += reply.$member.name$.has_value() ? 1 : 0;}; separator="\n"$
+        return n_fields;
     }
 
     template<typename T>
@@ -264,9 +301,7 @@ private:
             const ReplyType& reply)
     {
         // Check if the reply has one and only one field set
-        size_t n_fields = 0;
-        $interface.replyTypeCode.members:{member | n_fields += reply.$member.name$.has_value() ? 1 : 0;}; separator="\n"$
-
+        size_t n_fields = count_reply_fields(reply);
         if (n_fields != 1u)
         {
             set_invalid_reply(promise);
@@ -276,32 +311,26 @@ private:
         return true;
     }
 
-    template<typename T>
-    static void set_promise_exception(
-            std::promise<T>& promise,
-            const frpc::RemoteExceptionCode_t& exception)
+    struct IExceptionHolder
     {
-        switch (exception)
+        virtual ~IExceptionHolder() = default;
+
+        virtual void set_exception(
+                std::exception_ptr exception) = 0;
+    };
+
+    static bool validate_reply(
+            IExceptionHolder& reader,
+            const ReplyType& reply)
+    {
+        // Check if the reply has one and only one field set
+        size_t n_fields = count_reply_fields(reply);
+        if (n_fields != 1u)
         {
-            case frpc::RemoteExceptionCode_t::REMOTE_EX_OK:
-                set_invalid_reply(promise);
-                break;
-            case frpc::RemoteExceptionCode_t::REMOTE_EX_UNSUPPORTED:
-                promise.set_exception(std::make_exception_ptr(frpc::RemoteUnsupportedError()));
-                break;
-            case frpc::RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT:
-                promise.set_exception(std::make_exception_ptr(frpc::RemoteInvalidArgumentError()));
-                break;
-            case frpc::RemoteExceptionCode_t::REMOTE_EX_OUT_OF_RESOURCES:
-                promise.set_exception(std::make_exception_ptr(frpc::RemoteOutOfResourcesError()));
-                break;
-            case frpc::RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION:
-                promise.set_exception(std::make_exception_ptr(frpc::RemoteUnknownOperationError()));
-                break;
-            default: // REMOTE_EX_UNKNOWN_EXCEPTION
-                promise.set_exception(std::make_exception_ptr(frpc::RemoteUnknownExceptionError()));
-                break;
+            set_invalid_reply(reader);
+            return false;
         }
+        return true;
     }
 
     //} reply helpers
@@ -363,6 +392,7 @@ $if(operation.annotationFeed)$
     struct $operation.name$_reader
         : public frpc::RpcClientReader<$paramRetType(operation.rettype)$>
         , public IReplyProcessor
+        , public IExceptionHolder
     {
         void process_reply(
                 const ReplyType& reply,
@@ -370,14 +400,30 @@ $if(operation.annotationFeed)$
                 bool& should_remove) override
         {
             should_remove = false;
-            if (req_info.related_sample_identity != info.related_sample_identity)
+            if (cancelled_ ||
+                (req_info.related_sample_identity != info.related_sample_identity))
             {
                 return;
             }
 
             should_remove = true;
+            if (!validate_reply(*this, reply))
+            {
+                return;
+            }
+
             // TODO: Process the reply
             static_cast<void>(reply);
+        }
+
+        void set_exception(
+                std::exception_ptr exception)
+        {
+            bool was_cancelled = cancelled_.exchange(true);
+            if (!was_cancelled)
+            {
+                exception_ = exception;
+            }
         }
 
         bool read(
@@ -422,6 +468,7 @@ $if(operation.annotationFeed)$
     private:
 
         std::atomic<bool> cancelled_ = false;
+        std::exception_ptr exception_;
 
     };
 $else$
@@ -451,7 +498,7 @@ $else$
 
             if (reply.remoteEx.has_value())
             {
-                set_promise_exception(promise, reply.remoteEx.value());
+                set_remote_exception(promise, reply.remoteEx.value());
                 return;
             }
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -1,0 +1,54 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group ProtocolHeader;
+
+import "eprosima.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Client.cxx"], description=["Client implementation for interfaces"])$
+
+#include "$ctx.filename$Client.hpp"
+
+#include <memory>
+#include <string>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/qos/RequesterQos.hpp>
+
+$definitions; separator="\n"$
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+
+$definition_list$
+
+} // namespace $module.name$
+
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+std::shared_ptr<$interface.name$> create_$interface.name$Client(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::RequesterQos& qos)
+{
+    static_cast<void>(part);
+    static_cast<void>(service_name);
+    static_cast<void>(qos);
+    return std::shared_ptr<$interface.name$>{};
+}
+
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -210,10 +210,11 @@ private:
 
     //{ request helpers
 
-    template<typename T>
-    auto send_request_with_promise(
+    template<typename T, typename TResult>
+    std::future<TResult> send_request_with_promise(
             const RequestType& request,
-            std::shared_ptr<T> result)
+            std::shared_ptr<T> result,
+            std::promise<TResult>& promise)
     {
         if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
         {
@@ -222,11 +223,11 @@ private:
         }
         else
         {
-            result->promise.set_exception(
+            promise.set_exception(
                 std::make_exception_ptr(frpc::RpcBrokenPipeException(false)));
         }
 
-        return result->promise.get_future();
+        return promise.get_future();
     }
 
     template<typename T>
@@ -383,7 +384,7 @@ $endif$
 $if(operation.annotationFeed)$
         return send_request_with_reader(request, result);
 $else$
-        return send_request_with_promise(request, result);
+        return send_request_with_promise(request, result, result->promise);
 $endif$
     }
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -15,17 +15,35 @@
 group ProtocolHeader;
 
 import "eprosima.stg"
+import "com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg"
 
 main(ctx, definitions) ::= <<
 $fileHeader(ctx=ctx,  file=[ctx.filename, "Client.cxx"], description=["Client implementation for interfaces"])$
 
 #include "$ctx.filename$Client.hpp"
 
+#include <atomic>
+#include <future>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <stdexcept>
 #include <string>
+#include <thread>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/qos/RequesterQos.hpp>
+#include <fastdds/dds/rpc/exceptions.hpp>
+#include <fastdds/dds/rpc/interfaces.hpp>
+#include <fastdds/dds/rpc/RequestInfo.hpp>
+#include <fastdds/dds/rpc/Requester.hpp>
+#include <fastdds/dds/rpc/Service.hpp>
+#include <fastdds/dds/rpc/ServiceTypeSupport.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
+
+#include "$ctx.filename$.hpp"
+#include "$ctx.filename$_details.hpp"
+#include "$ctx.filename$PubSubTypes.hpp"
 
 $definitions; separator="\n"$
 >>
@@ -40,15 +58,100 @@ $definition_list$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+//{ interface $interface.name$
+
+namespace detail {
+
+namespace fdds = eprosima::fastdds::dds;
+namespace frpc = eprosima::fastdds::dds::rpc;
+namespace frtps = eprosima::fastdds::rtps;
+
+class $interface.name$Client : public $interface.name$
+{
+public:
+    $interface.name$Client(
+            fdds::DomainParticipant& part,
+            const char* service_name,
+            const fdds::RequesterQos& qos)
+        : $interface.name$()
+        , participant_(part)
+    {
+        // Register the service type support
+        auto service_type = create_$interface.name$_service_type_support();
+        auto ret = service_type.register_service_type(&participant_, "$interface.scopedname$");
+        if (ret != fdds::RETCODE_OK)
+        {
+            throw std::runtime_error("Error registering service type");
+        }
+
+        // Create the service
+        service_ = participant_.create_service(service_name, "$interface.scopedname$");
+        if (nullptr == service_)
+        {
+            throw std::runtime_error("Error creating service");
+        }
+
+        // Create the requester
+        requester_ = participant_.create_service_requester(service_, qos);
+        if (nullptr == requester_)
+        {
+            throw std::runtime_error("Error creating requester");
+        }
+    }
+
+    ~$interface.name$Client() override
+    {
+        // Destroy the requester
+        if (nullptr != requester_)
+        {
+            participant_.delete_service_requester(service_->get_service_name(), requester_);
+            requester_ = nullptr;
+        }
+
+        // Destroy the service
+        if (nullptr != service_)
+        {
+            participant_.delete_service(service_);
+            service_ = nullptr;
+        }
+    }
+
+    $export_list$
+
+private:
+
+    fdds::DomainParticipant& participant_;
+    frpc::Service* service_ = nullptr;
+    frpc::Requester* requester_ = nullptr;
+};
+
+}  // namespace detail
+
 std::shared_ptr<$interface.name$> create_$interface.name$Client(
         eprosima::fastdds::dds::DomainParticipant& part,
         const char* service_name,
         const eprosima::fastdds::dds::RequesterQos& qos)
 {
-    static_cast<void>(part);
-    static_cast<void>(service_name);
-    static_cast<void>(qos);
-    return std::shared_ptr<$interface.name$>{};
+    return std::make_shared<detail::$interface.name$Client>(part, service_name, qos);
+}
+
+//} interface $interface.name$Client
+
+>>
+
+operation(ctx, parent, operation, param_list, operation_type) ::= <<
+$operationRetType(operation)$ $operation.name$(
+        $paramDeclarations(params=operation.parameters)$) override
+{
+    throw frpc::RemoteUnsupportedError("Not implemented");
 }
 
 >>
+
+operationRetType(operation) ::= <%
+$if(operation.annotationFeed)$
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$> >
+$else$
+eprosima::fastdds::dds::rpc::RpcFuture<$paramRetType(operation.rettype)$>
+$endif$
+%>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -28,6 +28,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "Client.cxx"], description=["Client im
 #include <map>
 #include <memory>
 #include <mutex>
+#include <queue>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -412,8 +413,44 @@ $if(operation.annotationFeed)$
                 return;
             }
 
-            // TODO: Process the reply
-            static_cast<void>(reply);
+            if (reply.remoteEx.has_value())
+            {
+                set_remote_exception(*this, reply.remoteEx.value());
+                return;
+            }
+
+            if (reply.$operation.name$.has_value())
+            {
+                const auto& result = reply.$operation.name$.value();
+                if (result.result.has_value())
+                {
+                    const auto& out = result.result.value();
+                    {
+                        if (out.return_.has_value())
+                        {
+                            // Store the return value
+                            std::lock_guard<std::mutex> _(mtx_);
+                            queue_.push(out.return_.value());
+                            cv_.notify_all();
+
+                            // Should be kept in order to receive further values
+                            should_remove = false;
+                        }
+                        else if (out.finished_.has_value())
+                        {
+                            // Store the finished value
+                            std::lock_guard<std::mutex> _(mtx_);
+                            finished_ = true;
+                            cv_.notify_all();
+                        }
+                        else
+                        {
+                            set_invalid_reply(*this);
+                        }
+                    }
+                    return;
+                }
+            }
         }
 
         void set_exception(
@@ -475,6 +512,7 @@ $if(operation.annotationFeed)$
                 $paramRetType(operation.rettype)$& value,
                 bool& ret_val)
         {
+            // Throw the exception if it was set
             if (exception_)
             {
                 auto ex = exception_;
@@ -482,18 +520,37 @@ $if(operation.annotationFeed)$
                 std::rethrow_exception(ex);
             }
 
+            // Early exit if the operation was cancelled
             if (cancelled_)
             {
                 ret_val = false;
                 return true;
             }
 
-            // TODO: Retrieve one value from the queue
+            // Retrieve one value from the queue
+            if (!queue_.empty())
+            {
+                value = queue_.front();
+                queue_.pop();
+                ret_val = true;
+                return true;
+            }
+
+            // Check if the operation was finished
+            if (finished_)
+            {
+                ret_val = false;
+                return true;
+            }
+
+            // Need to wait for a new value
             return false;
         }
 
         std::atomic<bool> cancelled_ = false;
         std::exception_ptr exception_;
+        std::queue<$paramRetType(operation.rettype)$> queue_;
+        bool finished_ = false;
         std::mutex mtx_;
         std::condition_variable cv_;
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -228,6 +228,64 @@ private:
 
     //} request helpers
 
+    //{ reply helpers
+
+    template<typename T>
+    static void set_invalid_reply(
+            std::promise<T>& promise)
+    {
+        promise.set_exception(
+            std::make_exception_ptr(frpc::RemoteInvalidArgumentError("An invalid reply was received")));
+    }
+
+    template<typename T>
+    static bool validate_reply(
+            std::promise<T>& promise,
+            const ReplyType& reply)
+    {
+        // Check if the reply has one and only one field set
+        size_t n_fields = 0;
+        $interface.replyTypeCode.members:{member | n_fields += reply.$member.name$.has_value() ? 1 : 0;}; separator="\n"$
+
+        if (n_fields != 1u)
+        {
+            set_invalid_reply(promise);
+            return false;
+        }
+
+        return true;
+    }
+
+    template<typename T>
+    static void set_promise_exception(
+            std::promise<T>& promise,
+            const frpc::RemoteExceptionCode_t& exception)
+    {
+        switch (exception)
+        {
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_OK:
+                set_invalid_reply(promise);
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_UNSUPPORTED:
+                promise.set_exception(std::make_exception_ptr(frpc::RemoteUnsupportedError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT:
+                promise.set_exception(std::make_exception_ptr(frpc::RemoteInvalidArgumentError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_OUT_OF_RESOURCES:
+                promise.set_exception(std::make_exception_ptr(frpc::RemoteOutOfResourcesError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION:
+                promise.set_exception(std::make_exception_ptr(frpc::RemoteUnknownOperationError()));
+                break;
+            default: // REMOTE_EX_UNKNOWN_EXCEPTION
+                promise.set_exception(std::make_exception_ptr(frpc::RemoteUnknownExceptionError()));
+                break;
+        }
+    }
+
+    //} reply helpers
+
 $export_list$
 
 };
@@ -301,8 +359,31 @@ private:
             }
 
             should_remove = true;
-            promise.set_exception(
-                std::make_exception_ptr(frpc::RemoteUnsupportedError("Not implemented")));
+            if (!validate_reply(promise, reply))
+            {
+                return;
+            }
+
+            if (reply.remoteEx.has_value())
+            {
+                set_promise_exception(promise, reply.remoteEx.value());
+                return;
+            }
+
+            if (reply.$operation.name$.has_value())
+            {
+                const auto& result = reply.$operation.name$.value();
+                if (result.result.has_value())
+                {
+                    const auto& out = result.result.value();
+                    $operation.outputparam:{param | *$param.name$ = out.$param.name$;}; separator="\n"$
+                    promise.set_value($if(operation.rettype)$out.return_$endif$);
+                    return;
+                }
+            }
+
+            // If we reach this point, the reply is for another operation
+            set_invalid_reply(promise);
         }
 
     };

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -450,6 +450,7 @@ $if(operation.annotationFeed)$
                     }
                     return;
                 }
+                $operation.exceptions : { exception |$operation_result_exception(name=[exception.formatedScopedname, "_ex"], receiver="(*this)")$}; separator="\n"$
             }
         }
 
@@ -597,7 +598,7 @@ $else$
                     promise.set_value($if(operation.rettype)$out.return_$endif$);
                     return;
                 }
-                $operation.exceptions : { exception |$operation_result_exception(name=[exception.formatedScopedname, "_ex"])$}; separator="\n"$
+                $operation.exceptions : { exception |$operation_result_exception(name=[exception.formatedScopedname, "_ex"], receiver="promise")$}; separator="\n"$
             }
 
             // If we reach this point, the reply is for another operation
@@ -696,10 +697,10 @@ private:
 
 >>
 
-operation_result_exception(name) ::= <<
+operation_result_exception(name, receiver) ::= <<
 if (result.$name$.has_value())
 {
-    promise.set_exception(
+    $receiver$.set_exception(
         std::make_exception_ptr(result.$name$.value()));
     return;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -226,6 +226,24 @@ private:
         return result->promise.get_future();
     }
 
+    template<typename T>
+    std::shared_ptr<T> send_request_with_reader(
+            const RequestType& request,
+            std::shared_ptr<T> result)
+    {
+        if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
+        {
+            std::lock_guard<std::mutex> _ (mtx_);
+            pending_results_[result->info.related_sample_identity] = result;
+        }
+        else
+        {
+            // TODO: Add broken pipe to the reader queue
+        }
+
+        return result;
+    }
+
     //} request helpers
 
     //{ reply helpers
@@ -307,26 +325,21 @@ std::shared_ptr<$interface.name$> create_$interface.name$Client(
 operation(ctx, parent, operation, param_list, operation_type) ::= <<
     //{ operation $operation.name$
 
+public:
+
+    $operationRetType(operation)$ $operation.name$(
+            $paramDeclarations(params=operation.parameters)$) override
+    {
 $if(operation.annotationFeed)$
-public:
-
-    $operationRetType(operation)$ $operation.name$(
-            $paramDeclarations(params=operation.parameters)$) override
-    {
-        throw frpc::RemoteUnsupportedError("Not implemented");
-    }
-
+        // Create a reader to hold the result
+        auto result = std::make_shared<$operation.name$_reader>();
 $else$
-public:
-
-    $operationRetType(operation)$ $operation.name$(
-            $paramDeclarations(params=operation.parameters)$) override
-    {
         // Create a promise to hold the result
         auto result = std::make_shared<$operation.name$_promise>();
         $if(operation.outputparam)$
         $operation.outputparam:{param | result->$param.name$ = &$param.name$;}; separator="\n"$
         $endif$
+$endif$
 
         // Create and send the request
         RequestType request;
@@ -335,11 +348,61 @@ public:
         $operation.inputparam:{param | $fill_input_param(operation, param)$}; separator="\n"$
         $endif$
 
+$if(operation.annotationFeed)$
+        return send_request_with_reader(request, result);
+$else$
         return send_request_with_promise(request, result);
+$endif$
     }
 
 private:
 
+$if(operation.annotationFeed)$
+    struct $operation.name$_reader
+        : public frpc::RpcClientReader<$paramRetType(operation.rettype)$>
+        , public IReplyProcessor
+    {
+        void process_reply(
+                const ReplyType& reply,
+                const frpc::RequestInfo& req_info,
+                bool& should_remove) override
+        {
+            should_remove = false;
+            if (req_info.related_sample_identity != info.related_sample_identity)
+            {
+                return;
+            }
+
+            should_remove = true;
+            // TODO: Process the reply
+            static_cast<void>(reply);
+        }
+
+        bool read(
+                $paramRetType(operation.rettype)$& value) override
+        {
+            // TODO: Read the value
+            static_cast<void>(value);
+            return false;
+        }
+
+        bool read(
+                $paramRetType(operation.rettype)$& value,
+                const fdds::Duration_t& timeout) override
+        {
+            // TODO: Read the value
+            static_cast<void>(value);
+            static_cast<void>(timeout);
+            return false;
+        }
+
+        void cancel() override
+        {
+            // TODO: Cancel the stream
+        }
+
+    };
+$else$
     struct $operation.name$_promise : public IReplyProcessor
     {
         std::promise<$paramRetType(operation.rettype)$> promise;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -59,6 +59,7 @@ $interface.all_operations : { operation | $operation_details(interface, operatio
 struct $interface.name$_Request
 {
     $interface.all_operations : { operation | $operation_request_members(interface, operation)$ }; separator="\n"$
+    $if(interface.withOutputFeeds)$eprosima::fastcdr::optional<bool\> feed_cancel_;$endif$
 };
 
 struct $interface.name$_Reply


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This generates the code for a client to consume an interface.

Depends on:
* https://github.com/eProsima/Fast-DDS/pull/5760

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- __NO__: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
    - Will add tests when we also have the service code generation
- __NO__: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Will do a final documentation PR for the whole feature
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
