### PR TITLE
[23150] Apply user template to included IDL files

### DIFF
--- a/src/main/java/com/eprosima/fastdds/fastddsgen.java
+++ b/src/main/java/com/eprosima/fastdds/fastddsgen.java
@@ -874,10 +874,10 @@ public class fastddsgen
             }
             else
             {
-                // Check if there is a '$' in the output_file_name
+                // Check if there is a '@' in the output_file_name
                 for (Map.Entry<String, String> entry : m_customStgOutput.entrySet())
                 {
-                    if (entry.getValue().contains("$"))
+                    if (entry.getValue().contains("@"))
                     {
                         System.out.println("Loading custom template " +
                                 entry.getKey() + " for included IDL file " + idlFilename + "...");
@@ -924,10 +924,8 @@ public class fastddsgen
                 {
                     for (Map.Entry<String, String> entry : m_customStgOutput.entrySet())
                     {
-                        String templatePath = entry.getKey();
-                        String outputName = entry.getValue().replace("$", "");
                         if (! (returnedValue = createOutputCustomTemplate(
-                                    templatePath, outputName, output_dir, relative_dir, ctx.getFilename(),
+                                    entry, idlFilename, output_dir, relative_dir, ctx.getFilename(),
                                     maintemplates, m_replace, project)))
                         {
                             break;
@@ -939,12 +937,10 @@ public class fastddsgen
                     // Check if there is a '$' in the output_file_name
                     for (Map.Entry<String, String> entry : m_customStgOutput.entrySet())
                     {
-                        if (entry.getValue().contains("$"))
+                        if (entry.getValue().contains("@"))
                         {
-                            String templatePath = entry.getKey();
-                            String outputName = entry.getValue().replace("$", idlFilename.substring(0, idlFilename.lastIndexOf('.')));
                             if (! (returnedValue = createOutputCustomTemplate(
-                                        templatePath, outputName, output_dir, relative_dir, ctx.getFilename(),
+                                        entry, idlFilename, output_dir, relative_dir, ctx.getFilename(),
                                         maintemplates, m_replace, project)))
                             {
                                 break;
@@ -1207,8 +1203,8 @@ public class fastddsgen
     }
 
     private boolean createOutputCustomTemplate(
-            String templatePath,
-            String outputName,
+            Map.Entry<String, String> entry,
+            String idlFilename,
             String outputDir,
             String relativeDir,
             String contextFilename,
@@ -1216,9 +1212,10 @@ public class fastddsgen
             boolean replace,
             Project project)
     {
-        Path path = Paths.get(templatePath);
+        Path path = Paths.get(entry.getKey());
         String templateName = path.getFileName().toString();
         templateName = templateName.substring(0, templateName.lastIndexOf('.'));
+        String outputName = entry.getValue().replace("@", idlFilename.substring(0, idlFilename.lastIndexOf('.')));
         System.out.println("Generating from custom " + templateName + " to " + outputName);
 
         boolean ret_val = Utils.writeFile(outputDir + outputName, maintemplates.getTemplate(templateName), replace);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
This PR adds the required logic to apply user templates to included IDL files.
If the `output file name` specified in `-extrastg` contains the character '@', the custom template will be also applied to included IDL files. The '$' will be replaced with the included file name. 

Usage example:
  `-extrastg /path/to/template/Custom.stg @MyCustomTemplate.cpp`

Above command will generate file: `HelloWorldMyCustomTemplate.cpp` in case `HelloWorld.idl` was included.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 4.0.x 3.3.x 2.5.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/1066
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
