### PR TITLE
[23151] Fix scope in TypeObjectSource.stg

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypeObjectSource.stg
@@ -90,17 +90,17 @@ $annotation.typeDefs : { it | $register_annotation_typedef(it)$}; separator="\n"
 >>
 
 register_annotation_enum(enum) ::= <<
-factory->add_type_object("$enum.name$", $if(enum.hasScope)$$enum.scope$::$endif$Get$enum.name$Identifier(true),
+factory->add_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", $if(enum.hasScope)$$enum.scope$::$endif$Get$enum.name$Identifier(true),
         $if(enum.hasScope)$$enum.scope$::$endif$Get$enum.name$Object(true));
-factory->add_type_object("$enum.name$", $if(enum.hasScope)$$enum.scope$::$endif$Get$enum.name$Identifier(false),
+factory->add_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", $if(enum.hasScope)$$enum.scope$::$endif$Get$enum.name$Identifier(false),
         $if(enum.hasScope)$$enum.scope$::$endif$Get$enum.name$Object(false));
 >>
 
 register_annotation_typedef(typedef) ::= <<
-factory->add_type_object("$typedef.name$",
+factory->add_type_object("$if(typedef.hasScope)$$typedef.scope$::$endif$$typedef.name$",
         $if(typedef.hasScope)$$typedef.scope$::$endif$Get$typedef.name$Identifier(true),
         $if(typedef.hasScope)$$typedef.scope$::$endif$Get$typedef.name$Object(true));
-factory->add_type_object("$typedef.name$",
+factory->add_type_object("$if(typedef.hasScope)$$typedef.scope$::$endif$$typedef.name$",
         $if(typedef.hasScope)$$typedef.scope$::$endif$Get$typedef.name$Identifier(false),
         $if(typedef.hasScope)$$typedef.scope$::$endif$Get$typedef.name$Object(false));
 >>
@@ -314,19 +314,19 @@ $declarator_type$
 $typedefs_type$
 const TypeIdentifier* Get$typedefs.name$Identifier(bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$typedefs.name$", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$typedefs.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$typedefs.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", complete);
 }
 
 const TypeObject* Get$typedefs.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -343,7 +343,7 @@ const TypeObject* Get$typedefs.name$Object(bool complete)
 
 const TypeObject* GetMinimal$typedefs.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -415,16 +415,16 @@ const TypeObject* GetMinimal$typedefs.name$Object()
     }
 
     // Don't add our TypeIdentifier but our alias
-    TypeObjectFactory::get_instance()->add_alias("$typedefs.name$", $get_content_type(ctx=ctx, type=typedefs.typedefContentTypeCode)$);
+    TypeObjectFactory::get_instance()->add_alias("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", $get_content_type(ctx=ctx, type=typedefs.typedefContentTypeCode)$);
 
-    TypeObjectFactory::get_instance()->add_type_object("$typedefs.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", false);
 }
 
 const TypeObject* GetComplete$typedefs.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -445,7 +445,7 @@ const TypeObject* GetComplete$typedefs.name$Object()
     //type_object->complete().alias_type().header().detail().ann_builtin().verbatim().language("language");
     //type_object->complete().alias_type().header().detail().ann_builtin().verbatim().text("text");
     //type_object->complete().alias_type().header().detail().ann_custom().push_back(...);
-    type_object->complete().alias_type().header().detail().type_name("$typedefs.name$");
+    type_object->complete().alias_type().header().detail().type_name("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$");
 
     // No flags apply
     //type_object->complete().alias_type().body().common().related_flags().TRY_CONSTRUCT1(false);
@@ -503,11 +503,11 @@ const TypeObject* GetComplete$typedefs.name$Object()
     }
 
     // Don't add our TypeIdentifier but our alias
-    TypeObjectFactory::get_instance()->add_alias("$typedefs.name$", $get_content_type(ctx=ctx, type=typedefs.typedefContentTypeCode)$);
+    TypeObjectFactory::get_instance()->add_alias("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", $get_content_type(ctx=ctx, type=typedefs.typedefContentTypeCode)$);
 
-    TypeObjectFactory::get_instance()->add_type_object("$typedefs.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$typedefs.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(typedefs.hasScope)$$typedefs.scope$::$endif$$typedefs.name$", true);
 }
 
 >>
@@ -515,19 +515,19 @@ const TypeObject* GetComplete$typedefs.name$Object()
 enum_type(ctx, parent, enum) ::= <<
 const TypeIdentifier* Get$enum.name$Identifier(bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$enum.name$", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$enum.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$enum.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", complete);
 }
 
 const TypeObject* Get$enum.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$enum.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -542,7 +542,7 @@ const TypeObject* Get$enum.name$Object(bool complete)
 
 const TypeObject* GetMinimal$enum.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$enum.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -592,14 +592,14 @@ const TypeObject* GetMinimal$enum.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$enum.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$enum.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", false);
 }
 
 const TypeObject* GetComplete$enum.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$enum.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -617,7 +617,7 @@ const TypeObject* GetComplete$enum.name$Object()
     //type_object->complete().enumerated_type().enum_flags().IS_AUTOID_HASH(false);
 
     type_object->complete().enumerated_type().header().common().bit_bound(32); // TODO fixed by IDL, isn't?
-    type_object->complete().enumerated_type().header().detail().type_name("$enum.name$");
+    type_object->complete().enumerated_type().header().detail().type_name("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$");
 
     $if(enum.annotationList)$
     $enum.annotationList:{ ann |
@@ -678,9 +678,9 @@ const TypeObject* GetComplete$enum.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$enum.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$enum.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(enum.hasScope)$$enum.scope$::$endif$$enum.name$", true);
 }
 
 >>
@@ -752,19 +752,19 @@ struct_type(ctx, parent, struct, extensions, member_list) ::= <<
 $member_list$
 const TypeIdentifier* Get$struct.name$Identifier(bool complete)
 {
-    const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$struct.name$", complete);
+    const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$struct.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$struct.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", complete);
 }
 
 const TypeObject* Get$struct.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$struct.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -779,7 +779,7 @@ const TypeObject* Get$struct.name$Object(bool complete)
 
 const TypeObject* GetMinimal$struct.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$struct.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -834,14 +834,14 @@ const TypeObject* GetMinimal$struct.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$struct.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$struct.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", false);
 }
 
 const TypeObject* GetComplete$struct.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$struct.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -861,7 +861,7 @@ const TypeObject* GetComplete$struct.name$Object()
     $struct.members:{ member | $complete_member_object_type(ctx=ctx, object=member)$}; separator="\n"$
 
     // Header
-    type_object->complete().struct_type().header().detail().type_name("$struct.name$");
+    type_object->complete().struct_type().header().detail().type_name("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$");
     // TODO inheritance
     $if(struct.inheritance)$
     $complete_struct_inheritance(struct.inheritance)$
@@ -923,9 +923,9 @@ const TypeObject* GetComplete$struct.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$struct.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$struct.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(struct.hasScope)$$struct.scope$::$endif$$struct.name$", true);
 }
 
 >>
@@ -1034,19 +1034,19 @@ union_type(ctx, parent, union, switch_type) ::= <<
 $switch_type$
 const TypeIdentifier* Get$union.name$Identifier(bool complete)
 {
-    const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$union.name$", complete);
+    const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(union.hasScope)$$union.scope$::$endif$$union.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$union.name$Object(complete);
-    return TypeObjectFactory::get_instance()->get_type_identifier("$union.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(union.hasScope)$$union.scope$::$endif$$union.name$", complete);
 }
 
 const TypeObject* Get$union.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$union.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1061,7 +1061,7 @@ const TypeObject* Get$union.name$Object(bool complete)
 
 const TypeObject* GetMinimal$union.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$union.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1121,15 +1121,15 @@ const TypeObject* GetMinimal$union.name$Object()
         identifier->equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$union.name$", identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", identifier, type_object);
     delete type_object;
     delete identifier;
-    return TypeObjectFactory::get_instance()->get_type_object("$union.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", false);
 }
 
 const TypeObject* GetComplete$union.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$union.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -1187,7 +1187,7 @@ const TypeObject* GetComplete$union.name$Object()
     $union.members:{ member | $complete_union_member_object_type(ctx=ctx, object=member, discriminator=union.discriminator)$}; separator="\n"$
 
     // Header
-    type_object->complete().union_type().header().detail().type_name("$union.name$");
+    type_object->complete().union_type().header().detail().type_name("$if(union.hasScope)$$union.scope$::$endif$$union.name$");
 
     $if(union.annotationList)$
     $union.annotationList:{ ann |
@@ -1245,10 +1245,10 @@ const TypeObject* GetComplete$union.name$Object()
         identifier->equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$union.name$", identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", identifier, type_object);
     delete type_object;
     delete identifier;
-    return TypeObjectFactory::get_instance()->get_type_object("$union.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(union.hasScope)$$union.scope$::$endif$$union.name$", true);
 }
 
 >>
@@ -1352,19 +1352,19 @@ $declarator$
 bitmask_type(ctx, parent, bitmask) ::= <<
 const TypeIdentifier* Get$bitmask.name$Identifier(bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$bitmask.name$", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$bitmask.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$bitmask.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", complete);
 }
 
 const TypeObject* Get$bitmask.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1379,7 +1379,7 @@ const TypeObject* Get$bitmask.name$Object(bool complete)
 
 const TypeObject* GetMinimal$bitmask.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1421,14 +1421,14 @@ const TypeObject* GetMinimal$bitmask.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$bitmask.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", false);
 }
 
 const TypeObject* GetComplete$bitmask.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -1475,7 +1475,7 @@ const TypeObject* GetComplete$bitmask.name$Object()
     }; separator="\n"$
     $endif$
 
-    type_object->complete().bitmask_type().header().detail().type_name("$bitmask.name$");
+    type_object->complete().bitmask_type().header().detail().type_name("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$");
 
     $bitmask.members:{ member | $complete_bitmask_flag(ctx=ctx, object=member)$}; separator="\n"$
 
@@ -1507,9 +1507,9 @@ const TypeObject* GetComplete$bitmask.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$bitmask.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$bitmask.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(bitmask.hasScope)$$bitmask.scope$::$endif$$bitmask.name$", true);
 }
 
 >>
@@ -1602,19 +1602,19 @@ type_object->complete().bitmask_type().flag_seq().emplace_back(cbf_$object.name$
 bitset_type(ctx, parent, bitset, extensions) ::= <<
 const TypeIdentifier* Get$bitset.name$Identifier(bool complete)
 {
-    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$bitset.name$", complete);
+    const TypeIdentifier* c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", complete);
     if (c_identifier != nullptr && (!complete || c_identifier->_d() == EK_COMPLETE))
     {
         return c_identifier;
     }
 
     Get$bitset.name$Object(complete); // Generated inside
-    return TypeObjectFactory::get_instance()->get_type_identifier("$bitset.name$", complete);
+    return TypeObjectFactory::get_instance()->get_type_identifier("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", complete);
 }
 
 const TypeObject* Get$bitset.name$Object(bool complete)
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", complete);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", complete);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1629,7 +1629,7 @@ const TypeObject* Get$bitset.name$Object(bool complete)
 
 const TypeObject* GetMinimal$bitset.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", false);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", false);
     if (c_type_object != nullptr)
     {
         return c_type_object;
@@ -1673,14 +1673,14 @@ const TypeObject* GetMinimal$bitset.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$bitset.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", false);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", false);
 }
 
 const TypeObject* GetComplete$bitset.name$Object()
 {
-    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", true);
+    const TypeObject* c_type_object = TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", true);
     if (c_type_object != nullptr && c_type_object->_d() == EK_COMPLETE)
     {
         return c_type_object;
@@ -1725,7 +1725,7 @@ const TypeObject* GetComplete$bitset.name$Object()
     }; separator="\n"$
     $endif$
 
-    type_object->complete().bitset_type().header().detail().type_name("$bitset.name$");
+    type_object->complete().bitset_type().header().detail().type_name("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$");
 
     $bitset.bitfields:{ member | $complete_bitfield(ctx=ctx, object=member)$}; separator="\n"$
 
@@ -1761,9 +1761,9 @@ const TypeObject* GetComplete$bitset.name$Object()
         identifier.equivalence_hash()[i] = objectHash.digest[i];
     }
 
-    TypeObjectFactory::get_instance()->add_type_object("$bitset.name$", &identifier, type_object);
+    TypeObjectFactory::get_instance()->add_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", &identifier, type_object);
     delete type_object;
-    return TypeObjectFactory::get_instance()->get_type_object("$bitset.name$", true);
+    return TypeObjectFactory::get_instance()->get_type_object("$if(bitset.hasScope)$$bitset.scope$::$endif$$bitset.name$", true);
 }
 
 >>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
This PR adds the scope (if present) to certain type values.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
