### PR TITLE
[23268] Generate TypeObject support code for RPC generated types

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectHeader.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectHeader.stg
@@ -108,6 +108,13 @@ $register_type_identifier(typename=union.name)$
 $endif$
 >>
 
+interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
+$register_type_identifier(typename=interface.requestTypeCode.name)$
+$register_type_identifier(typename=interface.replyTypeCode.name)$
+$endif$
+>>
+
 /***** Utils *****/
 register_type_identifier(typename) ::= <<
 /**

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -32,6 +32,9 @@ $fileHeader(ctx=ctx, file=[ctx.filename, "TypeObjectSupport.cxx"], description=[
 #include <fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp>
 #include <fastdds/dds/xtypes/type_representation/TypeObject.hpp>
 #include <fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp>
+$if(ctx.thereIsInterface)$
+#include <fastdds/dds/rpc/RPCTypeObjectSupport.hpp>
+$endif$
 
 #include "$ctx.filename$.hpp"
 

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -388,6 +388,13 @@ $endif$
 >>
 
 interface(ctx, parent, interface, export_list) ::= <<
+
+namespace detail {
+
+$interface.operations : { operation | $operation_details(interface, operation)$ }; separator="\n"$
+
+}  // namespace detail
+
 $if(!interface.annotatedAsNested)$
 $content_for_struct_type(ctx, interface.requestTypeCode)$
 $content_for_struct_type(ctx, interface.replyTypeCode)$
@@ -395,6 +402,36 @@ $endif$
 >>
 
 /***** Utils *****/
+operation_details(interface, operation) ::= <<
+//{ $operation.name$
+$operation_in_struct(interface, operation)$
+
+$operation.inputparam : { param | $if (param.annotationFeed)$$operation_feed_struct(interface, operation, param)$$endif$ }$
+
+$operation_out_struct(interface, operation)$
+
+$operation_result_struct(interface, operation)$
+
+//}  // $operation.name$
+
+>>
+
+operation_in_struct(interface, operation) ::= <<
+$content_for_struct_type(ctx, operation.inTypeCode)$
+>>
+
+operation_feed_struct(interface, operation, param) ::= <<
+$content_for_struct_type(ctx, param.feedTypeCode)$
+>>
+
+operation_out_struct(interface, operation) ::= <<
+$content_for_struct_type(ctx, operation.outTypeCode)$
+>>
+
+operation_result_struct(interface, operation) ::= <<
+$content_for_struct_type(ctx, operation.resultTypeCode)$
+>>
+
 register_type(ctx, object) ::= <<
 $if (object.isTypeDeclaration)$
 $if ((object.typeCode.isStructType || object.typeCode.isUnionType) && !object.typeCode.forwarded)$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -181,9 +181,7 @@ $endif$
 >>
 
 struct_type(ctx, parent, struct, member_list) ::= <<
-$if(!struct.declaredInsideInterface)$
 $content_for_struct_type(ctx, struct)$
-$endif$
 >>
 
 content_for_struct_type(ctx, struct) ::= <<
@@ -207,7 +205,7 @@ void register_$struct.name$_type_identifier(
         $get_type_identifier(type=struct.inheritance, name=struct.name)$
         if (return_code_$struct.name$ != eprosima::fastdds::dds::RETCODE_OK)
         {
-            $struct.inheritance.scope$::register_$struct.inheritance.name$_type_identifier(type_ids_$struct.name$);
+            $struct.inheritance.namespace$::register_$struct.inheritance.name$_type_identifier(type_ids_$struct.name$);
         }
         $endif$
         $complete_type_detail(type=struct, type_kind=" Structure", name=struct.name)$
@@ -339,9 +337,9 @@ void register_$union.name$_type_identifier(
         if (return_code_$union.name$ != eprosima::fastdds::dds::RETCODE_OK)
         {
             $if (union.discriminator.typecode.isAliasType)$
-            $union.discriminator.typecode.scope$::register_$union.discriminator.typecode.name$_type_identifier(type_ids_$union.name$);
+            $union.discriminator.typecode.namespace$::register_$union.discriminator.typecode.name$_type_identifier(type_ids_$union.name$);
             $elseif (union.discriminator.typecode.isEnumType)$
-            $union.discriminator.typecode.scope$::register_$union.discriminator.typecode.name$_type_identifier(type_ids_$union.name$);
+            $union.discriminator.typecode.namespace$::register_$union.discriminator.typecode.name$_type_identifier(type_ids_$union.name$);
             $else$
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "Union discriminator TypeIdentifier unknown to TypeObjectRegistry.");
@@ -387,7 +385,13 @@ void register_$union.name$_type_identifier(
 $endif$
 >>
 
+exception(ctx, parent, exception, extensions) ::= <<
+$content_for_struct_type(ctx, exception.typeCode)$
+>>
+
 interface(ctx, parent, interface, export_list) ::= <<
+
+$export_list$
 
 namespace detail {
 
@@ -435,10 +439,10 @@ $content_for_struct_type(ctx, operation.resultTypeCode)$
 register_type(ctx, object) ::= <<
 $if (object.isTypeDeclaration)$
 $if ((object.typeCode.isStructType || object.typeCode.isUnionType) && !object.typeCode.forwarded)$
-$if (!object.scope.empty)$$object.scope$::$endif$register_$object.name$_type_identifier(type_id);
+$if (!object.namespace.empty)$$object.namespace$::$endif$register_$object.name$_type_identifier(type_id);
 $endif$
 $elseif (object.isAnnotation)$
-$if (!object.scope.empty)$$object.scope$::$endif$register_$object.name$_type_identifier(type_id);
+$if (!object.namespace.empty)$$object.namespace$::$endif$register_$object.name$_type_identifier(type_id);
 $endif$
 >>
 
@@ -559,9 +563,9 @@ annotation_parameter(param, parent) ::= <<
     if (return_code_$param.name$ != eprosima::fastdds::dds::RETCODE_OK)
     {
         $if (param.typecode.isAliasType)$
-        $param.typecode.scope$::register_$param.typecode.name$_type_identifier(type_ids_$param.name$);
+        $param.typecode.namespace$::register_$param.typecode.name$_type_identifier(type_ids_$param.name$);
         $elseif (param.typecode.isEnumType)$
-        $param.typecode.scope$::register_$param.typecode.name$_type_identifier(type_ids_$param.name$);
+        $param.typecode.namespace$::register_$param.typecode.name$_type_identifier(type_ids_$param.name$);
         $elseif (param.typecode.isStringType)$
         $register_string_type(string=param.typecode, name=param.name)$
         $elseif (param.typecode.isWStringType)$
@@ -950,13 +954,13 @@ check_register_type_identifier(type, message, name) ::= <<
 if (eprosima::fastdds::dds::RETCODE_OK != return_code_$name$)
 {
     $if (type.isAliasType)$
-    $type.scope$::register_$type.name$_type_identifier(type_ids_$name$);
+    $type.namespace$::register_$type.name$_type_identifier(type_ids_$name$);
     $elseif (type.isStructType)$
-    $type.scope$::register_$type.name$_type_identifier(type_ids_$name$);
+    $type.namespace$::register_$type.name$_type_identifier(type_ids_$name$);
     $elseif (type.isUnionType)$
-    $type.scope$::register_$type.name$_type_identifier(type_ids_$name$);
+    $type.namespace$::register_$type.name$_type_identifier(type_ids_$name$);
     $elseif (type.isBitsetType)$
-    $type.scope$::register_$type.name$_type_identifier(type_ids_$name$);
+    $type.namespace$::register_$type.name$_type_identifier(type_ids_$name$);
     $elseif (type.isSequenceType)$
     $register_sequence_type(sequence=type, name=name)$
     $elseif (type.isArrayType)$
@@ -964,9 +968,9 @@ if (eprosima::fastdds::dds::RETCODE_OK != return_code_$name$)
     $elseif (type.isMapType)$
     $register_map_type(map=type, name=name)$
     $elseif (type.isEnumType)$
-    $type.scope$::register_$type.name$_type_identifier(type_ids_$name$);
+    $type.namespace$::register_$type.name$_type_identifier(type_ids_$name$);
     $elseif (type.isBitmaskType)$
-    $type.scope$::register_$type.name$_type_identifier(type_ids_$name$);
+    $type.namespace$::register_$type.name$_type_identifier(type_ids_$name$);
     $elseif (type.isStringType)$
     $register_string_type(string=type, name=name)$
     $elseif (type.isWStringType)$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/XTypesTypeObjectSource.stg
@@ -182,6 +182,11 @@ $endif$
 
 struct_type(ctx, parent, struct, member_list) ::= <<
 $if(!struct.declaredInsideInterface)$
+$content_for_struct_type(ctx, struct)$
+$endif$
+>>
+
+content_for_struct_type(ctx, struct) ::= <<
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_$struct.name$_type_identifier(
         TypeIdentifierPair& type_ids_$struct.name$)
@@ -242,7 +247,6 @@ void register_$struct.name$_type_identifier(
                         "$struct.scopedname$ contains forward declarations (not yet supported).");
     $endif$
 }
-$endif$
 >>
 
 typedef_decl(ctx, parent, typedefs, typedefs_type, declarator_type) ::= <<
@@ -380,6 +384,13 @@ void register_$union.name$_type_identifier(
                         "$union.scopedname$ contains forward declarations (not yet supported).");
     $endif$
 }
+$endif$
+>>
+
+interface(ctx, parent, interface, export_list) ::= <<
+$if(!interface.annotatedAsNested)$
+$content_for_struct_type(ctx, interface.requestTypeCode)$
+$content_for_struct_type(ctx, interface.replyTypeCode)$
 $endif$
 >>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This adds XTypes registration of interface detail types (i.e. request and reply types)

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

This PR depends on the following:
- https://github.com/eProsima/Fast-DDS/pull/5889

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
