### PR TITLE
[23094] Escape folder separator in generated `CMakeLists.txt`

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -957,6 +957,7 @@ public class fastddsgen
                                 Utils.writeFile(output_dir + ctx.getFilename() + ".i",
                                     maintemplates.getTemplate("com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg"), m_replace))
                         {
+                            project.setSwigInterfaceFile(relative_dir + ctx.getFilename() + ".i");
                         }
                     }
                 }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
@@ -80,13 +80,13 @@ pub_sub_execs(project, libraries, test) ::= <<
 
 message(STATUS "Configuring $project.name$...")
 $if(!project.commonSrcFiles.empty)$
-add_library($project.name$_lib $project.commonSrcFiles : { file | $file$}; separator=" "$)
-target_link_libraries($project.name$_lib $libraries : { library | $library$}; separator=" "$)
+add_library($project.name$_lib $project.commonSrcFiles; separator=" "$)
+target_link_libraries($project.name$_lib $libraries; separator=" "$)
 $endif$
 
 $if(!project.projectSrcFiles.empty)$
-add_executable($project.name$ $project.projectSrcFiles : { file | $file$}; separator=" "$)
-target_link_libraries($project.name$ $libraries : { library | $library$}; separator=" "$
+add_executable($project.name$ $project.projectSrcFiles; separator=" "$)
+target_link_libraries($project.name$ $libraries; separator=" "$
         $project.name$_lib $project.dependencies : { dep | $dep$_lib}; separator=" "$
         )
 $endif$
@@ -104,11 +104,11 @@ include(GoogleTest)
 
 # $project.name$ Serialization Test
 add_executable($project.name$SerializationTest
-        $project.commonTestingFiles : { file | $file$}; separator="\n"$
+        $project.commonTestingFiles; separator="\n"$
 )
 target_link_libraries($project.name$SerializationTest
         GTest::gtest_main
-        $libraries : { library | $library$}; separator=" "$
+        $libraries; separator=" "$
         $project.name$_lib $project.dependencies : { dep | $dep$_lib}; separator=" "$
         )
 gtest_discover_tests($project.name$SerializationTest)
@@ -122,11 +122,11 @@ type_object_tests(project, libraries) ::= <<
 $if(project.typeObjectTestingFiles)$
 # $project.name$ TypeObject Test
 add_executable($project.name$TypeObjectTestingTest
-        $project.typeObjectTestingFiles : { file | $file$}; separator="\n"$
+        $project.typeObjectTestingFiles; separator="\n"$
 )
 target_link_libraries($project.name$TypeObjectTestingTest
         GTest::gtest_main
-        $libraries : { library | $library$}; separator=" "$
+        $libraries; separator=" "$
         $project.name$_lib $project.dependencies : { dep | $dep$_lib}; separator=" "$)
 gtest_discover_tests($project.name$TypeObjectTestingTest)
 $endif$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/CMakeLists.stg
@@ -79,13 +79,13 @@ $endif$
 pub_sub_execs(project, libraries, test) ::= <<
 
 message(STATUS "Configuring $project.name$...")
-$if(!project.commonSrcFiles.empty)$
-add_library($project.name$_lib $project.commonSrcFiles; separator=" "$)
+$if(!project.commonSrcFiles_escaped.empty)$
+add_library($project.name$_lib $project.commonSrcFiles_escaped; separator=" "$)
 target_link_libraries($project.name$_lib $libraries; separator=" "$)
 $endif$
 
-$if(!project.projectSrcFiles.empty)$
-add_executable($project.name$ $project.projectSrcFiles; separator=" "$)
+$if(!project.projectSrcFiles_escaped.empty)$
+add_executable($project.name$ $project.projectSrcFiles_escaped; separator=" "$)
 target_link_libraries($project.name$ $libraries; separator=" "$
         $project.name$_lib $project.dependencies : { dep | $dep$_lib}; separator=" "$
         )
@@ -104,7 +104,7 @@ include(GoogleTest)
 
 # $project.name$ Serialization Test
 add_executable($project.name$SerializationTest
-        $project.commonTestingFiles; separator="\n"$
+        $project.commonTestingFiles_escaped; separator="\n"$
 )
 target_link_libraries($project.name$SerializationTest
         GTest::gtest_main
@@ -119,10 +119,10 @@ $endif$
 >>
 
 type_object_tests(project, libraries) ::= <<
-$if(project.typeObjectTestingFiles)$
+$if(project.typeObjectTestingFiles_escaped)$
 # $project.name$ TypeObject Test
 add_executable($project.name$TypeObjectTestingTest
-        $project.typeObjectTestingFiles; separator="\n"$
+        $project.typeObjectTestingFiles_escaped; separator="\n"$
 )
 target_link_libraries($project.name$TypeObjectTestingTest
         GTest::gtest_main

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -92,7 +92,7 @@ set(\${PROJECT_NAME}_MODULE
     )
 
 set(\${PROJECT_NAME}_MODULE_FILES
-    \${PROJECT_NAME}.i
+    $project.swigInterfaceFile_escaped$
     )
 
 SET_SOURCE_FILES_PROPERTIES(

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SwigCMake.stg
@@ -51,8 +51,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #Create library for C++ types
 add_library(\${PROJECT_NAME} SHARED
-        $project.commonSrcFiles : { file | $file$}; separator="\n"$
-        $project.projectSrcFiles : { file | $file$}; separator="\n"$
+        $project.commonSrcFiles_escaped; separator="\n"$
+        $project.projectSrcFiles_escaped; separator="\n"$
         )
 if(WIN32)
     target_compile_definitions(\${PROJECT_NAME} PRIVATE EPROSIMA_USER_DLL_EXPORT)

--- a/src/main/java/com/eprosima/fastdds/solution/Project.java
+++ b/src/main/java/com/eprosima/fastdds/solution/Project.java
@@ -40,6 +40,55 @@ public class Project extends com.eprosima.solution.Project
         ctx_ = ctx;
     }
 
+    // Escaped getters for base class getters
+    public ArrayList<String> getCommonSrcFiles_escaped()
+    {
+        ArrayList<String> base_files = super.getCommonSrcFiles();
+        ArrayList<String> escaped = new ArrayList<String>();
+        for(int count = 0; count < base_files.size(); ++count)
+        {
+            String file = (String)base_files.get(count);
+            escaped.add(file.replace("\\", "/"));
+        }
+        return escaped;
+    }
+
+    public ArrayList<String> getCommonIncludeFiles_escaped()
+    {
+        ArrayList<String> base_files = super.getCommonIncludeFiles();
+        ArrayList<String> escaped = new ArrayList<String>();
+        for(int count = 0; count < base_files.size(); ++count)
+        {
+            String file = (String)base_files.get(count);
+            escaped.add(file.replace("\\", "/"));
+        }
+        return escaped;
+    }
+
+    public ArrayList<String> getCommonTestingFiles_escaped()
+    {
+        ArrayList<String> base_files = super.getCommonTestingFiles();
+        ArrayList<String> escaped = new ArrayList<String>();
+        for(int count = 0; count < base_files.size(); ++count)
+        {
+            String file = (String)base_files.get(count);
+            escaped.add(file.replace("\\", "/"));
+        }
+        return escaped;
+    }
+
+    public ArrayList<String> getTypeObjectTestingFiles_escaped()
+    {
+        ArrayList<String> base_files = super.getTypeObjectTestingFiles();
+        ArrayList<String> escaped = new ArrayList<String>();
+        for(int count = 0; count < base_files.size(); ++count)
+        {
+            String file = (String)base_files.get(count);
+            escaped.add(file.replace("\\", "/"));
+        }
+        return escaped;
+    }
+
     public void addSubscriberSrcFile(String file)
     {
         m_subscribersrcfiles.add(file);
@@ -48,6 +97,17 @@ public class Project extends com.eprosima.solution.Project
     public ArrayList getSubscriberSrcFiles()
     {
         return m_subscribersrcfiles;
+    }
+
+    public ArrayList getSubscriberSrcFiles_escaped()
+    {
+        ArrayList<String> escaped = new ArrayList<String>();
+        for(int count = 0; count < m_subscribersrcfiles.size(); ++count)
+        {
+            String file = (String)m_subscribersrcfiles.get(count);
+            escaped.add(file.replace("\\", "/"));
+        }
+        return escaped;
     }
 
     public void addSubscriberIncludeFile(String file)
@@ -68,6 +128,17 @@ public class Project extends com.eprosima.solution.Project
     public ArrayList getPublisherSrcFiles()
     {
         return m_publishersrcfiles;
+    }
+
+    public ArrayList getPublisherSrcFiles_escaped()
+    {
+        ArrayList<String> escaped = new ArrayList<String>();
+        for(int count = 0; count < m_publishersrcfiles.size(); ++count)
+        {
+            String file = (String)m_publishersrcfiles.get(count);
+            escaped.add(file.replace("\\", "/"));
+        }
+        return escaped;
     }
 
     public void addPublisherIncludeFile(String file)
@@ -100,6 +171,17 @@ public class Project extends com.eprosima.solution.Project
         return m_projectsrcfiles;
     }
 
+    public ArrayList getProjectSrcFiles_escaped()
+    {
+        ArrayList<String> escaped = new ArrayList<String>();
+        for(int count = 0; count < m_projectsrcfiles.size(); ++count)
+        {
+            String file = (String)m_projectsrcfiles.get(count);
+            escaped.add(file.replace("\\", "/"));
+        }
+        return escaped;
+    }
+
     public void addJniSrcFile(String file)
     {
         m_jnisrcfiles.add(file);
@@ -108,6 +190,17 @@ public class Project extends com.eprosima.solution.Project
     public ArrayList<String> getJniSrcFiles()
     {
         return m_jnisrcfiles;
+    }
+
+    public ArrayList<String> getJniSrcFiles_escaped()
+    {
+        ArrayList<String> escaped = new ArrayList<String>();
+        for(int count = 0; count < m_jnisrcfiles.size(); ++count)
+        {
+            String file = (String)m_jnisrcfiles.get(count);
+            escaped.add(file.replace("\\", "/"));
+        }
+        return escaped;
     }
 
     public void addJniIncludeFile(String file)

--- a/src/main/java/com/eprosima/fastdds/solution/Project.java
+++ b/src/main/java/com/eprosima/fastdds/solution/Project.java
@@ -312,6 +312,21 @@ public class Project extends com.eprosima.solution.Project
         return ctx_;
     }
 
+    public void setSwigInterfaceFile(String file)
+    {
+        m_swiginterfacefile = file;
+    }
+
+    public String getSwigInterfaceFile()
+    {
+        return m_swiginterfacefile;
+    }
+
+    public String getSwigInterfaceFile_escaped()
+    {
+        return m_swiginterfacefile.replace("\\", "/");
+    }
+
     private boolean m_containsInterfaces = false;
     private ArrayList<String> m_subscribersrcfiles = null;
     private ArrayList<String> m_subscriberincludefiles = null;
@@ -324,6 +339,7 @@ public class Project extends com.eprosima.solution.Project
     private ArrayList<String> m_jnisrcfiles = null;
     private ArrayList<String> m_jniincludefiles = null;
     private ArrayList<String> m_idlincludefiles = null;
+    private String m_swiginterfacefile = null;
     String m_guid = null;
 
     private Context ctx_ = null;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Fixes a bug in Windows when generating `CMakeLists.txt`

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x (not sure if all, only those supporting relative dir generation)

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
    - Affects only Windows, where we currently have no CI
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
