### PR TITLE
[23675] Add python-string getter from fixed string

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -154,10 +154,10 @@ class RpcFuture {
     ~RpcFuture();
     RpcFuture& operator=(const RpcFuture& rhs) = delete;
     RpcFuture& operator=(RpcFuture&&) noexcept;
- 
+
     // retrieving the value
     R get();
- 
+
     // functions to check state
     bool valid() const noexcept;
     void wait() const;
@@ -350,6 +350,11 @@ $if(member.typecode.isStringType && member.typecode.isBounded)$
         eprosima::fastcdr::fixed_string<$member.typecode.maxsize$> tmp(value);
         \$self->$member.name$(tmp);
     }
+
+    std::string $member.name$_str() const
+    {
+        return std::string(\$self->$member.name$(), strnlen(\$self->$member.name$(), $member.typecode.maxsize$));
+    }
 }
 $endif$
 
@@ -406,7 +411,7 @@ output_non_feed(type) ::= <<
 %shared_ptr(eprosima::fastdds::dds::rpc::RpcFuture<$type.cppTypename$>);
 %template($type.formatedCppTypename$_rpc_future) eprosima::fastdds::dds::rpc::RpcFuture<$type.cppTypename$>;
 
-$! 
+$!
 // Combine the typemap from shared_ptr
 // https://github.com/swig/swig/blob/b96b955ca15a01f0425fb26c234528530923202a/Lib/python/boost_shared_ptr.i#L41-L44
 // with the use of the 'optimal' attribute to avoid the need for a copy constructor, inspired by


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR introduces a Python string getter for fixed string members.

The generated getter follows the naming convention:
- <member_name>_str

This provides direct access to the member value as a Python str.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
-  N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
