### PR TITLE
[23271] Allow injection of execution scheduling to RPC servers

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -141,7 +141,7 @@ struct $interface.name$ServerSchedulingStrategy
  * @param service_name     The name of the service.
  * @param qos              The QoS settings for the server.
  * @param thread_pool_size The size of the thread pool to use for processing requests.
- *                         When set to 0, a new thread will be created when no threads are available.
+ *                         When set to 0, a pool with a single thread will be created.
  * @param implementation   The implementation of the server interface.
  */
 extern eProsima_user_DllExport std::shared_ptr<$interface.name$Server> create_$interface.name$Server(

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -150,6 +150,22 @@ extern eProsima_user_DllExport std::shared_ptr<$interface.name$Server> create_$i
         const eprosima::fastdds::dds::ReplierQos& qos,
         size_t thread_pool_size,
         std::shared_ptr<$interface.name$Server_IServerImplementation> implementation);
+
+/**
+ * @brief Create a $interface.name$Server instance.
+ *
+ * @param part            The DomainParticipant to use for the server.
+ * @param service_name    The name of the service.
+ * @param qos             The QoS settings for the server.
+ * @param scheduler       The request scheduling strategy to use for the server.
+ * @param implementation  The implementation of the server interface.
+ */
+extern eProsima_user_DllExport std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        std::shared_ptr<$interface.name$ServerSchedulingStrategy> scheduler,
+        std::shared_ptr<$interface.name$Server_IServerImplementation> implementation);
 $endif$
 >>
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -117,6 +117,15 @@ struct $interface.name$ServerSchedulingStrategy
     /**
      * @brief Schedule a request for processing.
      *
+     * This method is called when a request is received and should be processed by the server.
+     * The implementation should decide how to handle the request, whether to process it immediately,
+     * or to queue it for later processing.
+     *
+     * A call to server->execute_request(request) should eventually be made to process the request.
+     *
+     * @note This method is called from the thread that takes requests and input feed values, so it
+     *       should not directly execute the request for operations that have input feed parameters.
+     *
      * @param request  The request to schedule.
      * @param server   The server instance that should process the request.
      */

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -96,7 +96,11 @@ struct $interface.name$Server
      * @brief Stop the server.
      *
      * This method stops the server and releases all resources.
-     * It will cancel all pending requests, and wait for all processing threads to finish before returning.
+     * It will cancel all pending requests, and then @c call server_stopped on the request scheduler to let
+     * it release any resources associated to this server.
+     *
+     * When the server has been created with the factory method that receives a @c thread_pool_size argument,
+     * it will wait for all threads in the pool to finish before returning.
      */
     virtual void stop() = 0;
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -124,6 +124,14 @@ struct $interface.name$ServerSchedulingStrategy
             const std::shared_ptr<$interface.name$Server_ClientContext>& request,
             const std::shared_ptr<$interface.name$Server>& server) = 0;
 
+    /**
+     * @brief Informs that a server has been stopped and all its requests have been cancelled.
+     *
+     * @param server  The server instance that has been stopped.
+     */
+    virtual void server_stopped(
+            const std::shared_ptr<$interface.name$Server>& server) = 0;
+
 };
 
 /**

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -100,6 +100,14 @@ struct $interface.name$Server
      */
     virtual void stop() = 0;
 
+    /**
+     * @brief Perform execution of a client request.
+     *
+     * @param request The client request to execute.
+     */
+    virtual void execute_request(
+            const std::shared_ptr<$interface.name$Server_ClientContext>& request) = 0;
+
 };
 
 /**

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerHeader.stg
@@ -110,6 +110,22 @@ struct $interface.name$Server
 
 };
 
+struct $interface.name$ServerSchedulingStrategy
+{
+    virtual ~$interface.name$ServerSchedulingStrategy() = default;
+
+    /**
+     * @brief Schedule a request for processing.
+     *
+     * @param request  The request to schedule.
+     * @param server   The server instance that should process the request.
+     */
+    virtual void schedule_request(
+            const std::shared_ptr<$interface.name$Server_ClientContext>& request,
+            const std::shared_ptr<$interface.name$Server>& server) = 0;
+
+};
+
 /**
  * @brief Create a $interface.name$Server instance.
  *

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -78,7 +78,7 @@ namespace frtps = eprosima::fastdds::rtps;
 
 class $interface.name$ServerLogic
     : public $interface.name$Server
-    , private std::enable_shared_from_this<$interface.name$ServerLogic>
+    , public std::enable_shared_from_this<$interface.name$ServerLogic>
 {
     using RequestType = $interface.name$_Request;
     using ReplyType = $interface.name$_Reply;

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -93,7 +93,7 @@ public:
             std::shared_ptr<$interface.name$Server_IServerImplementation> implementation)
         : $interface.name$Server()
         , participant_(part)
-        , thread_pool_(*this, thread_pool_size)
+        , request_scheduler_(std::make_shared<ThreadPool>(*this, thread_pool_size))
         , implementation_(std::move(implementation))
     {
         // Register the service type support
@@ -189,7 +189,7 @@ public:
         }
 
         // Wait for all threads to finish
-        thread_pool_.server_stopped(shared_from_this());
+        request_scheduler_->server_stopped(shared_from_this());
     }
 
 private:
@@ -462,7 +462,7 @@ $endif$
             processing_requests_[id] = ctx;
         }
 
-        thread_pool_.schedule_request(ctx, shared_from_this());
+        request_scheduler_->schedule_request(ctx, shared_from_this());
     }
 
     void execute_request(
@@ -513,7 +513,7 @@ $endif$
     fdds::GuardCondition finish_condition_;
     std::mutex mtx_;
     std::map<frtps::SampleIdentity, std::shared_ptr<RequestContext\>> processing_requests_;
-    ThreadPool thread_pool_;
+    std::shared_ptr<$interface.name$ServerSchedulingStrategy> request_scheduler_;
     std::shared_ptr<$interface.name$Server_IServerImplementation> implementation_;
 
 };

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -86,14 +86,29 @@ class $interface.name$ServerLogic
 public:
 
     $interface.name$ServerLogic(
-            eprosima::fastdds::dds::DomainParticipant& part,
+            fdds::DomainParticipant& part,
             const char* service_name,
-            const eprosima::fastdds::dds::ReplierQos& qos,
+            const fdds::ReplierQos& qos,
             size_t thread_pool_size,
+            std::shared_ptr<$interface.name$Server_IServerImplementation> implementation)
+        : $interface.name$ServerLogic(
+                part,
+                service_name,
+                qos,
+                std::make_shared<ThreadPool>(*this, thread_pool_size),
+                std::move(implementation))
+    {
+    }
+
+    $interface.name$ServerLogic(
+            fdds::DomainParticipant& part,
+            const char* service_name,
+            const fdds::ReplierQos& qos,
+            std::shared_ptr<$interface.name$ServerSchedulingStrategy> scheduler,
             std::shared_ptr<$interface.name$Server_IServerImplementation> implementation)
         : $interface.name$Server()
         , participant_(part)
-        , request_scheduler_(std::make_shared<ThreadPool>(*this, thread_pool_size))
+        , request_scheduler_(scheduler)
         , implementation_(std::move(implementation))
     {
         // Register the service type support

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -136,8 +136,6 @@ public:
 
     ~$interface.name$ServerLogic() override
     {
-        stop();
-
         if (nullptr != replier_)
         {
             participant_.delete_service_replier(service_->get_service_name(), replier_);
@@ -533,6 +531,44 @@ $endif$
 
 };
 
+struct $interface.name$ServerProxy
+    : public $interface.name$Server
+{
+    $interface.name$ServerProxy(
+            std::shared_ptr<$interface.name$Server> impl)
+        : impl_(std::move(impl))
+    {
+    }
+
+    ~$interface.name$ServerProxy() override
+    {
+        if (impl_)
+        {
+            impl_->stop();
+        }
+    }
+
+    void run() override
+    {
+        impl_->run();
+    }
+
+    void stop() override
+    {
+        impl_->stop();
+    }
+
+    void execute_request(
+            const std::shared_ptr<$interface.name$Server_ClientContext>& request) override
+    {
+        impl_->execute_request(request);
+    }
+
+private:
+
+   std::shared_ptr<$interface.name$Server> impl_;
+};
+
 }  // namespace detail
 
 std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
@@ -542,8 +578,9 @@ std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
         size_t thread_pool_size,
         std::shared_ptr<$interface.name$Server_IServerImplementation> implementation)
 {
-    return std::make_shared<detail::$interface.name$ServerLogic>(
+    auto ptr = std::make_shared<detail::$interface.name$ServerLogic>(
         part, service_name, qos, thread_pool_size, implementation);
+    return std::make_shared<detail::$interface.name$ServerProxy>(ptr);
 }
 
 std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
@@ -553,8 +590,9 @@ std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
         std::shared_ptr<$interface.name$ServerSchedulingStrategy> scheduler,
         std::shared_ptr<$interface.name$Server_IServerImplementation> implementation)
 {
-    return std::make_shared<detail::$interface.name$ServerLogic>(
+    auto ptr = std::make_shared<detail::$interface.name$ServerLogic>(
         part, service_name, qos, scheduler, implementation);
+    return std::make_shared<detail::$interface.name$ServerProxy>(ptr);
 }
 
 //} interface $interface.name$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -205,6 +205,20 @@ public:
         request_scheduler_->server_stopped(shared_from_this());
     }
 
+    void execute_request(
+            const std::shared_ptr<$interface.name$Server_ClientContext>& request) override
+    {
+        auto ctx = std::dynamic_pointer_cast<RequestContext>(request);
+        if (ctx)
+        {
+            execute_request(ctx);
+        }
+        else
+        {
+            throw std::runtime_error("Invalid request context type");
+        }
+    }
+
 private:
 
     //{ Output feed helpers
@@ -476,20 +490,6 @@ $endif$
         }
 
         request_scheduler_->schedule_request(ctx, shared_from_this());
-    }
-
-    void execute_request(
-            const std::shared_ptr<$interface.name$Server_ClientContext>& request) override
-    {
-        auto ctx = std::dynamic_pointer_cast<RequestContext>(request);
-        if (ctx)
-        {
-            execute_request(ctx);
-        }
-        else
-        {
-            throw std::runtime_error("Invalid request context type");
-        }
     }
 
     void execute_request(

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -546,6 +546,17 @@ std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
         part, service_name, qos, thread_pool_size, implementation);
 }
 
+std::shared_ptr<$interface.name$Server> create_$interface.name$Server(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        std::shared_ptr<$interface.name$ServerSchedulingStrategy> scheduler,
+        std::shared_ptr<$interface.name$Server_IServerImplementation> implementation)
+{
+    return std::make_shared<detail::$interface.name$ServerLogic>(
+        part, service_name, qos, scheduler, implementation);
+}
+
 //} interface $interface.name$
 $endif$
 >>

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -78,6 +78,7 @@ namespace frtps = eprosima::fastdds::rtps;
 
 class $interface.name$ServerLogic
     : public $interface.name$Server
+    , private std::enable_shared_from_this<$interface.name$ServerLogic>
 {
     using RequestType = $interface.name$_Request;
     using ReplyType = $interface.name$_Reply;
@@ -346,6 +347,7 @@ $endif$
     };
 
     struct ThreadPool
+        : public $interface.name$ServerSchedulingStrategy
     {
         ThreadPool(
                 $interface.name$ServerLogic& server,
@@ -362,7 +364,7 @@ $endif$
                     {
                         while (!finished_)
                         {
-                            std::shared_ptr<RequestContext> req;
+                            std::shared_ptr<$interface.name$Server_ClientContext> req;
                             {
                                 std::unique_lock<std::mutex> lock(mtx_);
                                 cv_.wait(lock, [this]()
@@ -388,9 +390,12 @@ $endif$
             }
         }
 
-        void new_request(
-                const std::shared_ptr<RequestContext>& req)
+        void schedule_request(
+                const std::shared_ptr<$interface.name$Server_ClientContext>& req,
+                const std::shared_ptr<$interface.name$Server>& server) override
         {
+            static_cast<void>(server);
+
             std::lock_guard<std::mutex> lock(mtx_);
             if (!finished_)
             {
@@ -422,7 +427,7 @@ $endif$
         $interface.name$ServerLogic& server_;
         std::mutex mtx_;
         std::condition_variable cv_;
-        std::queue<std::shared_ptr<RequestContext\>> requests_;
+        std::queue<std::shared_ptr<$interface.name$Server_ClientContext\>> requests_;
         bool finished_{ false };
         std::vector<std::thread> threads_;
     };
@@ -454,7 +459,7 @@ $endif$
             processing_requests_[id] = ctx;
         }
 
-        thread_pool_.new_request(ctx);
+        thread_pool_.schedule_request(ctx, shared_from_this());
     }
 
     void execute_request(

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -189,7 +189,7 @@ public:
         }
 
         // Wait for all threads to finish
-        thread_pool_.stop();
+        thread_pool_.server_stopped(shared_from_this());
     }
 
 private:
@@ -404,8 +404,11 @@ $endif$
             }
         }
 
-        void stop()
+        void server_stopped(
+                const std::shared_ptr<$interface.name$Server>& server) override
         {
+            static_cast<void>(server);
+
             // Notify all threads in the pool to stop
             {
                 std::lock_guard<std::mutex> lock(mtx_);

--- a/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/ServerSource.stg
@@ -458,6 +458,20 @@ $endif$
     }
 
     void execute_request(
+            const std::shared_ptr<$interface.name$Server_ClientContext>& request) override
+    {
+        auto ctx = std::dynamic_pointer_cast<RequestContext>(request);
+        if (ctx)
+        {
+            execute_request(ctx);
+        }
+        else
+        {
+            throw std::runtime_error("Invalid request context type");
+        }
+    }
+
+    void execute_request(
             const std::shared_ptr<RequestContext>& req)
     {
         try


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This adds a `ServerSchedulingStrategy` interface for each generated RPC server, allowing the user to create a server with a custom scheduling of requests, instead of always using a thread pool.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- __NO__: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
    - Tests for interfaces will be added in a follow-up
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
