### PR TITLE
[23153] Generate code for interfaces and support `@nested`

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -28,7 +28,7 @@ $typecode.cppTypename$&
 
 paramTypeByValue(typecode, feed) ::= <%
 $if(feed)$
-std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientWriter<$typecode.cppTypename$> >&
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientWriter<$typecode.cppTypename$>>&
 $else$
 $if(typecode.primitive)$
 $typecode.cppTypename$

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -26,9 +26,13 @@ paramTypeByRef(typecode) ::= <%
 $typecode.cppTypename$&
 %>
 
-paramTypeByValue(typecode, feed) ::= <%
+paramTypeByValue(typecode, feed, is_server) ::= <%
 $if(feed)$
+$if(is_server)$
+eprosima::fastdds::dds::rpc::RpcServerReader<$typecode.cppTypename$>&
+$else$
 std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientWriter<$typecode.cppTypename$>>&
+$endif$
 $else$
 $if(typecode.primitive)$
 $typecode.cppTypename$
@@ -39,7 +43,7 @@ $endif$
 %>
 
 paramDeclarations(params, initialSeparator="") ::= <<
-$if(params)$$initialSeparator$$endif$$params : {param | /*$param.comment$*/ $if(param.output)$$paramTypeByRef(typecode=param.typecode)$$else$$paramTypeByValue(typecode=param.typecode, feed=param.annotationFeed)$$endif$ $param.name$}; anchor, separator=",\n"$
+$if(params)$$initialSeparator$$endif$$params : {param | /*$param.comment$*/ $if(param.output)$$paramTypeByRef(typecode=param.typecode)$$else$$paramTypeByValue(typecode=param.typecode, feed=param.annotationFeed, is_server=false)$$endif$ $param.name$}; anchor, separator=",\n"$
 >>
 
 object_serialization(ctx, object) ::= <<

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -14,6 +14,34 @@
 
 group FastCdrCommon;
 
+paramRetType(typecode) ::= <%
+$if(typecode)$
+$typecode.cppTypename$
+$else$
+void
+$endif$
+%>
+
+paramTypeByRef(typecode) ::= <%
+$typecode.cppTypename$&
+%>
+
+paramTypeByValue(typecode, feed) ::= <%
+$if(feed)$
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientWriter<$typecode.cppTypename$> >&
+$else$
+$if(typecode.primitive)$
+$typecode.cppTypename$
+$else$
+const $typecode.cppTypename$&
+$endif$
+$endif$
+%>
+
+paramDeclarations(params, initialSeparator="") ::= <<
+$if(params)$$initialSeparator$$endif$$params : {param | /*$param.comment$*/ $if(param.output)$$paramTypeByRef(typecode=param.typecode)$$else$$paramTypeByValue(typecode=param.typecode, feed=param.annotationFeed)$$endif$ $param.name$}; anchor, separator=",\n"$
+>>
+
 object_serialization(ctx, object) ::= <<
 scdr << eprosima::fastcdr::MemberId($object.id$) << $object.name$();
 >>

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -129,7 +129,7 @@ exception(ctx, parent, exception, extensions) ::= <<
  * @brief This class implements the user exception $exception.scopedname$
  * @ingroup $ctx.trimfilename$
  */
-class $ctx.fileNameUpper$_DllAPI $exception.name$ : public eprosima::fastdds::dds::rpc::RpcOperationError
+class eProsima_user_DllExport $exception.name$ : public eprosima::fastdds::dds::rpc::RpcOperationError
 {
 public:
 
@@ -193,7 +193,7 @@ interface(ctx, parent, interface, export_list) ::= <<
  * @brief This class represents the interface $interface.name$ defined by the user in the IDL file.
  * @ingroup $ctx.trimfilename$
  */
-class $ctx.fileNameUpper$_DllAPI $interface.name$ $if(interface.bases)$: $interface.bases : {base |public $base.scopedname$}; separator=", "$$endif$
+class eProsima_user_DllExport $interface.name$ $if(interface.bases)$: $interface.bases : {base |public $base.scopedname$}; separator=", "$$endif$
 {
 public:
     virtual ~$interface.name$() = default;

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -54,6 +54,10 @@ $if(ctx.thereIsUnion)$
 #include <fastcdr/exceptions/BadParamException.h>
 $endif$
 
+$if(ctx.thereIsException)$
+#include <fastdds/dds/rpc/exceptions/RpcOperationError.hpp>
+$endif$
+
 $ctx.directIncludeDependencies : {include | #include "$include$.hpp"}; separator="\n"$
 
 #if defined(_WIN32)
@@ -106,6 +110,70 @@ namespace $annotation.name$ {
 
 } // namespace $annotation.name$
 $endif$
+>>
+
+exception(ctx, parent, exception, extensions) ::= <<
+/*!
+ * @brief This class implements the user exception $exception.scopedname$
+ * @ingroup $ctx.trimfilename$
+ */
+class $ctx.fileNameUpper$_DllAPI $exception.name$ : public eprosima::fastdds::dds::rpc::RpcOperationError
+{
+public:
+
+    /**
+     * Default constructor.
+     */
+    $exception.name$()
+        : $exception.name$("$exception.name$")
+    {
+    }
+
+    /**
+     * Constructor.
+     */
+    $exception.name$(
+            const std::string& message)
+        : eprosima::fastdds::dds::rpc::RpcOperationError(message)
+    {
+    }
+
+    /**
+     * Constructor.
+     */
+    $exception.name$(
+            const char* message)
+        : eprosima::fastdds::dds::rpc::RpcOperationError(message)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    $exception.name$(
+            const $exception.name$& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    $exception.name$& operator =(
+            const $exception.name$& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~$exception.name$() noexcept = default;
+
+    $exception.members:{ member | $public_member_declaration(member)$}; separator="\n"$
+
+    $extensions : { extension | $extension$}; separator="\n"$
+
+private:
+
+    $exception.members:{ member | $private_member_declaration(member=member)$}; separator="\n"$
+
+};
+
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -33,6 +33,9 @@ $endif$
 $if(ctx.thereIsMap)$
 #include <map>
 $endif$
+$if(ctx.thereIsInputFeed || ctx.thereIsOutputFeed)$
+#include <memory>
+$endif$
 $if(ctx.thereIsString)$
 #include <string>
 $endif$
@@ -56,6 +59,15 @@ $endif$
 
 $if(ctx.thereIsException)$
 #include <fastdds/dds/rpc/exceptions/RpcOperationError.hpp>
+$endif$
+$if(ctx.thereIsOutputFeed)$
+#include <fastdds/dds/rpc/interfaces/RpcClientReader.hpp>
+$endif$
+$if(ctx.thereIsInputFeed)$
+#include <fastdds/dds/rpc/interfaces/RpcClientWriter.hpp>
+$endif$
+$if(ctx.thereIsNonFeedOperation)$
+#include <fastdds/dds/rpc/interfaces/RpcFuture.hpp>
 $endif$
 
 $ctx.directIncludeDependencies : {include | #include "$include$.hpp"}; separator="\n"$
@@ -187,6 +199,12 @@ public:
 
     $export_list$
 };
+>>
+
+operation(ctx, parent, operation, param_list, operation_type) ::= <<
+virtual $operationRetType(operation)$ $operation.name$(
+        $paramDeclarations(params=operation.parameters)$) = 0;
+
 >>
 
 const_decl(ctx, parent, const, const_type) ::= <<
@@ -916,6 +934,14 @@ member_destructor_ = [&]()
 new(&m_$member.name$) $member_type_declaration(member)$();
 $endif$
 >>
+
+operationRetType(operation) ::= <%
+$if(operation.annotationFeed)$
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$> >
+$else$
+eprosima::fastdds::dds::rpc::RpcFuture<$paramRetType(operation.rettype)$>
+$endif$
+%>
 
 //{ Fast DDS-Gen extensions
 module_conversion(ctx, parent, modules, definition_list) ::= <<

--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesHeader.stg
@@ -196,6 +196,7 @@ interface(ctx, parent, interface, export_list) ::= <<
 class $ctx.fileNameUpper$_DllAPI $interface.name$ $if(interface.bases)$: $interface.bases : {base |public $base.scopedname$}; separator=", "$$endif$
 {
 public:
+    virtual ~$interface.name$() = default;
 
     $export_list$
 };

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -1044,13 +1044,13 @@ public class fastddsgen
                         Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.hpp",
                                 maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg"), m_replace);
                     project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "PubSubTypes.hpp");
-                    if (ctx.existsLastStructure() || ctx.isThereIsInterface())
+                    if (returnedValue &=
+                            Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.cxx",
+                                maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg"), m_replace))
                     {
-                        if (returnedValue &=
-                                Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.cxx",
-                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg"), m_replace))
+                        project.addCommonSrcFile(relative_dir + ctx.getFilename() + "PubSubTypes.cxx");
+                        if (ctx.existsLastStructure() || ctx.isThereIsInterface())
                         {
-                            project.addCommonSrcFile(relative_dir + ctx.getFilename() + "PubSubTypes.cxx");
                             if (m_python)
                             {
                                 System.out.println("Generating Swig interface files...");

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -1039,11 +1039,8 @@ public class fastddsgen
                         Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.hpp",
                                 maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg"), m_replace);
                     project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "PubSubTypes.hpp");
-                    if (ctx.existsLastStructure())
+                    if (ctx.existsLastStructure() || ctx.isThereIsInterface())
                     {
-                        m_atLeastOneStructure = true;
-                        project.setHasStruct(true);
-
                         if (returnedValue &=
                                 Utils.writeFile(output_dir + ctx.getFilename() + "PubSubTypes.cxx",
                                     maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg"), m_replace))
@@ -1057,6 +1054,12 @@ public class fastddsgen
                                         maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg"), m_replace);
                             }
                         }
+                    }
+
+                    if (ctx.existsLastStructure())
+                    {
+                        m_atLeastOneStructure = true;
+                        project.setHasStruct(true);
 
                         if (m_exampleOption != null)
                         {

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -1014,7 +1014,7 @@ public class fastddsgen
                         }
                     }
 
-                    if (ctx.isThereIsStructOrUnion())
+                    if (ctx.isThereIsStructOrUnion() || ctx.isThereIsException())
                     {
                         if (returnedValue &=
                                 Utils.writeFile(output_dir + ctx.getFilename() + "CdrAux.hpp",

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -807,6 +807,8 @@ public class fastddsgen
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg");
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/ClientHeader.stg");
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/ClientSource.stg");
 
                 if (generate_typeobjectsupport_)
                 {
@@ -1053,6 +1055,23 @@ public class fastddsgen
                                         output_dir + ctx.getFilename() + "PubSubTypes.i",
                                         maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSwigInterface.stg"), m_replace);
                             }
+                        }
+                    }
+
+                    // Generate client code for interfaces
+                    if (ctx.isThereIsInterface())
+                    {
+                        if (returnedValue &=
+                                Utils.writeFile(output_dir + ctx.getFilename() + "Client.hpp",
+                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/ClientHeader.stg"), m_replace))
+                        {
+                            project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "Client.hpp");
+                        }
+                        if (returnedValue &=
+                                Utils.writeFile(output_dir + ctx.getFilename() + "Client.cxx",
+                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/ClientSource.stg"), m_replace))
+                        {
+                            project.addCommonSrcFile(relative_dir + ctx.getFilename() + "Client.cxx");
                         }
                     }
 

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -809,6 +809,9 @@ public class fastddsgen
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/ClientHeader.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/ClientSource.stg");
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/ServerHeader.stg");
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/ServerSource.stg");
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/ServerImplementation.stg");
 
                 if (generate_typeobjectsupport_)
                 {
@@ -1073,6 +1076,21 @@ public class fastddsgen
                         {
                             project.addCommonSrcFile(relative_dir + ctx.getFilename() + "Client.cxx");
                         }
+                        if (returnedValue &=
+                                Utils.writeFile(output_dir + ctx.getFilename() + "Server.hpp",
+                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/ServerHeader.stg"), m_replace))
+                        {
+                            project.addCommonIncludeFile(relative_dir + ctx.getFilename() + "Server.hpp");
+                        }
+                        if (returnedValue &=
+                                Utils.writeFile(output_dir + ctx.getFilename() + "Server.cxx",
+                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/ServerSource.stg"), m_replace))
+                        {
+                            project.addCommonSrcFile(relative_dir + ctx.getFilename() + "Server.cxx");
+                        }
+                        returnedValue &=
+                            Utils.writeFile(output_dir + ctx.getFilename() + "ServerImpl.hpp",
+                                maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/ServerImplementation.stg"), m_replace);
                     }
 
                     if (ctx.existsLastStructure())

--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -802,6 +802,7 @@ public class fastddsgen
             // Load Types common templates
             if (generate_typesupport_)
             {
+                tmanager.addGroup("com/eprosima/fastdds/idl/templates/InterfaceDetails.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg");
                 tmanager.addGroup("com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg");
@@ -1012,6 +1013,14 @@ public class fastddsgen
                                 project.addCommonSrcFile(relative_dir + ctx.getFilename() + "TypeObjectSupport.cxx");
                             }
                         }
+                    }
+
+                    if (ctx.isThereIsInterface())
+                    {
+                        // Generate Interface details
+                        returnedValue &=
+                            Utils.writeFile(output_dir + ctx.getFilename() + "_details.hpp",
+                                    maintemplates.getTemplate("com/eprosima/fastdds/idl/templates/InterfaceDetails.stg"), m_replace);
                     }
 
                     if (ctx.isThereIsStructOrUnion() || ctx.isThereIsException())

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Annotation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Annotation.java
@@ -1,0 +1,27 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.idl.parser.tree.AnnotationDeclaration;
+
+public class Annotation extends com.eprosima.idl.parser.tree.Annotation
+{
+    public static final String rpc_feed_str = "feed";
+
+    public Annotation(AnnotationDeclaration declaration)
+    {
+        super(declaration);
+    }
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -292,7 +292,9 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     {
         super.addTypeDeclaration(typedecl);
 
-        if (typedecl.getTypeCode().getKind() == Kind.KIND_STRUCT && typedecl.isInScope())
+        boolean is_nested = typedecl.isAnnotatedAsNested();
+
+        if (typedecl.getTypeCode().getKind() == Kind.KIND_STRUCT && typedecl.isInScope() && !is_nested)
         {
             Annotation topicann = typedecl.getAnnotations().get("Topic");
 

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -318,7 +318,9 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             there_is_at_least_one_exception = true;
         }
 
-        return super.createException(name, token);
+        Exception ex = new Exception(this, getScopeFile(), isInScopedFile(), getScope(), name, token);
+        addException(ex);
+        return ex;
     }
 
 

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -550,7 +550,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             int beginindex = text.indexOf("=");
             return text.substring(beginindex + 1).trim();
         }
-        catch (Exception ex)
+        catch (java.lang.Exception ex)
         {
             System.out.println(ColorMessage.error() + "Getting version. " + ex.getMessage());
         }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -480,6 +480,39 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return there_is_at_least_one_exception;
     }
 
+    public void setThereIsInputFeed(
+            boolean value)
+    {
+        there_is_at_least_one_input_feed = value;
+    }
+
+    public boolean isThereIsInputFeed()
+    {
+        return there_is_at_least_one_input_feed;
+    }
+
+    public boolean setThereIsOutputFeed(
+            boolean value)
+    {
+        return there_is_at_least_one_output_feed = value;
+    }
+
+    public boolean isThereIsOutputFeed()
+    {
+        return there_is_at_least_one_output_feed;
+    }
+
+    public boolean setThereIsNonFeedOperation(
+            boolean value)
+    {
+        return there_is_at_least_one_non_feed_operation = value;
+    }
+
+    public boolean isThereIsNonFeedOperation()
+    {
+        return there_is_at_least_one_non_feed_operation;
+    }
+
     /*** Functions inherited from FastCDR Context ***/
 
     @Override
@@ -743,11 +776,21 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     }
 
     @Override
+    public Interface createInterface(
+            String name,
+            Token token)
+    {
+        Interface interfaceObject = new com.eprosima.fastdds.idl.grammar.Interface(
+                this, getScopeFile(), isInScopedFile(), null, name, token);
+        return interfaceObject;
+    }
+
+    @Override
     public Operation createOperation(
             String name,
             Token token)
     {
-        Operation operationObject = new Operation(getScopeFile(), isInScopedFile(), null, name, token);
+        Operation operationObject = new Operation(this, getScopeFile(), isInScopedFile(), null, name, token);
         return operationObject;
     }
 
@@ -799,4 +842,10 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     private boolean there_is_at_least_one_union = false;
 
     private boolean there_is_at_least_one_exception = false;
+
+    private boolean there_is_at_least_one_input_feed = false;
+
+    private boolean there_is_at_least_one_output_feed = false;
+
+    private boolean there_is_at_least_one_non_feed_operation = false;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -790,6 +790,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         Interface interfaceObject = new com.eprosima.fastdds.idl.grammar.Interface(
                 this, getScopeFile(), isInScopedFile(), getScope(), name, token);
         there_is_at_least_one_interface = true;
+        addInterface(interfaceObject);
         return interfaceObject;
     }
 

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -88,6 +88,9 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         AnnotationDeclaration keyann = this.createAnnotationDeclaration(Annotation.eprosima_key_str, null);
         keyann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
+        // Create default @feed annotation.
+        AnnotationDeclaration feed_ann = this.createAnnotationDeclaration(com.eprosima.fastdds.idl.grammar.Annotation.rpc_feed_str, null);
+        feed_ann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
     }
 
     public void setTypelimitation(
@@ -718,6 +721,25 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         }
 
         return super.getAnnotationDeclaration(name);
+    }
+
+    @Override
+    public Operation createOperation(
+            String name,
+            Token token)
+    {
+        Operation operationObject = new Operation(getScopeFile(), isInScopedFile(), null, name, token);
+        return operationObject;
+    }
+
+    @Override
+    public Param createParam(
+            String name,
+            TypeCode typecode,
+            Param.Kind kind)
+    {
+        Param paramObject = new Param(name, typecode, kind);
+        return paramObject;
     }
 
     //// Java block ////

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -480,6 +480,11 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         return there_is_at_least_one_exception;
     }
 
+    public boolean isThereIsInterface()
+    {
+        return there_is_at_least_one_interface;
+    }
+
     public void setThereIsInputFeed(
             boolean value)
     {
@@ -781,7 +786,8 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             Token token)
     {
         Interface interfaceObject = new com.eprosima.fastdds.idl.grammar.Interface(
-                this, getScopeFile(), isInScopedFile(), null, name, token);
+                this, getScopeFile(), isInScopedFile(), getScope(), name, token);
+        there_is_at_least_one_interface = true;
         return interfaceObject;
     }
 
@@ -848,4 +854,6 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     private boolean there_is_at_least_one_output_feed = false;
 
     private boolean there_is_at_least_one_non_feed_operation = false;
+
+    private boolean there_is_at_least_one_interface = false;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -308,6 +308,20 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
         }
     }
 
+    @Override
+    public com.eprosima.idl.parser.tree.Exception createException(
+            String name,
+            Token token)
+    {
+        if (isInScopedFile())
+        {
+            there_is_at_least_one_exception = true;
+        }
+
+        return super.createException(name, token);
+    }
+
+
     public boolean isClient()
     {
         return m_subscribercode;
@@ -459,6 +473,11 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     public boolean isThereIsStructOrUnion()
     {
         return there_is_at_least_one_struct || there_is_at_least_one_union;
+    }
+
+    public boolean isThereIsException()
+    {
+        return there_is_at_least_one_exception;
     }
 
     /*** Functions inherited from FastCDR Context ***/
@@ -778,4 +797,6 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     private boolean there_is_at_least_one_struct = false;
 
     private boolean there_is_at_least_one_union = false;
+
+    private boolean there_is_at_least_one_exception = false;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Exception.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Exception.java
@@ -1,0 +1,68 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
+
+import com.eprosima.idl.parser.typecode.Kind;
+import com.eprosima.idl.parser.typecode.Member;
+import com.eprosima.idl.parser.typecode.PrimitiveTypeCode;
+import com.eprosima.idl.parser.typecode.TypeCode.ExtensibilityKind;
+
+import org.antlr.v4.runtime.Token;
+
+public class Exception extends com.eprosima.idl.parser.tree.Exception
+{
+    public Exception(Context ctx, String scopeFile, boolean isInScope, String scope, String name, Token token)
+    {
+        super(scopeFile, isInScope, scope, name, token);
+        m_context = ctx;
+    }
+
+    public StructTypeCode getTypeCode()
+    {
+        if (m_typecode == null)
+        {
+            m_typecode = new StructTypeCode(getScope(), getName());
+            // Add inheritance
+            m_typecode.addInheritance(m_context, getRpcOperationErrorTypeCode());
+            // Add annotations
+            getAnnotations().forEach((name, ann) -> m_typecode.addAnnotation(m_context, ann));
+            // Add members
+            getMembers().forEach(member -> m_typecode.addMember(member));
+            // Default to final extensibility
+            m_typecode.get_extensibility(ExtensibilityKind.FINAL);
+        }
+
+        return m_typecode;
+    }
+
+    private StructTypeCode getRpcOperationErrorTypeCode()
+    {
+        if (m_rpcOperationErrorTypeCode == null)
+        {
+            m_rpcOperationErrorTypeCode = new StructTypeCode("eprosima::fastdds::dds::rpc", "RpcOperationError");
+            m_rpcOperationErrorTypeCode.get_extensibility(ExtensibilityKind.FINAL);
+            int kind = com.eprosima.idl.parser.typecode.Kind.KIND_STRING;
+            Member msg_member = new Member(m_context.createStringTypeCode(kind, null), "_error_message_");
+            m_rpcOperationErrorTypeCode.addMember(msg_member);
+        }
+        return m_rpcOperationErrorTypeCode;
+    }
+
+    private Context m_context = null;
+    private StructTypeCode m_typecode = null;
+    static private StructTypeCode m_rpcOperationErrorTypeCode = null;
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
@@ -38,6 +38,7 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
             Operation op = (Operation)exp;
             if (op.isAnnotationFeed())
             {
+                m_hasOutputFeeds = true;
                 m_context.setThereIsOutputFeed(true);
             }
             else
@@ -47,6 +48,16 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
         }
 
         super.add(exp);
+    }
+
+    /*!
+     * @brief This function is used to check if the interface has output feeds.
+     *
+     * @return True if the interface has output feeds, false otherwise.
+     */
+    public boolean isWithOutputFeeds()
+    {
+        return m_hasOutputFeeds;
     }
 
     /*!
@@ -84,6 +95,16 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
                     }
                 });
             });
+
+            if (m_hasOutputFeeds)
+            {
+                // Optional boolean to indicate if the feed is cancelled
+                Member feed_cancel = new Member(m_context.createPrimitiveTypeCode(
+                    com.eprosima.idl.parser.typecode.Kind.KIND_BOOLEAN), "feed_cancel_");
+                feed_cancel.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                feed_cancel.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+                request_type.addMember(feed_cancel);
+            }
 
             m_request_type = request_type;
         }
@@ -142,6 +163,7 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
     }
 
     private Context m_context = null;
+    private boolean m_hasOutputFeeds = false;
     private StructTypeCode m_request_type = null;
     private StructTypeCode m_reply_type = null;
     static private EnumTypeCode m_remoteExceptionCode_t_type = null;

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
@@ -1,0 +1,48 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.fastdds.idl.grammar.Operation;
+import org.antlr.v4.runtime.Token;
+
+public class Interface extends com.eprosima.idl.parser.tree.Interface
+{
+    public Interface(Context ctx, String scopeFile, boolean isInScope, String scope, String name, Token tk)
+    {
+        super(scopeFile, isInScope, scope, name, tk);
+        m_context = ctx;
+    }
+
+    @Override
+    public void add(com.eprosima.idl.parser.tree.Export exp)
+    {
+        if (exp instanceof Operation)
+        {
+            Operation op = (Operation)exp;
+            if (op.isAnnotationFeed())
+            {
+                m_context.setThereIsOutputFeed(true);
+            }
+            else
+            {
+                m_context.setThereIsNonFeedOperation(true);
+            }
+        }
+
+        super.add(exp);
+    }
+
+    private Context m_context;
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
@@ -15,6 +15,11 @@
 package com.eprosima.fastdds.idl.grammar;
 
 import com.eprosima.fastdds.idl.grammar.Operation;
+import com.eprosima.fastdds.idl.parser.typecode.EnumTypeCode;
+import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
+import com.eprosima.idl.parser.typecode.Member;
+import com.eprosima.idl.parser.typecode.EnumMember;
+import com.eprosima.idl.parser.typecode.TypeCode.ExtensibilityKind;
 import org.antlr.v4.runtime.Token;
 
 public class Interface extends com.eprosima.idl.parser.tree.Interface
@@ -44,5 +49,100 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
         super.add(exp);
     }
 
-    private Context m_context;
+    /*!
+     * @brief This function is used in stringtemplates to generate the typesupport code for the interface.
+     *
+     * @return The typecode of the request type.
+     */
+    public StructTypeCode getRequestTypeCode()
+    {
+        if (m_request_type == null)
+        {
+            String scope = getHasScope() ? getScope() + "::detail" : "detail";
+            StructTypeCode request_type = new StructTypeCode(scope, getName() + "_Request");
+
+            // The request type should be a `@choice`, which means that it should have MUTABLE extensibility,
+            // and also treat all fields as optional.
+            request_type.get_extensibility(ExtensibilityKind.MUTABLE);
+
+            getAll_operations().forEach(operation -> {
+                Operation op = (Operation)operation;
+                Member member = new Member(op.getInTypeCode(), op.getName());
+                // Add `@optional` and `@hashid` annotations
+                member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+                request_type.addMember(member);
+                // Add input feed parameters
+                op.getParameters().forEach(param -> {
+                    Param p = (Param)param;
+                    if (p.isInput() && p.isAnnotationFeed())
+                    {
+                        Member feed_member = new Member(p.getFeedTypeCode(), op.getName() + "_" + p.getName());
+                        feed_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                        feed_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+                        request_type.addMember(feed_member);
+                    }
+                });
+            });
+
+            m_request_type = request_type;
+        }
+        return m_request_type;
+    }
+
+    /*!
+     * @brief This function is used in stringtemplates to generate the typesupport code for the interface.
+     *
+     * @return The typecode of the reply type.
+     */
+    public StructTypeCode getReplyTypeCode()
+    {
+        if (m_reply_type == null)
+        {
+            String scope = getHasScope() ? getScope() + "::detail" : "detail";
+            StructTypeCode reply_type = new StructTypeCode(scope, getName() + "_Reply");
+
+            // The reply type should be a `@choice`, which means that it should have MUTABLE extensibility,
+            // and also treat all fields as optional.
+            reply_type.get_extensibility(ExtensibilityKind.MUTABLE);
+
+            getAll_operations().forEach(operation -> {
+                Operation op = (Operation)operation;
+                Member member = new Member(op.getResultTypeCode(), op.getName());
+                // Add `@optional` and `@hashid` annotations
+                member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+                reply_type.addMember(member);
+            });
+
+            Member remoteEx = new Member(get_remoteExceptionCode_t_type(), "remoteEx");
+            remoteEx.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+            remoteEx.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+            reply_type.addMember(remoteEx);
+
+            m_reply_type = reply_type;
+        }
+        return m_reply_type;
+    }
+
+    private EnumTypeCode get_remoteExceptionCode_t_type()
+    {
+        if (m_remoteExceptionCode_t_type == null)
+        {
+            EnumTypeCode type = new EnumTypeCode("eprosima::fastdds::dds::rpc", "RemoteExceptionCode_t");
+            type.addMember(new EnumMember("REMOTE_EX_OK"));
+            type.addMember(new EnumMember("REMOTE_EX_UNSUPPORTED"));
+            type.addMember(new EnumMember("REMOTE_EX_INVALID_ARGUMENT"));
+            type.addMember(new EnumMember("REMOTE_EX_OUT_OF_RESOURCES"));
+            type.addMember(new EnumMember("REMOTE_EX_UNKNOWN_OPERATION"));
+            type.addMember(new EnumMember("REMOTE_EX_UNKNOWN_EXCEPTION"));
+            m_remoteExceptionCode_t_type = type;
+        }
+        return m_remoteExceptionCode_t_type;
+    }
+
+    private Context m_context = null;
+    private StructTypeCode m_request_type = null;
+    private StructTypeCode m_reply_type = null;
+    static private EnumTypeCode m_remoteExceptionCode_t_type = null;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -1,0 +1,48 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import org.antlr.v4.runtime.Token;
+
+public class Operation extends com.eprosima.idl.parser.tree.Operation
+{
+    public Operation(String scopeFile, boolean isInScope, String scope, String name, Token tk)
+    {
+        super(scopeFile, isInScope, scope, name, tk);
+    }
+
+    /**
+     * Return whether the operation has been annotated as feed
+     *
+     * @return true when the operation has been annotated as feed, false otherwise.
+     */
+    public boolean isAnnotationFeed()
+    {
+        com.eprosima.idl.parser.tree.Annotation ann = getAnnotations().get(Annotation.rpc_feed_str);
+        if (ann != null)
+        {
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @feed annotation has only one parameter
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -14,9 +14,14 @@
 
 package com.eprosima.fastdds.idl.grammar;
 
+import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
+import com.eprosima.fastdds.idl.grammar.Param;
 import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.exception.ParseException;
-import com.eprosima.fastdds.idl.grammar.Param;
+import com.eprosima.idl.parser.typecode.Member;
+import com.eprosima.idl.parser.typecode.Kind;
+import com.eprosima.idl.parser.typecode.PrimitiveTypeCode;
+import com.eprosima.idl.parser.typecode.TypeCode.ExtensibilityKind;
 import org.antlr.v4.runtime.Token;
 
 public class Operation extends com.eprosima.idl.parser.tree.Operation
@@ -49,6 +54,17 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
         return false;
     }
 
+    /**
+     * Return whether the operation has been annotated as mutable
+     *
+     * @return true when the operation has been annotated as mutable, false otherwise.
+     */
+    public boolean isAnnotationMutable()
+    {
+        // TODO(MiguelCompany): Add support for @mutable annotation
+        return false;
+    }
+
     @Override
     public void add(com.eprosima.idl.parser.tree.Param param)
     {
@@ -71,5 +87,159 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
         super.add(param);
     }
 
-    private Context m_context;
+    public StructTypeCode getInTypeCode()
+    {
+        if (m_in_type == null)
+        {
+            Interface parent = (Interface)getParent();
+            String scope = parent.getHasScope() ? parent.getScope() + "::detail" : "detail";
+
+            // Create In type
+            StructTypeCode in_type = new StructTypeCode(
+                scope,
+                parent.getName() + "_" + getName() + "_In");
+
+            // If the operation is marked as mutable, then the in type should be mutable as well
+            if (isAnnotationMutable())
+            {
+                in_type.get_extensibility(ExtensibilityKind.MUTABLE);
+            }
+            else
+            {
+                in_type.get_extensibility(ExtensibilityKind.FINAL);
+            }
+
+            // Add non-feed input parameters as members
+            getParameters().forEach(param -> {
+                if (param.isInput() && !((Param)param).isAnnotationFeed())
+                {
+                    Member member = new Member(param.getTypecode(), param.getName());
+                    in_type.addMember(member);
+                }
+            });
+
+            m_in_type = in_type;
+        }
+        return m_in_type;
+    }
+
+    public StructTypeCode createFeedTypeCode(Param p)
+    {
+        // Add feed typecode to the parameter
+        Interface iface = (Interface)getParent();
+        String scope = iface.getHasScope() ? iface.getScope() + "::detail" : "detail";
+
+        StructTypeCode feed_type = new StructTypeCode(
+            scope,
+            iface.getName() + "_" + getName() + "_" + p.getName() + "_Feed");
+
+        feed_type.get_extensibility(ExtensibilityKind.FINAL);
+
+        // Add optional value member
+        Member value_member = new Member(p.getTypecode(), "value");
+        value_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+        feed_type.addMember(value_member);
+
+        // Add optional finished_ member
+        Member finished_member = new Member(m_context.createPrimitiveTypeCode(Kind.KIND_LONG), "finished_");
+        finished_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+        feed_type.addMember(finished_member);
+
+        return feed_type;
+    }
+
+    public StructTypeCode getOutTypeCode()
+    {
+        if (m_out_type == null)
+        {
+            Interface parent = (Interface)getParent();
+            String scope = parent.getHasScope() ? parent.getScope() + "::detail" : "detail";
+
+            // Create Out type
+            StructTypeCode out_type = new StructTypeCode(
+                scope,
+                parent.getName() + "_" + getName() + "_Out");
+
+            // If the operation is marked as mutable, then the out type should be mutable as well
+            if (isAnnotationMutable())
+            {
+                out_type.get_extensibility(ExtensibilityKind.MUTABLE);
+            }
+            else
+            {
+                out_type.get_extensibility(ExtensibilityKind.FINAL);
+            }
+
+            if (isAnnotationFeed())
+            {
+                // Feeds have an optional return_ member, and an optional finished_ member
+                Member return_member = new Member(getRettype(), "return_");
+                return_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                out_type.addMember(return_member);
+                Member finished_member = new Member(m_context.createPrimitiveTypeCode(Kind.KIND_BOOLEAN), "finished_");
+                finished_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                out_type.addMember(finished_member);
+            }
+            else
+            {
+                // Add output parameters as members
+                getParameters().forEach(param -> {
+                    if (param.isOutput())
+                    {
+                        Member member = new Member(param.getTypecode(), param.getName());
+                        out_type.addMember(member);
+                    }
+                });
+                // Add return_ member if operation has a return type
+                if (getRettype() != null)
+                {
+                    Member return_member = new Member(getRettype(), "return_");
+                    out_type.addMember(return_member);
+                }
+            }
+
+            m_out_type = out_type;
+        }
+
+        return m_out_type;
+    }
+
+    public StructTypeCode getResultTypeCode()
+    {
+        if (m_result_type == null)
+        {
+            Interface parent = (Interface)getParent();
+            String scope = parent.getHasScope() ? parent.getScope() + "::detail" : "detail";
+            StructTypeCode result_type = new StructTypeCode(
+                scope,
+                parent.getName() + "_" + getName() + "_Result");
+
+            // The result type should be a `@choice`, which means that it should have MUTABLE extensibility
+            result_type.get_extensibility(ExtensibilityKind.MUTABLE);
+
+            // Add out type as a member of the result type
+            Member result_member = new Member(getOutTypeCode(), "result");
+            result_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+            result_member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+            result_type.addMember(result_member);
+
+            // Add exceptions as optional members
+            getExceptions().forEach(exception -> {
+                String member_name = exception.getFormatedScopedname() + "_ex";
+                Member member = new Member(((Exception)exception).getTypeCode(), member_name);
+                member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("optional")));
+                member.addAnnotation(m_context, new Annotation(m_context.getAnnotationDeclaration("hashid")));
+                result_type.addMember(member);
+            });
+
+            m_result_type = result_type;
+        }
+
+        return m_result_type;
+    }
+
+    private Context m_context = null;
+    private StructTypeCode m_in_type = null;
+    private StructTypeCode m_out_type = null;
+    private StructTypeCode m_result_type = null;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -15,13 +15,16 @@
 package com.eprosima.fastdds.idl.grammar;
 
 import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.exception.ParseException;
+import com.eprosima.fastdds.idl.grammar.Param;
 import org.antlr.v4.runtime.Token;
 
 public class Operation extends com.eprosima.idl.parser.tree.Operation
 {
-    public Operation(String scopeFile, boolean isInScope, String scope, String name, Token tk)
+    public Operation(Context ctx, String scopeFile, boolean isInScope, String scope, String name, Token tk)
     {
         super(scopeFile, isInScope, scope, name, tk);
+        m_context = ctx;
     }
 
     /**
@@ -45,4 +48,28 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
         }
         return false;
     }
+
+    @Override
+    public void add(com.eprosima.idl.parser.tree.Param param)
+    {
+        Param p = (Param)param;
+        // Process feed annotation
+        if (p.isAnnotationFeed())
+        {
+            if (p.isOutput())
+            {
+                // Fail if parameter is out and feed
+                throw new ParseException(null, "Output parameter " + p.getName() + " has '@feed' annotation.");
+            }
+            else
+            {
+                // Take note that there is at least one input feed
+                m_context.setThereIsInputFeed(true);
+            }
+        }
+
+        super.add(param);
+    }
+
+    private Context m_context;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -65,6 +65,11 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
         return false;
     }
 
+    public boolean isHasInputFeeds()
+    {
+        return m_hasInputFeeds;
+    }
+
     @Override
     public void add(com.eprosima.idl.parser.tree.Param param)
     {
@@ -81,6 +86,7 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
             {
                 // Take note that there is at least one input feed
                 m_context.setThereIsInputFeed(true);
+                m_hasInputFeeds = true;
             }
         }
 
@@ -242,4 +248,5 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
     private StructTypeCode m_in_type = null;
     private StructTypeCode m_out_type = null;
     private StructTypeCode m_result_type = null;
+    private boolean m_hasInputFeeds = false;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Param.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Param.java
@@ -1,0 +1,51 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.fastdds.idl.grammar;
+
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.typecode.TypeCode;
+
+import org.antlr.v4.runtime.Token;
+
+public class Param extends com.eprosima.idl.parser.tree.Param
+{
+    public Param(String name, TypeCode typecode, Kind kind)
+
+    {
+        super(name, typecode, kind);
+    }
+
+    /**
+     * Return whether the operation has been annotated as feed
+     *
+     * @return true when the operation has been annotated as feed, false otherwise.
+     */
+    public boolean isAnnotationFeed()
+    {
+        com.eprosima.idl.parser.tree.Annotation ann = getAnnotations().get(Annotation.rpc_feed_str);
+        if (ann != null)
+        {
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @feed annotation has only one parameter
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Param.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Param.java
@@ -14,6 +14,7 @@
 
 package com.eprosima.fastdds.idl.grammar;
 
+import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
 import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.typecode.TypeCode;
 
@@ -48,4 +49,15 @@ public class Param extends com.eprosima.idl.parser.tree.Param
         }
         return false;
     }
+
+    public StructTypeCode getFeedTypeCode()
+    {
+        if (m_feedTypeCode == null)
+        {
+            m_feedTypeCode = ((Operation) getParent()).createFeedTypeCode(this);
+        }
+        return m_feedTypeCode;
+    }
+
+    private StructTypeCode m_feedTypeCode = null;
 }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientHeader.stg
@@ -45,7 +45,7 @@ $definition_list$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
-extern $ctx.fileNameUpper$_DllAPI std::shared_ptr<$interface.name$> create_$interface.name$Client(
+extern eProsima_user_DllExport std::shared_ptr<$interface.name$> create_$interface.name$Client(
         eprosima::fastdds::dds::DomainParticipant& part,
         const char* service_name,
         const eprosima::fastdds::dds::RequesterQos& qos);

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientHeader.stg
@@ -45,8 +45,10 @@ $definition_list$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
 extern eProsima_user_DllExport std::shared_ptr<$interface.name$> create_$interface.name$Client(
         eprosima::fastdds::dds::DomainParticipant& part,
         const char* service_name,
         const eprosima::fastdds::dds::RequesterQos& qos);
+$endif$
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientHeader.stg
@@ -1,0 +1,52 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group ProtocolHeader;
+
+import "eprosima.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Client.hpp"], description=["Client implementation for interfaces"])$
+
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_CLIENT_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_CLIENT_HPP
+
+#include <memory>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/qos/RequesterQos.hpp>
+
+#include "$ctx.filename$.hpp"
+
+$definitions; separator="\n"$
+
+#endif  // FAST_DDS_GENERATED__$ctx.headerGuardName$_CLIENT_HPP
+
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+
+$definition_list$
+
+} // namespace $module.name$
+
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+extern $ctx.fileNameUpper$_DllAPI std::shared_ptr<$interface.name$> create_$interface.name$Client(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::RequesterQos& qos);
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -43,6 +43,7 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "Client.cxx"], description=["Client im
 #include <fastdds/dds/rpc/Service.hpp>
 #include <fastdds/dds/rpc/ServiceTypeSupport.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
+#include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/common/WriteParams.hpp>
 
 #include "$ctx.filename$.hpp"
@@ -409,7 +410,18 @@ $if(operation.annotationFeed)$
                 bool& should_remove) override
         {
             should_remove = false;
+            // Check if the reply is for this operation
             if (req_info.related_sample_identity != info.related_sample_identity)
+            {
+                return;
+            }
+
+            // Avoid processing replies from different writers
+            if (frtps::GUID_t::unknown() == writer_id_)
+            {
+                writer_id_ = req_info.sample_identity.writer_guid();
+            }
+            else if (writer_id_ != req_info.sample_identity.writer_guid())
             {
                 return;
             }
@@ -590,6 +602,7 @@ $if(operation.annotationFeed)$
         bool finished_ = false;
         std::mutex mtx_;
         std::condition_variable cv_;
+        frtps::GUID_t writer_id_ = frtps::GUID_t::unknown();
 
     };
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -337,7 +337,7 @@ private:
 
     //} reply helpers
 
-$export_list$
+$interface.all_operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
 
 };
 
@@ -355,7 +355,7 @@ std::shared_ptr<$interface.name$> create_$interface.name$Client(
 
 >>
 
-operation(ctx, parent, operation, param_list, operation_type) ::= <<
+operation_details(parent, operation) ::= <<
     //{ operation $operation.name$
 
 public:
@@ -376,7 +376,7 @@ $endif$
 
         // Create and send the request
         RequestType request;
-        request.$operation.name$ = $parent.name$_$operation.name$_In{};
+        request.$operation.name$ = $operation.inTypeCode.scopedname${};
         $if(operation.inputparam)$
         $operation.inputparam:{param | $fill_input_param(operation, param)$}; separator="\n"$
         $endif$
@@ -669,7 +669,7 @@ $endif$
 input_feed_writer(operation, param) ::= <<
 struct $operation.name$_$param.name$_writer : public frpc::RpcClientWriter<$paramRetType(param.typecode)$>
 {
-    using FeedType = $operation.parent.name$_$operation.name$_$param.name$_Feed;
+    using FeedType = $param.feedTypeCode.scopedname$;
 
     $operation.name$_$param.name$_writer(
             frpc::Requester* requester,

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -62,6 +62,7 @@ $definition_list$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
 //{ interface $interface.name$
 
 namespace detail {
@@ -352,7 +353,7 @@ std::shared_ptr<$interface.name$> create_$interface.name$Client(
 }
 
 //} interface $interface.name$Client
-
+$endif$
 >>
 
 operation_details(parent, operation) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -1,0 +1,740 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group ProtocolHeader;
+
+import "eprosima.stg"
+import "com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Client.cxx"], description=["Client implementation for interfaces"])$
+
+#include "$ctx.filename$Client.hpp"
+
+#include <atomic>
+#include <exception>
+#include <future>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/qos/RequesterQos.hpp>
+#include <fastdds/dds/publisher/DataWriter.hpp>
+#include <fastdds/dds/rpc/exceptions.hpp>
+#include <fastdds/dds/rpc/interfaces.hpp>
+#include <fastdds/dds/rpc/RequestInfo.hpp>
+#include <fastdds/dds/rpc/Requester.hpp>
+#include <fastdds/dds/rpc/Service.hpp>
+#include <fastdds/dds/rpc/ServiceTypeSupport.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
+#include <fastdds/rtps/common/WriteParams.hpp>
+
+#include "$ctx.filename$.hpp"
+#include "$ctx.filename$_details.hpp"
+#include "$ctx.filename$PubSubTypes.hpp"
+
+$definitions; separator="\n"$
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+
+$definition_list$
+
+} // namespace $module.name$
+
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+//{ interface $interface.name$
+
+namespace detail {
+
+namespace fdds = eprosima::fastdds::dds;
+namespace frpc = eprosima::fastdds::dds::rpc;
+namespace frtps = eprosima::fastdds::rtps;
+
+class $interface.name$Client : public $interface.name$
+{
+
+    using RequestType = $interface.name$_Request;
+    using ReplyType = $interface.name$_Reply;
+
+public:
+
+    $interface.name$Client(
+            fdds::DomainParticipant& part,
+            const char* service_name,
+            const fdds::RequesterQos& qos)
+        : $interface.name$()
+        , participant_(part)
+    {
+        // Register the service type support
+        auto service_type = create_$interface.name$_service_type_support();
+        auto ret = service_type.register_service_type(&participant_, "$interface.scopedname$");
+        if (ret != fdds::RETCODE_OK)
+        {
+            throw std::runtime_error("Error registering service type");
+        }
+
+        // Create the service
+        service_ = participant_.create_service(service_name, "$interface.scopedname$");
+        if (nullptr == service_)
+        {
+            throw std::runtime_error("Error creating service");
+        }
+
+        // Create the requester
+        requester_ = participant_.create_service_requester(service_, qos);
+        if (nullptr == requester_)
+        {
+            throw std::runtime_error("Error creating requester");
+        }
+
+        // Start the processing thread
+        start_thread();
+    }
+
+    ~$interface.name$Client() override
+    {
+        // Stop the processing thread
+        stop_thread();
+
+        // Destroy the requester
+        if (nullptr != requester_)
+        {
+            participant_.delete_service_requester(service_->get_service_name(), requester_);
+            requester_ = nullptr;
+        }
+
+        // Destroy the service
+        if (nullptr != service_)
+        {
+            participant_.delete_service(service_);
+            service_ = nullptr;
+        }
+    }
+
+private:
+
+    void start_thread()
+    {
+        stop_thread_ = false;
+        processing_thread_ = std::thread(&$interface.name$Client::run, this);
+    }
+
+    void stop_thread()
+    {
+        stop_thread_ = true;
+        if (processing_thread_.joinable())
+        {
+            processing_thread_.join();
+        }
+    }
+
+    void run()
+    {
+        while (!stop_thread_)
+        {
+            // Wait for a reply
+            if (requester_->get_requester_reader()->wait_for_unread_message({ 0, 100000000 }))
+            {
+                // Take and process the reply
+                frpc::RequestInfo req_info;
+                ReplyType reply;
+                auto ret = requester_->take_reply(&reply, req_info);
+                if (ret == fdds::RETCODE_OK)
+                {
+                    process_reply(reply, req_info);
+                }
+            }
+        }
+    }
+
+    void process_reply(
+            const ReplyType& reply,
+            const frpc::RequestInfo& req_info)
+    {
+        auto sample_id = req_info.related_sample_identity;
+        {
+            std::lock_guard<std::mutex> _(mtx_);
+            auto it = pending_results_.find(sample_id);
+            if (it != pending_results_.end())
+            {
+                bool should_erase = false;
+                it->second->process_reply(reply, req_info, should_erase);
+                if (should_erase)
+                {
+                    pending_results_.erase(it);
+                }
+            }
+        }
+    }
+
+    struct IReplyProcessor
+    {
+        frpc::RequestInfo info;
+
+        virtual ~IReplyProcessor() = default;
+
+        virtual void process_reply(
+                const ReplyType& reply,
+                const frpc::RequestInfo& req_info,
+                bool& should_remove) = 0;
+
+    };
+
+    fdds::DomainParticipant& participant_;
+    frpc::Service* service_ = nullptr;
+    frpc::Requester* requester_ = nullptr;
+    std::atomic<bool> stop_thread_{false};
+    std::thread processing_thread_;
+    std::mutex mtx_;
+    std::map<frtps::SampleIdentity, std::shared_ptr<IReplyProcessor\>> pending_results_;
+
+    //{ request helpers
+
+    template<typename T, typename TResult>
+    std::future<TResult> send_request_with_promise(
+            const RequestType& request,
+            std::shared_ptr<T> result,
+            std::promise<TResult>& promise)
+    {
+        if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
+        {
+            std::lock_guard<std::mutex> _ (mtx_);
+            pending_results_[result->info.related_sample_identity] = result;
+        }
+        else
+        {
+            promise.set_exception(
+                std::make_exception_ptr(frpc::RpcBrokenPipeException(false)));
+        }
+
+        return promise.get_future();
+    }
+
+    template<typename T>
+    std::shared_ptr<T> send_request_with_reader(
+            const RequestType& request,
+            std::shared_ptr<T> result)
+    {
+        if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
+        {
+            std::lock_guard<std::mutex> _ (mtx_);
+            pending_results_[result->info.related_sample_identity] = result;
+        }
+        else
+        {
+            result->set_exception(
+                std::make_exception_ptr(frpc::RpcBrokenPipeException(false)));
+        }
+
+        return result;
+    }
+
+    //} request helpers
+
+    //{ reply helpers
+
+    template<typename T>
+    static void set_invalid_reply(
+            T& exception_receiver)
+    {
+        exception_receiver.set_exception(
+            std::make_exception_ptr(frpc::RemoteInvalidArgumentError("An invalid reply was received")));
+    }
+
+    template<typename T>
+    static void set_remote_exception(
+            T& exception_receiver,
+            const frpc::RemoteExceptionCode_t& exception)
+    {
+        switch (exception)
+        {
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_OK:
+                set_invalid_reply(exception_receiver);
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_UNSUPPORTED:
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteUnsupportedError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT:
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteInvalidArgumentError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_OUT_OF_RESOURCES:
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteOutOfResourcesError()));
+                break;
+            case frpc::RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION:
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteUnknownOperationError()));
+                break;
+            default: // REMOTE_EX_UNKNOWN_EXCEPTION
+                exception_receiver.set_exception(std::make_exception_ptr(frpc::RemoteUnknownExceptionError()));
+                break;
+        }
+    }
+
+    static size_t count_reply_fields(
+            const ReplyType& reply)
+    {
+        size_t n_fields = 0;
+        $interface.replyTypeCode.members:{member | n_fields += reply.$member.name$.has_value() ? 1 : 0;}; separator="\n"$
+        return n_fields;
+    }
+
+    template<typename T>
+    static bool validate_reply(
+            std::promise<T>& promise,
+            const ReplyType& reply)
+    {
+        // Check if the reply has one and only one field set
+        size_t n_fields = count_reply_fields(reply);
+        if (n_fields != 1u)
+        {
+            set_invalid_reply(promise);
+            return false;
+        }
+
+        return true;
+    }
+
+    struct IExceptionHolder
+    {
+        virtual ~IExceptionHolder() = default;
+
+        virtual void set_exception(
+                std::exception_ptr exception) = 0;
+    };
+
+    static bool validate_reply(
+            IExceptionHolder& reader,
+            const ReplyType& reply)
+    {
+        // Check if the reply has one and only one field set
+        size_t n_fields = count_reply_fields(reply);
+        if (n_fields != 1u)
+        {
+            set_invalid_reply(reader);
+            return false;
+        }
+        return true;
+    }
+
+    //} reply helpers
+
+$export_list$
+
+};
+
+}  // namespace detail
+
+std::shared_ptr<$interface.name$> create_$interface.name$Client(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::RequesterQos& qos)
+{
+    return std::make_shared<detail::$interface.name$Client>(part, service_name, qos);
+}
+
+//} interface $interface.name$Client
+
+>>
+
+operation(ctx, parent, operation, param_list, operation_type) ::= <<
+    //{ operation $operation.name$
+
+public:
+
+    $operationRetType(operation)$ $operation.name$(
+            $paramDeclarations(params=operation.parameters)$) override
+    {
+$if(operation.annotationFeed)$
+        // Create a reader to hold the result
+        auto result = std::make_shared<$operation.name$_reader>(requester_);
+$else$
+        // Create a promise to hold the result
+        auto result = std::make_shared<$operation.name$_promise>();
+        $if(operation.outputparam)$
+        $operation.outputparam:{param | result->$param.name$ = &$param.name$;}; separator="\n"$
+        $endif$
+$endif$
+
+        // Create and send the request
+        RequestType request;
+        request.$operation.name$ = $parent.name$_$operation.name$_In{};
+        $if(operation.inputparam)$
+        $operation.inputparam:{param | $fill_input_param(operation, param)$}; separator="\n"$
+        $endif$
+
+$if(operation.annotationFeed)$
+        return send_request_with_reader(request, result);
+$else$
+        return send_request_with_promise(request, result, result->promise);
+$endif$
+    }
+
+private:
+
+$if(operation.annotationFeed)$
+    struct $operation.name$_reader
+        : public frpc::RpcClientReader<$paramRetType(operation.rettype)$>
+        , public IReplyProcessor
+        , public IExceptionHolder
+    {
+        $operation.name$_reader(
+                frpc::Requester* requester)
+            : requester_(requester)
+        {
+        }
+
+        void process_reply(
+                const ReplyType& reply,
+                const frpc::RequestInfo& req_info,
+                bool& should_remove) override
+        {
+            should_remove = false;
+            if (cancelled_ ||
+                (req_info.related_sample_identity != info.related_sample_identity))
+            {
+                return;
+            }
+
+            should_remove = true;
+            if (!validate_reply(*this, reply))
+            {
+                return;
+            }
+
+            if (reply.remoteEx.has_value())
+            {
+                set_remote_exception(*this, reply.remoteEx.value());
+                return;
+            }
+
+            if (reply.$operation.name$.has_value())
+            {
+                const auto& result = reply.$operation.name$.value();
+                if (result.result.has_value())
+                {
+                    const auto& out = result.result.value();
+                    {
+                        if (out.return_.has_value())
+                        {
+                            // Store the return value
+                            std::lock_guard<std::mutex> _(mtx_);
+                            queue_.push(out.return_.value());
+                            cv_.notify_all();
+
+                            // Should be kept in order to receive further values
+                            should_remove = false;
+                        }
+                        else if (out.finished_.has_value())
+                        {
+                            // Store the finished value
+                            std::lock_guard<std::mutex> _(mtx_);
+                            finished_ = true;
+                            cv_.notify_all();
+                        }
+                        else
+                        {
+                            set_invalid_reply(*this);
+                        }
+                    }
+                    return;
+                }
+                $operation.exceptions : { exception |$operation_result_exception(name=[exception.formatedScopedname, "_ex"], receiver="(*this)")$}; separator="\n"$
+            }
+
+            // If we reach this point, the reply is for another operation
+            set_invalid_reply(*this);
+        }
+
+        void set_exception(
+                std::exception_ptr exception)
+        {
+            std::lock_guard<std::mutex> _(mtx_);
+            if (!finished_)
+            {
+                exception_ = exception;
+                finished_ = true;
+                cv_.notify_all();
+            }
+        }
+
+        bool read(
+                $paramRetType(operation.rettype)$& value) override
+        {
+            bool ret_val = false;
+            std::unique_lock<std::mutex> lock(mtx_);
+            while (!try_read(value, ret_val))
+            {
+                cv_.wait(lock);
+            }
+            return ret_val;
+        }
+
+        bool read(
+                $paramRetType(operation.rettype)$& value,
+                const fdds::Duration_t& timeout) override
+        {
+            bool ret_val = false;
+            std::unique_lock<std::mutex> lock(mtx_);
+            std::chrono::steady_clock::time_point end_time =
+                std::chrono::steady_clock::now() +
+                std::chrono::seconds(timeout.seconds) +
+                std::chrono::nanoseconds(timeout.nanosec);
+            while (!try_read(value, ret_val))
+            {
+                cv_.wait_until(lock, end_time);
+            }
+            return ret_val;
+        }
+
+        void cancel() override
+        {
+            bool old_cancelled = cancelled_.exchange(true);
+            if (!old_cancelled)
+            {
+                // Notify read calls that the operation was cancelled
+                cv_.notify_all();
+
+                // Communicate the cancellation to the server and wait for it to be acknowledged
+                RequestType request;
+                request.feed_cancel_ = true;
+                frpc::RequestInfo req_info = info;
+                auto ret = requester_->send_request((void*)&request, req_info);
+                if (ret != fdds::RETCODE_OK)
+                {
+                    if (ret == fdds::RETCODE_TIMEOUT)
+                    {
+                        throw frpc::RpcTimeoutException();
+                    }
+                    else
+                    {
+                        throw frpc::RpcBrokenPipeException(false);
+                    }
+                }
+
+                // Wait for the server to acknowledge the cancellation
+                std::unique_lock<std::mutex> lock(mtx_);
+                while (!finished_)
+                {
+                    cv_.wait(lock);
+                }
+            }
+        }
+
+    private:
+
+        bool try_read(
+                $paramRetType(operation.rettype)$& value,
+                bool& ret_val)
+        {
+            // Early exit if the operation was cancelled
+            if (cancelled_)
+            {
+                ret_val = false;
+                return true;
+            }
+
+            // Retrieve one value from the queue
+            if (!queue_.empty())
+            {
+                value = queue_.front();
+                queue_.pop();
+                ret_val = true;
+                return true;
+            }
+
+            // Throw the exception if it was set
+            if (exception_)
+            {
+                auto ex = exception_;
+                exception_ = nullptr;
+                std::rethrow_exception(ex);
+            }
+
+            // Check if the operation was finished
+            if (finished_)
+            {
+                ret_val = false;
+                return true;
+            }
+
+            // Need to wait for a new value
+            return false;
+        }
+
+        frpc::Requester* requester_ = nullptr;
+        std::atomic<bool> cancelled_{false};
+        std::exception_ptr exception_;
+        std::queue<$paramRetType(operation.rettype)$> queue_;
+        bool finished_ = false;
+        std::mutex mtx_;
+        std::condition_variable cv_;
+
+    };
+
+$else$
+    struct $operation.name$_promise : public IReplyProcessor
+    {
+        std::promise<$paramRetType(operation.rettype)$> promise;
+        $if(operation.outputparam)$
+        $operation.outputparam:{param | $param.typecode.cppTypename$* $param.name$ = nullptr;}; separator="\n"$
+        $endif$
+
+        void process_reply(
+                const ReplyType& reply,
+                const frpc::RequestInfo& req_info,
+                bool& should_remove) override
+        {
+            should_remove = false;
+            if (req_info.related_sample_identity != info.related_sample_identity)
+            {
+                return;
+            }
+
+            should_remove = true;
+            if (!validate_reply(promise, reply))
+            {
+                return;
+            }
+
+            if (reply.remoteEx.has_value())
+            {
+                set_remote_exception(promise, reply.remoteEx.value());
+                return;
+            }
+
+            if (reply.$operation.name$.has_value())
+            {
+                const auto& result = reply.$operation.name$.value();
+                if (result.result.has_value())
+                {
+                    const auto& out = result.result.value();
+                    $operation.outputparam:{param | *$param.name$ = out.$param.name$;}; separator="\n"$
+                    promise.set_value($if(operation.rettype)$out.return_$endif$);
+                    return;
+                }
+                $operation.exceptions : { exception |$operation_result_exception(name=[exception.formatedScopedname, "_ex"], receiver="promise")$}; separator="\n"$
+            }
+
+            // If we reach this point, the reply is for another operation
+            set_invalid_reply(promise);
+        }
+
+    };
+
+$endif$
+
+    $operation.inputparam:{param | $if(param.annotationFeed)$$input_feed_writer(operation, param)$$endif$}$
+
+    //} operation $operation.name$
+
+>>
+
+operationRetType(operation) ::= <%
+$if(operation.annotationFeed)$
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcClientReader<$paramRetType(operation.rettype)$>>
+$else$
+eprosima::fastdds::dds::rpc::RpcFuture<$paramRetType(operation.rettype)$>
+$endif$
+%>
+
+fill_input_param(operation, param) ::= <%
+$if(param.annotationFeed)$
+$param.name$ = std::make_shared<$operation.name$_$param.name$_writer>(requester_, result);
+$else$
+request.$operation.name$->$param.name$ = $param.name$;
+$endif$
+%>
+
+input_feed_writer(operation, param) ::= <<
+struct $operation.name$_$param.name$_writer : public frpc::RpcClientWriter<$paramRetType(param.typecode)$>
+{
+    using FeedType = $operation.parent.name$_$operation.name$_$param.name$_Feed;
+
+    $operation.name$_$param.name$_writer(
+            frpc::Requester* requester,
+            std::shared_ptr<IReplyProcessor> result)
+        : requester_(requester)
+        , result_(result)
+    {
+    }
+
+    void write(
+            const $paramRetType(param.typecode)$& value) override
+    {
+        RequestType request;
+        request.$operation.name$_$param.name$ = FeedType{};
+        request.$operation.name$_$param.name$->value = value;
+        send_request(request);
+    }
+
+    void write(
+            $paramRetType(param.typecode)$&& value) override
+    {
+        RequestType request;
+        request.$operation.name$_$param.name$ = FeedType{};
+        request.$operation.name$_$param.name$->value = value;
+        send_request(request);
+    }
+
+    void finish(
+            frpc::RpcStatusCode reason = frpc::RPC_STATUS_CODE_OK) override
+    {
+        RequestType request;
+        request.$operation.name$_$param.name$ = FeedType{};
+        request.$operation.name$_$param.name$->finished_ = reason;
+        send_request(request);
+    }
+
+private:
+
+    void send_request(
+            const RequestType& request)
+    {
+        frpc::RequestInfo req_info = result_->info;
+        auto ret = requester_->send_request((void*)&request, req_info);
+        if (ret != fdds::RETCODE_OK)
+        {
+            if (ret == fdds::RETCODE_TIMEOUT)
+            {
+                throw frpc::RpcTimeoutException();
+            }
+            else
+            {
+                throw frpc::RpcBrokenPipeException(false);
+            }
+        }
+    }
+
+    frpc::Requester* requester_ = nullptr;
+    std::shared_ptr<IReplyProcessor> result_;
+};
+
+>>
+
+operation_result_exception(name, receiver) ::= <<
+if (result.$name$.has_value())
+{
+    $receiver$.set_exception(
+        std::make_exception_ptr(result.$name$.value()));
+    return;
+}
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ClientSource.stg
@@ -408,8 +408,7 @@ $if(operation.annotationFeed)$
                 bool& should_remove) override
         {
             should_remove = false;
-            if (cancelled_ ||
-                (req_info.related_sample_identity != info.related_sample_identity))
+            if (req_info.related_sample_identity != info.related_sample_identity)
             {
                 return;
             }
@@ -433,22 +432,25 @@ $if(operation.annotationFeed)$
                 {
                     const auto& out = result.result.value();
                     {
-                        if (out.return_.has_value())
-                        {
-                            // Store the return value
-                            std::lock_guard<std::mutex> _(mtx_);
-                            queue_.push(out.return_.value());
-                            cv_.notify_all();
-
-                            // Should be kept in order to receive further values
-                            should_remove = false;
-                        }
-                        else if (out.finished_.has_value())
+                        if (out.finished_.has_value())
                         {
                             // Store the finished value
                             std::lock_guard<std::mutex> _(mtx_);
                             finished_ = true;
                             cv_.notify_all();
+                        }
+                        else if (out.return_.has_value())
+                        {
+                            if (!cancelled_)
+                            {
+                                // Store the return value
+                                std::lock_guard<std::mutex> _(mtx_);
+                                queue_.push(out.return_.value());
+                                cv_.notify_all();
+                            }
+
+                            // Should be kept in order to receive further values
+                            should_remove = false;
                         }
                         else
                         {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -100,6 +100,7 @@ inline size_t constexpr $struct.name$_offset_of()
 $endif$
 $endif$
 
+$if(!struct.parent.annotatedAsNested)$
 /*!
  * @brief This class represents the TopicDataType of the type $struct.name$ defined by the user in the IDL file.
  * @ingroup $ctx.trimfilename$
@@ -232,6 +233,7 @@ $if(struct.isPlain)$
 
 $endif$
 };
+$endif$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -108,7 +108,7 @@ class $struct.name$PubSubType : public eprosima::fastdds::dds::TopicDataType
 {
 public:
 
-    typedef $struct.name$ type;
+    typedef ::$struct.scopedname$ type;
 
     eProsima_user_DllExport $struct.name$PubSubType();
 
@@ -235,6 +235,7 @@ $endif$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$export_list$
 $if(!interface.annotatedAsNested)$
 eProsima_user_DllExport eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_type_support();
 $endif$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -235,7 +235,9 @@ $endif$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
 eProsima_user_DllExport eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_type_support();
+$endif$
 >>
 
 //{ Fast DDS-Gen extensions

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeHeader.stg
@@ -24,6 +24,9 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "PubSubTypes.hpp"], description=["This
 #define FAST_DDS_GENERATED__$ctx.headerGuardName$_PUBSUBTYPES_HPP
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+$if(ctx.thereIsInterface)$
+#include <fastdds/dds/rpc/ServiceTypeSupport.hpp>
+$endif$
 #include <fastdds/dds/topic/TopicDataType.hpp>
 #include <fastdds/rtps/common/InstanceHandle.hpp>
 #include <fastdds/rtps/common/SerializedPayload.hpp>
@@ -229,6 +232,10 @@ $if(struct.isPlain)$
 
 $endif$
 };
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+eProsima_user_DllExport eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_type_support();
 >>
 
 //{ Fast DDS-Gen extensions

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -51,6 +51,7 @@ namespace $module.name$ {
 
 struct_type(ctx, parent, struct, member_list) ::= <<
 $member_list$
+$if(!struct.parent.annotatedAsNested)$
 $struct.name$PubSubType::$struct.name$PubSubType()
 {
     $if(ctx.GenerateTypesROS2)$set_name("$struct.ROS2Scopedname$");$else$set_name("$struct.scopedname$");$endif$
@@ -237,7 +238,7 @@ void $struct.name$PubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
     $endif$
 }
-
+$endif$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -35,7 +35,7 @@ using DataRepresentationId_t = eprosima::fastdds::dds::DataRepresentationId_t;
 
 $definitions; separator="\n"$
 
-$if(ctx.thereIsStructOrUnion)$
+$if(ctx.thereIsStructOrUnion || ctx.thereIsInterface)$
 // Include auxiliary functions like for serializing/deserializing.
 #include "$ctx.filename$CdrAux.ipp"
 $endif$
@@ -238,6 +238,171 @@ void $struct.name$PubSubType::register_type_object_representation()
     $endif$
 }
 
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+// { $interface.name$ interface
+
+$interface_generic_ser_code(ctx, parent, interface, "Request")$
+
+$interface_generic_ser_code(ctx, parent, interface, "Reply")$
+
+eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_type_support()
+{
+    eprosima::fastdds::dds::TypeSupport request_type(
+        new $interface.name$_RequestPubSubType());
+    eprosima::fastdds::dds::TypeSupport reply_type(
+        new $interface.name$_ReplyPubSubType());
+    return eprosima::fastdds::dds::rpc::ServiceTypeSupport(
+        request_type, reply_type);
+}
+
+// }  // $interface.name$ interface
+>>
+
+interface_generic_ser_code(ctx, parent, interface, suffix) ::= <<
+class $interface.name$_$suffix$PubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+    // Alias for the type to be serialized.
+    typedef detail::$interface.name$_$suffix$ type;
+
+    // Constructor
+    $interface.name$_$suffix$PubSubType()
+    {
+        set_name("$interface.scopedname$_$suffix$");
+        uint32_t type_size = $interface.requestTypeCode.maxSerializedSize$UL;
+        type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+        max_serialized_type_size = type_size + 4; /*encapsulation*/
+        is_compute_key_provided = false;
+    }
+
+    // Destructor
+    ~$interface.name$_$suffix$PubSubType() override = default;
+
+    // This function serializes the data.
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
+    {
+        const type* p_type = static_cast<const type*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+        payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        ser.set_encoding_flag(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2);
+
+        try
+        {
+            // Serialize encapsulation
+            ser.serialize_encapsulation();
+            // Serialize the object.
+            ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return false;
+        }
+
+        // Get the serialized length
+        payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+        return true;
+    }
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            void* data) override
+    {
+        try
+        {
+            // Convert DATA to pointer of your type
+            type* p_type = static_cast<type*>(data);
+    
+            // Object that manages the raw buffer.
+            eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+    
+            // Object that deserializes the data.
+            eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+    
+            // Deserialize encapsulation.
+            deser.read_encapsulation();
+            payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    
+            // Deserialize the object.
+            deser \>> *p_type;
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
+    {
+        try
+        {
+            eprosima::fastcdr::CdrSizeCalculator calculator(
+                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+            size_t current_alignment {0};
+            return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                        *static_cast<const type*>(data), current_alignment)) +
+                    4u /*encapsulation*/;
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return 0;
+        }
+    }
+
+    eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override
+    {
+        static_cast<void>(payload);
+        static_cast<void>(ihandle);
+        static_cast<void>(force_md5);
+        return false;
+    }
+
+    eProsima_user_DllExport bool compute_key(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override
+    {
+        static_cast<void>(data);
+        static_cast<void>(ihandle);
+        static_cast<void>(force_md5);
+        return false;
+    }
+
+    eProsima_user_DllExport void* create_data() override
+    {
+        return new type();
+    }
+
+    eProsima_user_DllExport void delete_data(
+            void* data) override
+    {
+        type* pData = static_cast<type*>(data);
+        delete pData;
+    }
+
+};
 >>
 
 //{ Fast DDS-Gen extensions

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -76,7 +76,7 @@ bool $struct.name$PubSubType::serialize(
         SerializedPayload_t& payload,
         DataRepresentationId_t data_representation)
 {
-    const $struct.name$* p_type = static_cast<const $struct.name$*>(data);
+    const ::$struct.scopedname$* p_type = static_cast<const ::$struct.scopedname$*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
@@ -115,7 +115,7 @@ bool $struct.name$PubSubType::deserialize(
     try
     {
         // Convert DATA to pointer of your type
-        $struct.name$* p_type = static_cast<$struct.name$*>(data);
+        ::$struct.scopedname$* p_type = static_cast<::$struct.scopedname$*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
@@ -149,7 +149,7 @@ uint32_t $struct.name$PubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const $struct.name$*>(data), current_alignment)) +
+                    *static_cast<const ::$struct.scopedname$*>(data), current_alignment)) +
                 4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -160,13 +160,13 @@ uint32_t $struct.name$PubSubType::calculate_serialized_size(
 
 void* $struct.name$PubSubType::create_data()
 {
-    return reinterpret_cast<void*>(new $struct.name$());
+    return reinterpret_cast<void*>(new ::$struct.scopedname$());
 }
 
 void $struct.name$PubSubType::delete_data(
         void* data)
 {
-    delete(reinterpret_cast<$struct.name$*>(data));
+    delete(reinterpret_cast<::$struct.scopedname$*>(data));
 }
 
 bool $struct.name$PubSubType::compute_key(
@@ -179,7 +179,7 @@ bool $struct.name$PubSubType::compute_key(
         return false;
     }
 
-    $struct.name$ data;
+    ::$struct.scopedname$ data;
     if (deserialize(payload, static_cast<void*>(&data)))
     {
         return compute_key(static_cast<void*>(&data), handle, force_md5);
@@ -198,7 +198,7 @@ bool $struct.name$PubSubType::compute_key(
         return false;
     }
 
-    const $struct.name$* p_type = static_cast<const $struct.name$*>(data);
+    const ::$struct.scopedname$* p_type = static_cast<const ::$struct.scopedname$*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
@@ -241,6 +241,7 @@ void $struct.name$PubSubType::register_type_object_representation()
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$export_list$
 $if(!interface.annotatedAsNested)$
 // { $interface.name$ interface
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/DDSPubSubTypeSource.stg
@@ -241,6 +241,7 @@ void $struct.name$PubSubType::register_type_object_representation()
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
 // { $interface.name$ interface
 
 $interface_generic_ser_code(ctx, parent, interface, "Request")$
@@ -258,6 +259,7 @@ eprosima::fastdds::dds::rpc::ServiceTypeSupport create_$interface.name$_service_
 }
 
 // }  // $interface.name$ interface
+$endif$
 >>
 
 interface_generic_ser_code(ctx, parent, interface, suffix) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -52,7 +52,7 @@ namespace detail {
 
 //{ $interface.name$ interface
 
-$interface.all_operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
+$interface.operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
 
 //{ top level
 
@@ -137,15 +137,15 @@ eprosima::fastcdr::optional<$typename$> $name$;
 %>
 
 operation_request_members(interface, operation) ::= <%
-eprosima::fastcdr::optional<$interface.name$_$operation.name$_In> $operation.name$;
+eprosima::fastcdr::optional<$operation.inTypeCode.scopedname$> $operation.name$;
 $operation.inputparam : { param | $if (param.annotationFeed)$$operation_request_feed(interface, operation, param)$$endif$ }$
 %>
 
 operation_request_feed(interface, operation, param) ::= <<
 
-eprosima::fastcdr::optional<$interface.name$_$operation.name$_$param.name$_Feed\> $operation.name$_$param.name$;
+eprosima::fastcdr::optional<$param.feedTypeCode.scopedname$\> $operation.name$_$param.name$;
 >>
 
 operation_reply_members(interface, operation) ::= <<
-eprosima::fastcdr::optional<$interface.name$_$operation.name$_Result\> $operation.name$;
+eprosima::fastcdr::optional<$operation.resultTypeCode.scopedname$\> $operation.name$;
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -54,6 +54,7 @@ namespace detail {
 
 $interface.operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
 
+$if(!interface.annotatedAsNested)$
 //{ top level
 
 struct $interface.name$_Request
@@ -69,6 +70,7 @@ struct $interface.name$_Reply
 };
 
 //}  // top level
+$endif$
 
 //}  // $interface.name$ interface
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -59,6 +59,7 @@ $interface.all_operations : { operation | $operation_details(interface, operatio
 struct $interface.name$_Request
 {
     $interface.all_operations : { operation | $operation_request_members(interface, operation)$ }; separator="\n"$
+    $if(interface.withOutputFeeds)$eprosima::fastcdr::optional<bool\> feed_cancel_;$endif$
 };
 
 struct $interface.name$_Reply

--- a/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/InterfaceDetails.stg
@@ -1,0 +1,150 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group InterfaceDetails;
+
+import "eprosima.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "_details.hpp"], description=["This header file contains support data structures for RPC communication."])$
+
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_DETAILS_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_DETAILS_HPP
+
+#include <fastcdr/xcdr/optional.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcStatusCode.hpp>
+
+#include "$ctx.filename$.hpp"
+
+$definitions; separator="\n"$
+
+#endif //FAST_DDS_GENERATED__$ctx.headerGuardName$_DETAILS_HPP
+>>
+
+struct_type(ctx, parent, struct, member_list) ::= <<>>
+
+union_type(ctx, parent, union, switch_type) ::= <<>>
+
+bitmask_type(ctx, parent, bitmask) ::= <<>>
+
+bitset_type(ctx, parent, bitset) ::= <<>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+    $definition_list$
+}  // namespace $module.name$
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+namespace detail {
+
+//{ $interface.name$ interface
+
+$interface.all_operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
+
+//{ top level
+
+struct $interface.name$_Request
+{
+    $interface.all_operations : { operation | $operation_request_members(interface, operation)$ }; separator="\n"$
+};
+
+struct $interface.name$_Reply
+{
+    $interface.all_operations : { operation | $operation_reply_members(interface, operation)$ }; separator="\n"$
+    eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RemoteExceptionCode_t\> remoteEx;
+};
+
+//}  // top level
+
+//}  // $interface.name$ interface
+
+} // namespace detail
+>>
+
+operation_details(interface, operation) ::= <<
+//{ $operation.name$
+$operation_in_struct(interface, operation)$
+
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_feed_struct(interface, operation, param)$$endif$ }$
+
+$operation_out_struct(interface, operation)$
+
+$operation_result_struct(interface, operation)$
+
+//}  // $operation.name$
+
+>>
+
+operation_in_struct(interface, operation) ::= <<
+struct $interface.name$_$operation.name$_In
+{
+    $if(operation.inputparam)$
+    $operation.inputparam : { param | $if (!param.annotationFeed)$$parameter_declaration(param)$$endif$ }; separator="\n"$
+    $endif$
+};
+>>
+
+operation_feed_struct(interface, operation, param) ::= <<
+struct $interface.name$_$operation.name$_$param.name$_Feed
+{
+    eprosima::fastcdr::optional<$param.typecode.cppTypename$> value;
+    eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RpcStatusCode> finished_;
+};
+>>
+
+operation_out_struct(interface, operation) ::= <<
+struct $interface.name$_$operation.name$_Out
+{
+    $if(operation.annotationFeed)$
+    eprosima::fastcdr::optional<$operation.rettypeparam.typecode.cppTypename$\> $operation.rettypeparam.name$;
+    eprosima::fastcdr::optional<bool\> finished_;
+    $else$
+    $if([operation.outputparam, operation.rettypeparam])$
+    $[operation.outputparam, operation.rettypeparam]:{param | $parameter_declaration(param)$}; separator="\n"$
+    $endif$
+    $endif$
+};
+>>
+
+operation_result_struct(interface, operation) ::= <<
+struct $interface.name$_$operation.name$_Result
+{
+    eprosima::fastcdr::optional<$interface.name$_$operation.name$_Out\> result;
+    $operation.exceptions : { exception |$operation_result_exception(typename=exception.scopedname, name=[exception.formatedScopedname, "_ex"])$}; separator="\n"$
+};
+>>
+
+parameter_declaration(param) ::= <%
+$param.typecode.cppTypename$ $param.name$;
+%>
+
+operation_result_exception(typename, name) ::= <%
+eprosima::fastcdr::optional<$typename$> $name$;
+%>
+
+operation_request_members(interface, operation) ::= <%
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_In> $operation.name$;
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_request_feed(interface, operation, param)$$endif$ }$
+%>
+
+operation_request_feed(interface, operation, param) ::= <<
+
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_$param.name$_Feed\> $operation.name$_$param.name$;
+>>
+
+operation_reply_members(interface, operation) ::= <<
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_Result\> $operation.name$;
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationHeader.stg
@@ -34,6 +34,7 @@ extern bool g_$ctx.filename$_test_empty_ext;
 
 struct_type(ctx, parent, struct, member_list) ::= <<
 $member_list$
+$if(!struct.declaredInsideInterface)$
 $if((ctx.generateTypesC))$
 void free_string$struct.name$(
         $struct.name$* topic);
@@ -52,11 +53,12 @@ int compare$struct.name$(
 
 $struct.name$ createKey$struct.name$(
         int idx);
-
+$endif$
 >>
 
 union_type(ctx, parent, union, switch_type) ::= <<
 $switch_type$
+$if(!union.declaredInsideInterface)$
 void print$union.name$(
         $union.name$* topic);
 
@@ -66,10 +68,11 @@ void initialize$union.name$(
 int compare$union.name$(
         $union.name$* a,
         $union.name$* b);
-
+$endif$
 >>
 
 bitmask_type(ctx, parent, bitmask) ::= <<
+$if(!bitmask.declaredInsideInterface)$
 void print$bitmask.name$(
         $bitmask.name$* topic);
 
@@ -79,10 +82,11 @@ void initialize$bitmask.name$(
 int compare$bitmask.name$(
         $bitmask.name$* a,
         $bitmask.name$* b);
-
+$endif$
 >>
 
 bitset_type(ctx, parent, bitset) ::= <<
+$if(!bitset.declaredInsideInterface)$
 void print$bitset.name$(
         $bitset.name$* topic);
 
@@ -92,7 +96,7 @@ void initialize$bitset.name$(
 int compare$bitset.name$(
         $bitset.name$* a,
         $bitset.name$* b);
-
+$endif$
 >>
 
 module(ctx, parent, module, definition_list) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationSource.stg
@@ -42,6 +42,7 @@ $definitions; separator="\n"$
 
 struct_type(ctx, parent, struct, member_list) ::= <<
 $member_list$
+$if(!struct.declaredInsideInterface)$
 $if((ctx.generateTypesC))$
 void $if(struct.hasScope)$$struct.scope$::$endif$free_string$struct.name$(
         $struct.name$* topic)
@@ -152,11 +153,12 @@ $if(struct.hasScope)$$struct.scope$::$endif$$struct.name$ $if(struct.hasScope)$$
     initialize$struct.name$(&result, idx+1); // 0 means don't use the idx internally.
     return result;
 }
-
+$endif$
 >>
 
 union_type(ctx, parent, union, switch_type) ::= <<
 $switch_type$
+$if(!union.declaredInsideInterface)$
 void $if(union.hasScope)$$union.scope$::$endif$print$union.name$(
         $union.name$* topic)
 {
@@ -214,10 +216,11 @@ int $if(union.hasScope)$$union.scope$::$endif$compare$union.name$(
     $endif$
     return 1;
 }
-
+$endif$
 >>
 
 bitmask_type(ctx, parent, bitmask) ::= <<
+$if(!bitmask.declaredInsideInterface)$
 void $if(bitmask.hasScope)$$bitmask.scope$::$endif$print$bitmask.name$(
         $bitmask.name$* topic)
 {
@@ -242,10 +245,11 @@ int $if(bitmask.hasScope)$$bitmask.scope$::$endif$compare$bitmask.name$(
 {
     return *topic_a == *topic_b;
 }
-
+$endif$
 >>
 
 bitset_type(ctx, parent, bitset) ::= <<
+$if(!bitset.declaredInsideInterface)$
 void $if(bitset.hasScope)$$bitset.scope$::$endif$print$bitset.name$(
         $bitset.name$* topic)
 {
@@ -273,7 +277,7 @@ int $if(bitset.hasScope)$$bitset.scope$::$endif$compare$bitset.name$(
     $bitset.definedBitfields:{ bitfield | if(topic_a->$bitfield.name$ != topic_b->$bitfield.name$) return 0; }; separator="\n"$
     return 1;
 }
-
+$endif$
 >>
 
 // ========================================================================================

--- a/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/SerializationTestSource.stg
@@ -98,7 +98,7 @@ $if(struct.hasScope)$} // namespace $struct.scope$$endif$
 
 struct_type(ctx, parent, struct, member_list) ::= <<
 $member_list$
-$if(!struct.annotationNested)$
+$if(!struct.parent.annotatedAsNested)$
 
 std::ostream& operator<<(std::ostream& stream, $struct.cppTypename$& e)
 {

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -1,0 +1,144 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group ProtocolHeader;
+
+import "eprosima.stg"
+import "com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Server.hpp"], description=["Server implementation for interfaces"])$
+
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_SERVER_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_SERVER_HPP
+
+#include <memory>
+
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/qos/ReplierQos.hpp>
+#include <fastdds/dds/rpc/exceptions.hpp>
+#include <fastdds/dds/rpc/interfaces.hpp>
+#include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/RemoteLocators.hpp>
+
+#include "$ctx.filename$.hpp"
+
+$definitions; separator="\n"$
+
+#endif  // FAST_DDS_GENERATED__$ctx.headerGuardName$_CLIENT_HPP
+
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+
+$definition_list$
+
+} // namespace $module.name$
+
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+/**
+ * @brief Context for a client request.
+ */
+struct $interface.name$Server_ClientContext
+{
+    virtual ~$interface.name$Server_ClientContext() = default;
+
+    /**
+     * @brief Get the GUID of the client that made the request.
+     *
+     * @return The GUID of the client that made the request.
+     */
+    virtual const eprosima::fastdds::rtps::GUID_t& get_client_id() const = 0;
+
+    /**
+     * @brief Get the locators of the client that made the request.
+     *
+     * @return The locators of the client that made the request.
+     */
+    virtual const eprosima::fastdds::rtps::RemoteLocatorList& get_client_locators() const = 0;
+};
+
+struct $interface.name$Server_IServerImplementation
+{
+    virtual ~$interface.name$Server_IServerImplementation() = default;
+
+    $interface.all_operations:{op | $operation_prototype(op)$}; separator="\n\n"$
+};
+
+struct $interface.name$Server
+{
+    virtual ~$interface.name$Server() = default;
+
+    /**
+     * @brief Run the server.
+     *
+     * This method starts the server and begins processing requests.
+     * The method will block until the server is stopped.
+     */
+    virtual void run() = 0;
+
+    /**
+     * @brief Stop the server.
+     *
+     * This method stops the server and releases all resources.
+     * It will cancel all pending requests, and wait for all processing threads to finish before returning.
+     */
+    virtual void stop() = 0;
+
+};
+
+/**
+ * @brief Create a $interface.name$Server instance.
+ *
+ * @param part             The DomainParticipant to use for the server.
+ * @param service_name     The name of the service.
+ * @param qos              The QoS settings for the server.
+ * @param thread_pool_size The size of the thread pool to use for processing requests.
+ *                         When set to 0, a new thread will be created when no threads are available.
+ * @param implementation   The implementation of the server interface.
+ */
+extern eProsima_user_DllExport std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        size_t thread_pool_size,
+        std::shared_ptr<$interface.name$Server_IServerImplementation> implementation);
+>>
+
+operation_prototype(op) ::= <<
+$if(op.annotationFeed)$
+virtual void $op.name$(
+        const $interface.name$Server_ClientContext& info,
+$if(op.parameters)$
+        $operation_parameters(op.parameters)$,
+$endif$
+        /*result*/ eprosima::fastdds::dds::rpc::RpcServerWriter<$paramRetType(op.rettype)$>& result_writer) = 0;
+$else$
+$if(op.parameters)$
+virtual $paramRetType(op.rettype)$ $op.name$(
+        const $interface.name$Server_ClientContext& info,
+        $operation_parameters(op.parameters)$) = 0;
+$else$
+virtual $paramRetType(op.rettype)$ $op.name$(
+        const $interface.name$Server_ClientContext& info) = 0;
+$endif$
+$endif$
+>>
+
+operation_parameters(params) ::= <<
+$params : {param | /*$param.comment$*/ $if(param.output)$$paramTypeByRef(typecode=param.typecode)$$else$$paramTypeByValue(typecode=param.typecode, feed=param.annotationFeed, is_server=true)$$endif$ $param.name$}; anchor, separator=",\n"$
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -50,6 +50,7 @@ $definition_list$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
 /**
  * @brief Context for a client request.
  */
@@ -117,6 +118,7 @@ extern eProsima_user_DllExport std::shared_ptr<$interface.name$Server> create_$i
         const eprosima::fastdds::dds::ReplierQos& qos,
         size_t thread_pool_size,
         std::shared_ptr<$interface.name$Server_IServerImplementation> implementation);
+$endif$
 >>
 
 operation_prototype(op) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerImplementation.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerImplementation.stg
@@ -42,6 +42,7 @@ $definition_list$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
 //{ interface $interface.name$
 
 struct $interface.name$ServerImplementation :
@@ -53,7 +54,7 @@ struct $interface.name$ServerImplementation :
 };
 
 //} interface $interface.name$
-
+$endif$
 >>
 
 operation_implementation(interface, op) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerImplementation.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerImplementation.stg
@@ -1,0 +1,89 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group ProtocolHeader;
+
+import "eprosima.stg"
+import "com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "ServerImpl.hpp"], description=["Server implementation for interfaces"])$
+
+#ifndef FAST_DDS_GENERATED__$ctx.headerGuardName$_SERVERIMPL_HPP
+#define FAST_DDS_GENERATED__$ctx.headerGuardName$_SERVERIMPL_HPP
+
+#include "$ctx.filename$.hpp"
+#include "$ctx.filename$Server.hpp"
+
+$definitions; separator="\n"$
+
+#endif  // FAST_DDS_GENERATED__$ctx.headerGuardName$_SERVERIMPL_HPP
+
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+
+$definition_list$
+
+} // namespace $module.name$
+
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+//{ interface $interface.name$
+
+struct $interface.name$ServerImplementation :
+    public $interface.name$Server_IServerImplementation
+{
+
+    $interface.all_operations:{op | $operation_implementation(interface, op)$}; separator="\n"$
+
+};
+
+//} interface $interface.name$
+
+>>
+
+operation_implementation(interface, op) ::= <<
+$if(op.annotationFeed)$
+void $op.name$(
+        const $interface.name$Server_ClientContext& info,
+$if(op.parameters)$
+        $operation_parameters(op.parameters)$,
+$endif$
+        /*result*/ eprosima::fastdds::dds::rpc::RpcServerWriter<$paramRetType(op.rettype)$>& result_writer) override
+$else$
+$if(op.parameters)$
+$paramRetType(op.rettype)$ $op.name$(
+        const $interface.name$Server_ClientContext& info,
+        $operation_parameters(op.parameters)$) override
+$else$
+$paramRetType(op.rettype)$ $op.name$(
+        const $interface.name$Server_ClientContext& info) override
+$endif$
+$endif$
+{
+    static_cast<void>(info);
+    $op.parameters : {param | static_cast<void>($param.name$);}; anchor, separator="\n"$
+    $if(op.annotationFeed)$
+    static_cast<void>(result_writer);
+    $endif$
+    throw eprosima::fastdds::dds::rpc::RemoteUnsupportedError("Operation '$op.name$' is not implemented");
+}
+>>
+
+operation_parameters(params) ::= <<
+$params : {param | /*$param.comment$*/ $if(param.output)$$paramTypeByRef(typecode=param.typecode)$$else$$paramTypeByValue(typecode=param.typecode, feed=param.annotationFeed, is_server=true)$$endif$ $param.name$}; anchor, separator=",\n"$
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -1,0 +1,803 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+group ProtocolHeader;
+
+import "eprosima.stg"
+import "com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg"
+
+main(ctx, definitions) ::= <<
+$fileHeader(ctx=ctx,  file=[ctx.filename, "Server.cxx"], description=["Server implementation for interfaces"])$
+
+#include "$ctx.filename$Server.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
+#include <fastdds/dds/core/condition/Condition.hpp>
+#include <fastdds/dds/core/condition/GuardCondition.hpp>
+#include <fastdds/dds/core/condition/WaitSet.hpp>
+#include <fastdds/dds/core/Time_t.hpp>
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/qos/ReplierQos.hpp>
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/rpc/exceptions.hpp>
+#include <fastdds/dds/rpc/interfaces.hpp>
+#include <fastdds/dds/rpc/RequestInfo.hpp>
+#include <fastdds/dds/rpc/Replier.hpp>
+#include <fastdds/dds/rpc/Service.hpp>
+#include <fastdds/dds/rpc/ServiceTypeSupport.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
+
+#include "$ctx.filename$.hpp"
+#include "$ctx.filename$_details.hpp"
+#include "$ctx.filename$PubSubTypes.hpp"
+
+$definitions; separator="\n"$
+
+>>
+
+module(ctx, parent, module, definition_list) ::= <<
+namespace $module.name$ {
+
+$definition_list$
+
+} // namespace $module.name$
+
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+//{ interface $interface.name$
+
+namespace detail {
+
+namespace fdds = eprosima::fastdds::dds;
+namespace frpc = eprosima::fastdds::dds::rpc;
+namespace frtps = eprosima::fastdds::rtps;
+
+class $interface.name$ServerLogic
+    : public $interface.name$Server
+{
+    using RequestType = $interface.name$_Request;
+    using ReplyType = $interface.name$_Reply;
+
+public:
+
+    $interface.name$ServerLogic(
+            eprosima::fastdds::dds::DomainParticipant& part,
+            const char* service_name,
+            const eprosima::fastdds::dds::ReplierQos& qos,
+            size_t thread_pool_size,
+            std::shared_ptr<$interface.name$Server_IServerImplementation> implementation)
+        : $interface.name$Server()
+        , participant_(part)
+        , thread_pool_(*this, thread_pool_size)
+        , implementation_(std::move(implementation))
+    {
+        // Register the service type support
+        auto service_type = create_$interface.name$_service_type_support();
+        auto ret = service_type.register_service_type(&participant_, "$interface.scopedname$");
+        if (ret != fdds::RETCODE_OK)
+        {
+            throw std::runtime_error("Error registering service type");
+        }
+
+        // Create the service
+        service_ = participant_.create_service(service_name, "$interface.scopedname$");
+        if (nullptr == service_)
+        {
+            throw std::runtime_error("Error creating service");
+        }
+
+        // Create the replier
+        replier_ = participant_.create_service_replier(service_, qos);
+        if (nullptr == replier_)
+        {
+            throw std::runtime_error("Error creating requester");
+        }
+    }
+
+    ~$interface.name$ServerLogic() override
+    {
+        stop();
+
+        if (nullptr != replier_)
+        {
+            participant_.delete_service_replier(service_->get_service_name(), replier_);
+        }
+
+        if (nullptr != service_)
+        {
+            participant_.delete_service(service_);
+        }
+    }
+
+    void run() override
+    {
+        finish_condition_.set_trigger_value(false);
+        fdds::WaitSet waitset;
+        waitset.attach_condition(finish_condition_);
+        waitset.attach_condition(replier_->get_replier_reader()->get_statuscondition());
+
+        while (true)
+        {
+            fdds::ConditionSeq active_conditions;
+            waitset.wait(active_conditions, fdds::c_TimeInfinite);
+
+            // Early exit if the finish condition is triggered
+            if (finish_condition_.get_trigger_value())
+            {
+                break;
+            }
+
+            // Take and process the requests
+            auto ctx = std::make_shared<RequestContext>();
+            while (fdds::RETCODE_OK == ctx->take_from(replier_))
+            {
+                if (ctx->validate_request())
+                {
+                    process_request(ctx);
+                }
+                else
+                {
+                    ctx->send_exception(frpc::RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT, replier_);
+                }
+
+                // Prepare next request context
+                ctx = std::make_shared<RequestContext>();
+            }
+        }
+    }
+
+    void stop() override
+    {
+        // Notify all threads to finish
+        finish_condition_.set_trigger_value(true);
+
+        // Cancel all pending requests
+        {
+            std::lock_guard<std::mutex> _(mtx_);
+            for (auto& it : processing_requests_)
+            {
+                it.second->cancel();
+            }
+            processing_requests_.clear();
+        }
+
+        // Wait for all threads to finish
+        thread_pool_.stop();
+    }
+
+private:
+
+    //{ Output feed helpers
+    
+    struct IOutputFeedCancellator
+    {
+        virtual ~IOutputFeedCancellator() = default;
+        virtual void cancel() = 0;
+    };
+
+    //} Output feed helpers
+
+    //{ Input feed helpers
+
+    struct IInputFeedProcessor
+    {
+        virtual ~IInputFeedProcessor() = default;
+        virtual bool process_additional_request(
+                const RequestType& request) = 0;
+        virtual void cancel_input_feed() = 0;
+    };
+
+    //} Input feed helpers
+
+    $interface.all_operations:{op | $operation_declarations(op)$}; separator="\n\n"$
+
+    struct RequestContext : $interface.name$Server_ClientContext
+    {
+        RequestType request;
+        frpc::RequestInfo info;
+        frtps::GUID_t client_id;
+        fdds::PublicationBuiltinTopicData pub_data;
+
+        $interface.all_operations:{op | $operation_feed_members(op)$}; separator="\n\n"$
+
+        const frtps::GUID_t& get_client_id() const override
+        {
+            return client_id;
+        }
+
+        const frtps::RemoteLocatorList& get_client_locators() const override
+        {
+            return pub_data.remote_locators;
+        }
+
+        fdds::ReturnCode_t take_from(
+                frpc::Replier* replier)
+        {
+            fdds::ReturnCode_t ret = replier->take_request(&request, info);
+            if (ret == fdds::RETCODE_OK)
+            {
+                client_id = info.sample_identity.writer_guid();
+                ret = replier->get_replier_reader()->get_matched_publication_data(pub_data, client_id);
+            }
+            return ret;
+        }
+
+        bool validate_request() const
+        {
+            size_t n_fields = 0;
+            $interface.requestTypeCode.members:{member | n_fields += request.$member.name$.has_value() ? 1 : 0;}; separator="\n"$
+
+            return n_fields == 1U;
+        }
+
+        void process_additional_request(
+                const std::shared_ptr<RequestContext>& ctx,
+                frpc::Replier* replier,
+                bool& should_erase)
+        {
+            should_erase = false;
+            if (ctx->info.related_sample_identity == info.related_sample_identity)
+            {
+$if(interface.withOutputFeeds)$
+                if (ctx->request.feed_cancel_.has_value())
+                {
+                    if (output_feed_cancellator_)
+                    {
+                        output_feed_cancellator_->cancel();
+                    }
+                    else
+                    {
+                        EPROSIMA_LOG_ERROR(RPC_SERVER, "Output feed cancel request received, but no output feed is active.");
+                    }
+
+                    return;
+                }
+$endif$
+                // Pass request to input feed processors
+                should_erase = true;
+                for (const auto& input_feed : input_feed_processors_)
+                {
+                    if (input_feed->process_additional_request(ctx->request))
+                    {
+                        should_erase = false;
+                        break;
+                    }
+                }
+
+                // If no input feed processor handled the request, send an exception
+                if (should_erase)
+                {
+                    send_exception(frpc::RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT, replier);
+                }
+            }
+            else
+            {
+                // This is not the expected request
+                should_erase = true;
+            }
+        }
+
+        bool prepare(
+                frpc::Replier* replier)
+        {
+            $interface.all_operations:{op | $operation_prepare_call(op)$}; separator="\n"$
+
+            send_exception(frpc::RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION, replier);
+            return false;
+        }
+
+        void send_exception(
+                frpc::RemoteExceptionCode_t ex,
+                frpc::Replier* replier)
+        {
+            ReplyType reply{};
+            reply.remoteEx = ex;
+            replier->send_reply(&reply, info);
+        }
+
+        void cancel()
+        {
+            // Cancel output feed
+            if (output_feed_cancellator_)
+            {
+                output_feed_cancellator_->cancel();
+            }
+
+            // Cancel input feeds
+            for (const auto& input_feed : input_feed_processors_)
+            {
+                input_feed->cancel_input_feed();
+            }
+        }
+
+    private:
+
+        std::shared_ptr<IOutputFeedCancellator> output_feed_cancellator_;
+        std::vector<std::shared_ptr<IInputFeedProcessor\>> input_feed_processors_;
+
+        $interface.all_operations:{op | $operation_prepare_impl(op)$}; separator="\n\n"$
+
+    };
+
+    struct ThreadPool
+    {
+        ThreadPool(
+                $interface.name$ServerLogic& server,
+                size_t num_threads)
+            : server_(server)
+        {
+            // Create worker threads (at least one)
+            if (num_threads == 0)
+            {
+                num_threads = 1;
+            }
+
+            auto process_requests = [this]()
+                    {
+                        while (!finished_)
+                        {
+                            std::shared_ptr<RequestContext> req;
+                            {
+                                std::unique_lock<std::mutex> lock(mtx_);
+                                cv_.wait(lock, [this]()
+                                        {
+                                            return finished_ || !requests_.empty();
+                                        });
+                                if (finished_)
+                                {
+                                    break;
+                                }
+                                req = requests_.front();
+                                requests_.pop();
+                            }
+
+                            // Process the request
+                            server_.execute_request(req);
+                        }
+                    };
+
+            for (size_t i = 0; i < num_threads; ++i)
+            {
+                threads_.emplace_back(process_requests);
+            }
+        }
+
+        void new_request(
+                const std::shared_ptr<RequestContext>& req)
+        {
+            std::lock_guard<std::mutex> lock(mtx_);
+            if (!finished_)
+            {
+                requests_.push(req);
+                cv_.notify_one();
+            }
+        }
+
+        void stop()
+        {
+            // Notify all threads in the pool to stop
+            {
+                std::lock_guard<std::mutex> lock(mtx_);
+                finished_ = true;
+                cv_.notify_all();
+            }
+
+            // Wait for all threads to finish
+            for (auto& thread : threads_)
+            {
+                if (thread.joinable())
+                {
+                    thread.join();
+                }
+            }
+            threads_.clear();
+        }
+
+        $interface.name$ServerLogic& server_;
+        std::mutex mtx_;
+        std::condition_variable cv_;
+        std::queue<std::shared_ptr<RequestContext\>> requests_;
+        bool finished_{ false };
+        std::vector<std::thread> threads_;
+    };
+
+    void process_request(
+            const std::shared_ptr<RequestContext>& ctx)
+    {
+        auto id = ctx->info.related_sample_identity;
+
+        {
+            std::lock_guard<std::mutex> _(mtx_);
+            auto it = processing_requests_.find(id);
+            if (it != processing_requests_.end())
+            {
+                bool should_erase = false;
+                it->second->process_additional_request(ctx, replier_, should_erase);
+                if (should_erase)
+                {
+                    processing_requests_.erase(it);
+                }
+                return;
+            }
+
+            if (!ctx->prepare(replier_))
+            {
+                return;
+            }
+
+            processing_requests_[id] = ctx;
+        }
+
+        thread_pool_.new_request(ctx);
+    }
+
+    void execute_request(
+            const std::shared_ptr<RequestContext>& req)
+    {
+        try
+        {
+            for (;;)
+            {
+                $interface.all_operations:{op | $call_operation(op)$}; separator="\n\n"$
+
+                req->send_exception(frpc::RemoteExceptionCode_t::REMOTE_EX_UNSUPPORTED, replier_);
+                break;
+            }
+        }
+        catch (const frpc::RpcRemoteException& ex)
+        {
+            req->send_exception(ex.code(), replier_);
+        }
+        catch (...)
+        {
+            req->send_exception(frpc::RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_EXCEPTION, replier_);
+        }
+
+        {
+            std::lock_guard<std::mutex> _(mtx_);
+            processing_requests_.erase(req->info.related_sample_identity);
+        }
+    }
+
+    fdds::DomainParticipant& participant_;
+    frpc::Service* service_ = nullptr;
+    frpc::Replier* replier_ = nullptr;
+    fdds::GuardCondition finish_condition_;
+    std::mutex mtx_;
+    std::map<frtps::SampleIdentity, std::shared_ptr<RequestContext\>> processing_requests_;
+    ThreadPool thread_pool_;
+    std::shared_ptr<$interface.name$Server_IServerImplementation> implementation_;
+
+};
+
+}  // namespace detail
+
+std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        size_t thread_pool_size,
+        std::shared_ptr<$interface.name$Server_IServerImplementation> implementation)
+{
+    return std::make_shared<detail::$interface.name$ServerLogic>(
+        part, service_name, qos, thread_pool_size, implementation);
+}
+
+//} interface $interface.name$
+
+>>
+
+operation_prepare_call(op) ::= <<
+if (request.$op.name$.has_value())
+{
+    return prepare_$op.name$(replier);
+}
+
+>>
+
+operation_prepare_impl(op) ::= <<
+bool prepare_$op.name$(
+        frpc::Replier* replier)
+{
+    static_cast<void>(replier);
+$if(op.hasInputFeeds)$
+    $op.inputparam : {param | $if(param.annotationFeed)$$create_operation_feed_reader(op, param)$$"\n"$$endif$}$
+$endif$
+$if(op.annotationFeed)$
+    $op.name$_feeds.result_writer = std::make_shared<$op.name$_result_writer>(info, replier);
+    output_feed_cancellator_ = $op.name$_feeds.result_writer;
+$endif$
+    return true;
+}
+>>
+
+create_operation_feed_reader(op, param) ::= <<
+$op.name$_feeds.$param.name$ = std::make_shared<$op.name$_$param.name$_reader>();
+input_feed_processors_.push_back($op.name$_feeds.$param.name$);
+>>
+
+operation_declarations(op) ::= <<
+//{ operation $op.name$
+
+$op.inputparam : {param | $if(param.annotationFeed)$$operation_feed_reader(op, param)$$endif$}$
+$if(op.annotationFeed)$
+$operation_feed_writer(op)$
+$endif$
+
+//} operation $op.name$
+>>
+
+operation_feed_reader(op, param) ::= <<
+struct $op.name$_$param.name$_reader :
+    public frpc::RpcServerReader<int32_t>,
+    public IInputFeedProcessor
+{
+    $op.name$_$param.name$_reader() = default;
+
+    bool process_additional_request(
+            const RequestType& request) override
+    {
+        if (request.$op.name$_$param.name$.has_value())
+        {
+            if (request.$op.name$_$param.name$->finished_.has_value())
+            {
+                std::lock_guard<std::mutex> _(mtx_);
+                if (!finished_)
+                {
+                    finished_ = true;
+                    status_ = request.$op.name$_$param.name$->finished_.value();
+                    cv_.notify_all();
+                }
+                return true;
+            }
+            else if (request.$op.name$_$param.name$->value.has_value())
+            {
+                std::lock_guard<std::mutex> _(mtx_);
+                if (!finished_)
+                {
+                    queue_.push(request.$op.name$_$param.name$->value.value());
+                    cv_.notify_all();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void cancel_input_feed() override
+    {
+        std::lock_guard<std::mutex> _(mtx_);
+        finished_ = true;
+        cv_.notify_all();
+    }
+
+    bool read(
+            $param.typecode.cppTypename$& value) override
+    {
+        bool ret_val = false;
+        std::unique_lock<std::mutex> lock(mtx_);
+        while (!try_read(value, ret_val))
+        {
+            cv_.wait(lock);
+        }
+        return ret_val;
+    }
+
+    bool read(
+            $param.typecode.cppTypename$& value,
+            const fdds::Duration_t& timeout) override
+    {
+        bool ret_val = false;
+        std::unique_lock<std::mutex> lock(mtx_);
+        std::chrono::steady_clock::time_point end_time =
+                std::chrono::steady_clock::now() +
+                std::chrono::seconds(timeout.seconds) +
+                std::chrono::nanoseconds(timeout.nanosec);
+        while (!try_read(value, ret_val))
+        {
+            if (cv_.wait_until(lock, end_time) == std::cv_status::timeout)
+            {
+                throw frpc::RpcTimeoutException();
+            }
+        }
+        return ret_val;
+    }
+
+private:
+
+    bool try_read(
+            $param.typecode.cppTypename$& value,
+            bool& ret_val)
+    {
+        if (!queue_.empty())
+        {
+            value = queue_.front();
+            queue_.pop();
+            ret_val = true;
+            return true;
+        }
+
+        if (finished_)
+        {
+            if (status_ == frpc::RPC_STATUS_CODE_OK)
+            {
+                ret_val = false;
+                return true;
+            }
+            else
+            {
+                throw frpc::RpcFeedCancelledException(status_);
+            }
+        }
+
+        ret_val = false;
+        return false;
+    }
+
+    std::mutex mtx_;
+    std::condition_variable cv_;
+    std::queue<$param.typecode.cppTypename$> queue_;
+    bool finished_{ false };
+    frpc::RpcStatusCode status_{ frpc::RPC_STATUS_CODE_OK };
+
+};
+
+
+>>
+
+operation_feed_writer(op) ::= <<
+struct $op.name$_result_writer :
+    public frpc::RpcServerWriter<$paramRetType(op.rettype)$>,
+    public IOutputFeedCancellator
+{
+    $op.name$_result_writer(
+            const frpc::RequestInfo& info,
+            frpc::Replier* replier)
+        : info_(info)
+        , replier_(replier)
+    {
+        reply_.$op.name$ = $op.parent.name$_$op.name$_Result{};
+        reply_.$op.name$->result = $op.parent.name$_$op.name$_Out{};
+    }
+
+    void write(
+            const $paramRetType(op.rettype)$& value) override
+    {
+        if (cancelled_.load())
+        {
+            throw frpc::RpcFeedCancelledException(0);
+        }
+        reply_.$op.name$->result->return_ = value;
+        replier_->send_reply(&reply_, info_);
+    }
+
+    void write(
+            $paramRetType(op.rettype)$&& value) override
+    {
+        if (cancelled_.load())
+        {
+            throw frpc::RpcFeedCancelledException(0);
+        }
+        reply_.$op.name$->result->return_ = value;
+        replier_->send_reply(&reply_, info_);
+    }
+
+    void cancel() override
+    {
+        cancelled_.store(true);
+    }
+
+private:
+
+    frpc::RequestInfo info_;
+    frpc::Replier* replier_ = nullptr;
+    ReplyType reply_{};
+    std::atomic<bool> cancelled_{ false };
+
+};
+>>
+
+operation_feed_members(op) ::= <<
+struct $op.name$_feeds_t
+{
+    $op.inputparam : {param | $if(param.annotationFeed)$std::shared_ptr<$op.name$_$param.name$_reader> $param.name$;$"\n"$$endif$}$
+$if(op.annotationFeed)$
+    std::shared_ptr<$op.name$_result_writer> result_writer;
+$endif$
+}
+$op.name$_feeds;
+>>
+
+call_operation(op) ::= <<
+if (req->request.$op.name$.has_value())
+{
+$if(op.exceptions || op.annotationFeed)$
+    try
+$endif$
+    {
+$if(op.annotationFeed)$
+        implementation_->$op.name$(
+            *req,
+$if(op.parameters)$
+            $op.parameters : {param | $operation_call_parameter(op, param)$}; separator=",\n"$,
+$endif$
+            *(req->$op.name$_feeds.result_writer));
+        ReplyType reply{};
+        reply.$op.name$ = $op.parent.name$_$op.name$_Result{};
+        reply.$op.name$->result = $op.parent.name$_$op.name$_Out{};
+        reply.$op.name$->result->finished_ = true;
+        replier_->send_reply(&reply, req->info);
+$else$
+        $op.outputparam : {param | $param.typecode.cppTypename$ $param.name$ $if(param.onlyOutput)${\}$else$= req->request.$op.name$->$param.name$$endif$;}; separator="\n"$
+        $if(op.rettype)$$op.rettype.cppTypename$ result = $else$/*void*/ $endif$implementation_->$op.name$(
+            *req$if(op.parameters)$,$else$);$endif$
+$if(op.parameters)$
+            $op.parameters : {param | $operation_call_parameter(op, param)$}; separator=",\n"$);
+$endif$
+        ReplyType reply{};
+        reply.$op.name$ = $op.parent.name$_$op.name$_Result{};
+        reply.$op.name$->result = $op.parent.name$_$op.name$_Out{};
+        $op.outputparam : {param | reply.$op.name$->result->$param.name$ = $param.name$;}; separator="\n"$
+$if(op.rettype)$
+        reply.$op.name$->result->return_ = result;
+$endif$
+        replier_->send_reply(&reply, req->info);
+$endif$
+    }
+$if(op.annotationFeed)$
+    catch (const frpc::RpcFeedCancelledException& ex)
+    {
+        ReplyType reply{};
+        reply.$op.name$ = $op.parent.name$_$op.name$_Result{};
+        reply.$op.name$->result = $op.parent.name$_$op.name$_Out{};
+        reply.$op.name$->result->finished_ = true;
+        replier_->send_reply(&reply, req->info);
+    }
+$endif$
+    $op.exceptions : {ex | $operation_result_exception(op=op, typename=ex.scopedname, name=[ex.formatedScopedname, "_ex"])$}; separator="\n"$
+    break;
+}
+>>
+
+operation_call_parameter(op, param) ::= <%
+$if(param.output)$
+$param.name$
+$elseif(param.annotationFeed)$
+*(req->$op.name$_feeds.$param.name$)
+$else$
+req->request.$op.name$->$param.name$
+$endif$
+%>
+
+operation_result_exception(op, typename, name) ::= <<
+catch (const $typename$& ex)
+{
+    ReplyType reply{};
+    reply.$op.name$ = $op.parent.name$_$op.name$_Result{};
+    reply.$op.name$->$name$ = ex;
+    replier_->send_reply(&reply, req->info);
+}
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -67,6 +67,7 @@ $definition_list$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
 //{ interface $interface.name$
 
 namespace detail {
@@ -507,7 +508,7 @@ std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
 }
 
 //} interface $interface.name$
-
+$endif$
 >>
 
 operation_prepare_call(op) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -679,8 +679,8 @@ struct $op.name$_result_writer :
         : info_(info)
         , replier_(replier)
     {
-        reply_.$op.name$ = $op.parent.name$_$op.name$_Result{};
-        reply_.$op.name$->result = $op.parent.name$_$op.name$_Out{};
+        reply_.$op.name$ = $op.resultTypeCode.scopedname${};
+        reply_.$op.name$->result = $op.outTypeCode.scopedname${};
     }
 
     void write(
@@ -746,8 +746,8 @@ $if(op.parameters)$
 $endif$
             *(req->$op.name$_feeds.result_writer));
         ReplyType reply{};
-        reply.$op.name$ = $op.parent.name$_$op.name$_Result{};
-        reply.$op.name$->result = $op.parent.name$_$op.name$_Out{};
+        reply.$op.name$ = $op.resultTypeCode.scopedname${};
+        reply.$op.name$->result = $op.outTypeCode.scopedname${};
         reply.$op.name$->result->finished_ = true;
         replier_->send_reply(&reply, req->info);
 $else$
@@ -758,8 +758,8 @@ $if(op.parameters)$
             $op.parameters : {param | $operation_call_parameter(op, param)$}; separator=",\n"$);
 $endif$
         ReplyType reply{};
-        reply.$op.name$ = $op.parent.name$_$op.name$_Result{};
-        reply.$op.name$->result = $op.parent.name$_$op.name$_Out{};
+        reply.$op.name$ = $op.resultTypeCode.scopedname${};
+        reply.$op.name$->result = $op.outTypeCode.scopedname${};
         $op.outputparam : {param | reply.$op.name$->result->$param.name$ = $param.name$;}; separator="\n"$
 $if(op.rettype)$
         reply.$op.name$->result->return_ = result;
@@ -771,8 +771,8 @@ $if(op.annotationFeed)$
     catch (const frpc::RpcFeedCancelledException& ex)
     {
         ReplyType reply{};
-        reply.$op.name$ = $op.parent.name$_$op.name$_Result{};
-        reply.$op.name$->result = $op.parent.name$_$op.name$_Out{};
+        reply.$op.name$ = $op.resultTypeCode.scopedname${};
+        reply.$op.name$->result = $op.outTypeCode.scopedname${};
         reply.$op.name$->result->finished_ = true;
         replier_->send_reply(&reply, req->info);
     }
@@ -796,7 +796,7 @@ operation_result_exception(op, typename, name) ::= <<
 catch (const $typename$& ex)
 {
     ReplyType reply{};
-    reply.$op.name$ = $op.parent.name$_$op.name$_Result{};
+    reply.$op.name$ = $op.resultTypeCode.scopedname${};
     reply.$op.name$->$name$ = ex;
     replier_->send_reply(&reply, req->info);
 }

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectTestingTestSource.stg
@@ -133,6 +133,7 @@ TEST(TypeObjectTests, TestTypedefTypeObject_$typedefs.name$)
 >>
 
 struct_type(ctx, parent, struct, member_list) ::= <<
+$if(!struct.declaredInsideInterface)$
 namespace $struct.cScopedname$_namespace {
 $member_list$
 } // $struct.cScopedname$_namespace
@@ -181,9 +182,11 @@ TEST(TypeObjectTests, TestStructureTypeObject_$struct.cScopedname$)
     ASSERT_EQ($struct.membersSize$, type_objects.minimal_type_object.minimal().struct_type().member_seq().size());
     ASSERT_EQ($struct.membersSize$, type_objects.complete_type_object.complete().struct_type().member_seq().size());
 }
+$endif$
 >>
 
 union_type(ctx, parent, union, switch_type) ::= <<
+$if(!union.declaredInsideInterface)$
 $switch_type$
 
 TEST(TypeObjectTests, TestUnionTypeObject_$union.name$)
@@ -236,9 +239,11 @@ TEST(TypeObjectTests, TestUnionTypeObject_$union.name$)
     ASSERT_EQ($union.membersSize$, type_objects.minimal_type_object.minimal().union_type().member_seq().size());
     ASSERT_EQ($union.membersSize$, type_objects.complete_type_object.complete().union_type().member_seq().size());
 }
+$endif$
 >>
 
 enum_type(ctx, parent, enum) ::= <<
+$if(!enum.declaredInsideInterface)$
 TEST(TypeObjectTests, TestEnumTypeObject_$enum.name$)
 {
     ReturnCode_t ret_code;
@@ -274,9 +279,11 @@ TEST(TypeObjectTests, TestEnumTypeObject_$enum.name$)
                 type_objects.complete_type_object.complete().enumerated_type().literal_seq()[i].common().value());
     }
 }
+$endif$
 >>
 
 bitmask_type(ctx, parent, bitmask) ::= <<
+$if(!bitmask.declaredInsideInterface)$
 TEST(TypeObjectTests, TestBitmaskTypeObject_$bitmask.name$)
 {
     ReturnCode_t ret_code;
@@ -311,9 +318,11 @@ TEST(TypeObjectTests, TestBitmaskTypeObject_$bitmask.name$)
                 type_objects.complete_type_object.complete().bitmask_type().flag_seq()[i].common().position());
     }
 }
+$endif$
 >>
 
 bitset_type(ctx, parent, bitset, extensions) ::= <<
+$if(!bitset.declaredInsideInterface)$
 TEST(TypeObjectTests, TestBitsetTypeObject_$bitset.name$)
 {
     ReturnCode_t ret_code;
@@ -346,6 +355,7 @@ TEST(TypeObjectTests, TestBitsetTypeObject_$bitset.name$)
                 type_objects.complete_type_object.complete().bitset_type().field_seq()[i].common().position());
     }
 }
+$endif$
 >>
 
 annotation(ctx, annotation) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeader.stg
@@ -23,6 +23,9 @@ $fileHeader(ctx=ctx, file=[ctx.filename, "CdrAux.hpp"], description=["This sourc
 #define FAST_DDS_GENERATED__$ctx.headerGuardName$CDRAUX_HPP
 
 #include "$ctx.filename$.hpp"
+$if(ctx.thereIsInterface)$
+#include "$ctx.filename$_details.hpp"
+$endif$
 
 $if(ctx.anyCdr)$
 $ctx.types:{ type | $if(type.inScope)$$if(type.typeCode.isStructType)$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -523,7 +523,7 @@ interface(ctx, parent, interface, export_list) ::= <<
 
 //{ $interface.scopedname$ interface
 
-$interface.all_operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
+$interface.operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
 
 //{ top level
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -55,8 +55,8 @@ eProsima_user_DllExport size_t calculate_serialized_size(
         const $struct.scopedname$& data,
         size_t& current_alignment)
 {
-$if(!struct.declaredInsideInterface && !struct.scope.empty)$
-    using namespace $struct.scope$;
+$if(!struct.namespace.empty)$
+    using namespace $struct.namespace$;
 $endif$
 
     static_cast<void>(data);
@@ -86,8 +86,8 @@ eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const $struct.scopedname$& data)
 {
-    $if(!struct.scope.empty)$
-    using namespace $struct.scope$;
+    $if(!struct.namespace.empty)$
+    using namespace $struct.namespace$;
     $endif$
 
     eprosima::fastcdr::Cdr::state current_state(scdr);
@@ -113,8 +113,8 @@ eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         $struct.scopedname$& data)
 {
-    $if(!struct.scope.empty)$
-    using namespace $struct.scope$;
+    $if(!struct.namespace.empty)$
+    using namespace $struct.namespace$;
     $endif$
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
@@ -152,8 +152,8 @@ void serialize_key(
         const $struct.scopedname$& data)
 {
     $if(!struct.inheritance)$
-    $if(!struct.scope.empty)$
-    using namespace $struct.scope$;
+    $if(!struct.namespace.empty)$
+    using namespace $struct.namespace$;
     $endif$
     $struct.membersById : { member |
         $if(member.typecode.isStructType)$
@@ -215,8 +215,8 @@ eProsima_user_DllExport size_t calculate_serialized_size(
         const $bitset.scopedname$&,
         size_t& current_alignment)
 {
-    $if(!bitset.scope.empty)$
-    using namespace $bitset.scope$;
+    $if(!bitset.namespace.empty)$
+    using namespace $bitset.namespace$;
     $endif$
 
     return calculator.calculate_serialized_size(std::bitset<$bitset.bitSize$>{}, current_alignment);
@@ -229,8 +229,8 @@ eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const $bitset.scopedname$& data)
 {
-    $if(!bitset.scope.empty)$
-    using namespace $bitset.scope$;
+    $if(!bitset.namespace.empty)$
+    using namespace $bitset.namespace$;
     $endif$
 
     std::bitset<$bitset.bitSize$> bitset;
@@ -250,8 +250,8 @@ eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& dcdr,
         $bitset.scopedname$& data)
 {
-    $if(!bitset.scope.empty)$
-    using namespace $bitset.scope$;
+    $if(!bitset.namespace.empty)$
+    using namespace $bitset.namespace$;
     $endif$
 
     std::bitset<$bitset.bitSize$> bitset;
@@ -276,8 +276,8 @@ eProsima_user_DllExport size_t calculate_serialized_size(
         const $union.scopedname$& data,
         size_t& current_alignment)
 {
-    $if(!union.scope.empty)$
-    using namespace $union.scope$;
+    $if(!union.namespace.empty)$
+    using namespace $union.namespace$;
     $endif$
 
     static_cast<void>(data);
@@ -320,8 +320,8 @@ eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const $union.scopedname$& data)
 {
-    $if(!union.scope.empty)$
-    using namespace $union.scope$;
+    $if(!union.namespace.empty)$
+    using namespace $union.namespace$;
     $endif$
 
     eprosima::fastcdr::Cdr::state current_state(scdr);
@@ -354,8 +354,8 @@ eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         $union.scopedname$& data)
 {
-    $if(!union.scope.empty)$
-    using namespace $union.scope$;
+    $if(!union.namespace.empty)$
+    using namespace $union.namespace$;
     $endif$
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
@@ -424,8 +424,8 @@ eProsima_user_DllExport size_t calculate_serialized_size(
         const $exception.scopedname$& data,
         size_t& current_alignment)
 {
-    $if(!exception.scope.empty)$
-    using namespace $exception.scope$;
+    $if(!exception.namespace.empty)$
+    using namespace $exception.namespace$;
     $endif$
 
     static_cast<void>(data);
@@ -455,8 +455,8 @@ eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const $exception.scopedname$& data)
 {
-    $if(!exception.scope.empty)$
-    using namespace $exception.scope$;
+    $if(!exception.namespace.empty)$
+    using namespace $exception.namespace$;
     $endif$
 
     eprosima::fastcdr::Cdr::state current_state(scdr);
@@ -481,8 +481,8 @@ eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         $exception.scopedname$& data)
 {
-    $if(!exception.scope.empty)$
-    using namespace $exception.scope$;
+    $if(!exception.namespace.empty)$
+    using namespace $exception.namespace$;
     $endif$
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
@@ -659,8 +659,8 @@ eProsima_user_DllExport size_t calculate_serialized_size(
         const ::$struct.scopedname$& data,
         size_t& current_alignment)
 {
-    $if(!struct.scope.empty)$
-    using namespace $struct.scope$;
+    $if(!struct.namespace.empty)$
+    using namespace $struct.namespace$;
     $endif$
 
     static_cast<void>(data);
@@ -688,8 +688,8 @@ eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const ::$struct.scopedname$& data)
 {
-    $if(!struct.scope.empty)$
-    using namespace $struct.scope$;
+    $if(!struct.namespace.empty)$
+    using namespace $struct.namespace$;
     $endif$
 
     eprosima::fastcdr::Cdr::state current_state(scdr);
@@ -715,8 +715,8 @@ eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         ::$struct.scopedname$& data)
 {
-    $if(!struct.scope.empty)$
-    using namespace $struct.scope$;
+    $if(!struct.namespace.empty)$
+    using namespace $struct.namespace$;
     $endif$
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -55,9 +55,9 @@ eProsima_user_DllExport size_t calculate_serialized_size(
         const $struct.scopedname$& data,
         size_t& current_alignment)
 {
-    $if(!struct.scope.empty)$
+$if(!struct.declaredInsideInterface && !struct.scope.empty)$
     using namespace $struct.scope$;
-    $endif$
+$endif$
 
     static_cast<void>(data);
 
@@ -497,7 +497,7 @@ eProsima_user_DllExport void deserialize(
                     {
                         std::string msg;
                         dcdr \>> msg;
-                        $exception.name$ tmp{msg};
+                        $exception.scopedname$ tmp{msg};
                         data = tmp;
                         break;
                     }
@@ -520,7 +520,7 @@ eProsima_user_DllExport void deserialize(
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
-
+$export_list$
 //{ $interface.scopedname$ interface
 
 $interface.operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
@@ -656,7 +656,7 @@ rpc_struct_serialization(struct) ::= <<
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const $struct.scopedname$& data,
+        const ::$struct.scopedname$& data,
         size_t& current_alignment)
 {
     $if(!struct.scope.empty)$
@@ -686,7 +686,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
 template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
-        const $struct.scopedname$& data)
+        const ::$struct.scopedname$& data)
 {
     $if(!struct.scope.empty)$
     using namespace $struct.scope$;
@@ -713,7 +713,7 @@ eProsima_user_DllExport void serialize(
 template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
-        $struct.scopedname$& data)
+        ::$struct.scopedname$& data)
 {
     $if(!struct.scope.empty)$
     using namespace $struct.scope$;
@@ -751,7 +751,7 @@ eProsima_user_DllExport void deserialize(
 
 void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
-        const $struct.scopedname$& data)
+        const ::$struct.scopedname$& data)
 {
     static_cast<void>(scdr);
     static_cast<void>(data);

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -416,3 +416,105 @@ eProsima_user_DllExport void deserialize(
 }
 $endif$
 >>
+
+exception(ctx, parent, exception) ::= <<
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const $exception.scopedname$& data,
+        size_t& current_alignment)
+{
+    $if(!exception.scope.empty)$
+    using namespace $exception.scope$;
+    $endif$
+
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+    std::string msg = data.what();
+    calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0), msg, current_alignment);
+
+    $exception.members : { member | $if(!member.annotationNonSerialized)$
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId($member.index$ + 1),
+            data.$member.name$(), current_alignment);
+    $endif$}; separator="\n"$
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const $exception.scopedname$& data)
+{
+    $if(!exception.scope.empty)$
+    using namespace $exception.scope$;
+    $endif$
+
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr << eprosima::fastcdr::MemberId(0) << data.what();
+    $if(exception.members)$
+    scdr$exception.members : { member | $if(!member.annotationNonSerialized)$
+        << eprosima::fastcdr::MemberId($member.index$ + 1) << data.$member.name$()
+    $endif$
+    }; separator=""$;
+    $endif$
+
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        $exception.scopedname$& data)
+{
+    $if(!exception.scope.empty)$
+    using namespace $exception.scope$;
+    $endif$
+
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                    case 0:
+                    {
+                        std::string msg;
+                        dcdr \>> msg;
+                        $exception.name$ tmp{msg};
+                        data = tmp;
+                        break;
+                    }
+
+                    $exception.members : { member |
+                    case $member.index$ + 1:
+                        $if(!member.annotationNonSerialized)$
+                            dcdr \>> data.$member.name$();
+                        $endif$
+                        break;
+                    }; separator="\n"$
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -525,6 +525,7 @@ interface(ctx, parent, interface, export_list) ::= <<
 
 $interface.operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
 
+$if(!interface.annotatedAsNested)$
 //{ top level
 
 // Serialization methods for $detail_scoped_name(interface)$_Request
@@ -547,6 +548,7 @@ struct $interface.name$_Reply
 $rpc_struct_serialization(interface.replyTypeCode)$
 
 //}  // top level
+$endif$
 
 //}  // $interface.scopedname$ interface
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -518,3 +518,240 @@ eProsima_user_DllExport void deserialize(
 }
 
 >>
+
+interface(ctx, parent, interface, export_list) ::= <<
+
+//{ $interface.scopedname$ interface
+
+$interface.all_operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
+
+//{ top level
+
+// Serialization methods for $detail_scoped_name(interface)$_Request
+/*
+struct $interface.name$_Request
+{
+    $interface.all_operations : { operation | $operation_request_members(interface, operation)$ }; separator="\n"$
+};
+*/
+$rpc_struct_serialization(interface.requestTypeCode)$
+
+// Serialization methods for $detail_scoped_name(interface)$_Reply
+/*
+struct $interface.name$_Reply
+{
+    $interface.all_operations : { operation | $operation_reply_members(interface, operation)$ }; separator="\n"$
+    eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RemoteExceptionCode_t\> remoteEx;
+};
+*/
+$rpc_struct_serialization(interface.replyTypeCode)$
+
+//}  // top level
+
+//}  // $interface.scopedname$ interface
+
+>>
+
+operation_details(interface, operation) ::= <<
+//{ $operation.name$
+$operation_in_struct(interface, operation)$
+
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_feed_struct(interface, operation, param)$$endif$ }$
+
+$operation_out_struct(interface, operation)$
+
+$operation_result_struct(interface, operation)$
+
+//}  // $operation.name$
+
+>>
+
+operation_in_struct(interface, operation) ::= <<
+// Serialization methods for $detail_scoped_name(interface)$_$operation.name$_In
+/*
+struct $interface.name$_$operation.name$_In
+{
+    $if(operation.inputparam)$
+    $operation.inputparam : { param | $if (!param.annotationFeed)$$parameter_declaration(param)$$endif$ }; separator="\n"$
+    $endif$
+};
+*/
+$rpc_struct_serialization(operation.inTypeCode)$
+>>
+
+operation_feed_struct(interface, operation, param) ::= <<
+// Serialization methods for $detail_scoped_name(interface)$_$operation.name$_$param.name$_Feed
+/*
+struct $interface.name$_$operation.name$_$param.name$_Feed
+{
+    eprosima::fastcdr::optional<$param.typecode.cppTypename$> value;
+    eprosima::fastcdr::optional<eprosima::fastdds::dds::rpc::RpcStatusCode> finished_;
+};
+*/
+$rpc_struct_serialization(param.feedTypeCode)$
+>>
+
+operation_out_struct(interface, operation) ::= <<
+// Serialization methods for $detail_scoped_name(interface)$_$operation.name$_Out
+/*
+struct $interface.name$_$operation.name$_Out
+{
+    $if(operation.annotationFeed)$
+    eprosima::fastcdr::optional<$operation.rettypeparam.typecode.cppTypename$\> $operation.rettypeparam.name$;
+    eprosima::fastcdr::optional<bool\> finished_;
+    $else$
+    $if([operation.outputparam, operation.rettypeparam])$
+    $[operation.outputparam, operation.rettypeparam]:{param | $parameter_declaration(param)$}; separator="\n"$
+    $endif$
+    $endif$
+};
+*/
+$rpc_struct_serialization(operation.outTypeCode)$
+>>
+
+operation_result_struct(interface, operation) ::= <<
+// Serialization methods for $detail_scoped_name(interface)$_$operation.name$_Result
+/*
+struct $interface.name$_$operation.name$_Result
+{
+    eprosima::fastcdr::optional<$interface.name$_$operation.name$_Out\> result;
+    $operation.exceptions : { exception |$operation_result_exception(typename=exception.scopedname, name=[exception.formatedScopedname, "_ex"])$}; separator="\n"$
+};
+*/
+$rpc_struct_serialization(operation.resultTypeCode)$
+>>
+
+parameter_declaration(param) ::= <%
+$param.typecode.cppTypename$ $param.name$;
+%>
+
+operation_result_exception(typename, name) ::= <%
+eprosima::fastcdr::optional<$typename$> $name$;
+%>
+
+operation_request_members(interface, operation) ::= <%
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_In> $operation.name$;
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_request_feed(interface, operation, param)$$endif$ }$
+%>
+
+operation_request_feed(interface, operation, param) ::= <<
+
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_$param.name$_Feed\> $operation.name$_$param.name$;
+>>
+
+operation_reply_members(interface, operation) ::= <<
+eprosima::fastcdr::optional<$interface.name$_$operation.name$_Result\> $operation.name$;
+>>
+
+detail_scoped_name(interface) ::= <%
+$if(interface.hasScope)$
+$interface.scope$::
+$endif$
+detail::$interface.name$
+%>
+
+rpc_struct_serialization(struct) ::= <<
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const $struct.scopedname$& data,
+        size_t& current_alignment)
+{
+    $if(!struct.scope.empty)$
+    using namespace $struct.scope$;
+    $endif$
+
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                $if(struct.annotationFinal)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2$elseif(struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2$endif$ :
+                                $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$,
+                                current_alignment)};
+
+
+    $struct.allMembers : { member | $if(!member.annotationNonSerialized)$
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId($if(struct.annotationMutable)$$member.id$$else$$member.index$$endif$),
+            data.$member.name$, current_alignment);
+    $endif$}; separator="\n"$
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const $struct.scopedname$& data)
+{
+    $if(!struct.scope.empty)$
+    using namespace $struct.scope$;
+    $endif$
+
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            $if(struct.annotationFinal)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2$elseif(struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2$endif$ :
+            $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$);
+
+    $if(struct.allMembers)$
+    scdr$struct.allMembers : { member | $if(!member.annotationNonSerialized)$
+        << eprosima::fastcdr::MemberId($if(struct.annotationMutable)$$member.id$$else$$member.index$$endif$) << data.$member.name$
+    $endif$
+    }; separator=""$;
+    $else$
+    static_cast<void>(data);
+    $endif$
+
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        $struct.scopedname$& data)
+{
+    $if(!struct.scope.empty)$
+    using namespace $struct.scope$;
+    $endif$
+
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            $if(struct.annotationFinal)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2$elseif(struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2$endif$ :
+            $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                $if(struct.allMembers)$
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                    $struct.allMembers : { member |
+                    case $if(struct.annotationMutable)$$member.id$$else$$member.index$$endif$:
+                        $if(!member.annotationNonSerialized)$
+                            dcdr \>> data.$member.name$;
+                        $endif$
+                        break;
+                    }; separator="\n"$
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+                $else$
+                static_cast<void>(data);
+                static_cast<void>(dcdr);
+                static_cast<void>(mid);
+                return false;
+                $endif$
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const $struct.scopedname$& data)
+{
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+}
+>>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectHeader.stg
@@ -84,7 +84,9 @@ $register_type_identifier(typename=enum.name)$
 >>
 
 struct_type(ctx, parent, struct, member_list) ::= <<
+$if(!struct.declaredInsideInterface)$
 $register_type_identifier(typename=struct.name)$
+$endif$
 >>
 
 typedef_decl(ctx, parent, typedefs, typedefs_type, declarator_type) ::= <<

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectHeader.stg
@@ -72,15 +72,21 @@ $register_type_identifier(typename=annotation.name)$
 >>
 
 bitmask_type(ctx, parent, bitmask) ::= <<
+$if(!bitmask.declaredInsideInterface)$
 $register_type_identifier(typename=bitmask.name)$
+$endif$
 >>
 
 bitset_type(ctx, parent, bitset) ::= <<
+$if(!bitset.declaredInsideInterface)$
 $register_type_identifier(typename=bitset.name)$
+$endif$
 >>
 
 enum_type(ctx, parent, enum) ::= <<
+$if(!enum.declaredInsideInterface)$
 $register_type_identifier(typename=enum.name)$
+$endif$
 >>
 
 struct_type(ctx, parent, struct, member_list) ::= <<
@@ -97,7 +103,9 @@ $register_type_identifier(typename=typedef.name)$
 >>
 
 union_type(ctx, parent, union, extensions, switch_type) ::= <<
+$if(!union.declaredInsideInterface)$
 $register_type_identifier(typename=union.name)$
+$endif$
 >>
 
 /***** Utils *****/

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -94,6 +94,7 @@ void register_$annotation.name$_type_identifier(
 >>
 
 bitmask_type(ctx, parent, bitmask) ::= <<
+$if(!bitmask.declaredInsideInterface)$
 void register_$bitmask.name$_type_identifier(
         TypeIdentifierPair& type_ids_$bitmask.name$)
 {
@@ -118,10 +119,12 @@ void register_$bitmask.name$_type_identifier(
         }
     }
 }
+$endif$
 >>
 
 
 bitset_type(ctx, parent, bitset, extensions) ::= <<
+$if(!bitset.declaredInsideInterface)$
 void register_$bitset.name$_type_identifier(
         TypeIdentifierPair& type_ids_$bitset.name$)
 {
@@ -144,10 +147,12 @@ void register_$bitset.name$_type_identifier(
         }
     }
 }
+$endif$
 >>
 
 
 enum_type(ctx, parent, enum) ::= <<
+$if(!enum.declaredInsideInterface)$
 void register_$enum.name$_type_identifier(
         TypeIdentifierPair& type_ids_$enum.name$)
 {
@@ -172,6 +177,7 @@ void register_$enum.name$_type_identifier(
         }
     }
 }
+$endif$
 >>
 
 struct_type(ctx, parent, struct, member_list) ::= <<
@@ -309,6 +315,7 @@ void register_$typedef.name$_type_identifier(
 >>
 
 union_type(ctx, parent, union, extensions, switch_type) ::= <<
+$if(!union.declaredInsideInterface)$
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_$union.name$_type_identifier(
         TypeIdentifierPair& type_ids_$union.name$)
@@ -373,7 +380,7 @@ void register_$union.name$_type_identifier(
                         "$union.scopedname$ contains forward declarations (not yet supported).");
     $endif$
 }
-
+$endif$
 >>
 
 /***** Utils *****/

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -175,6 +175,7 @@ void register_$enum.name$_type_identifier(
 >>
 
 struct_type(ctx, parent, struct, member_list) ::= <<
+$if(!struct.declaredInsideInterface)$
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_$struct.name$_type_identifier(
         TypeIdentifierPair& type_ids_$struct.name$)
@@ -235,7 +236,7 @@ void register_$struct.name$_type_identifier(
                         "$struct.scopedname$ contains forward declarations (not yet supported).");
     $endif$
 }
-
+$endif$
 >>
 
 typedef_decl(ctx, parent, typedefs, typedefs_type, declarator_type) ::= <<


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds C++ code generation for IDL interfaces (a.k.a RPC).

* The generated client interface provides an asynchronous API based on `std::future`.
* The generated server interface allows for aggregating the operation implementation (thus decoupling the DDS logic from the operation logic)
* Includes support for custom extension `@feed`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
This PR depends on the following ones and must be merged after them:

* https://github.com/eProsima/Fast-DDS/pull/5801
* https://github.com/eProsima/IDL-Parser/pull/172
* https://github.com/eProsima/IDL-Parser/pull/176
* https://github.com/eProsima/dds-types-test/pull/43

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
    - https://github.com/eProsima/dds-types-test/pull/43
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#1064
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
