### PR TITLE
[23657] Remove EOL versions & add new nightly for Fast DDS 3.2.x with 4.1.x

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->
+<!-- @Mergifyio backport 3.3.x 2.1.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 4.0.x 3.3.x 2.5.x 2.1.x -->
+<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -71,18 +71,3 @@ jobs:
       run-build: true
       run-tests: true
       use-ccache: false
-
-  nightly-ubuntu-ci-2_5_x:
-    uses: eProsima/Fast-DDS-Gen/.github/workflows/reusable-ubuntu-ci.yml@2.5.x
-    with:
-      os-version: 'ubuntu-22.04'
-      java-version: 'openjdk-11-jdk'
-      label: 'nightly-ubuntu-ci-2.5.x'
-      fastddsgen-branch: '2.5.x'
-      fastdds-branch: '2.10.x'
-      fastcdr-branch: '1.0.x'
-      fastdds-python-branch: '1.2.x'
-      discovery-server-branch: 'v1.2.1'
-      run-build: true
-      run-tests: true
-      use-ccache: false

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -27,6 +27,27 @@ jobs:
       run-tests: true
       use-ccache: false
 
+  nightly-ubuntu-ci-4_1_x:
+      strategy:
+        fail-fast: false
+        matrix:
+          java-version:
+            - 'openjdk-11-jdk'
+            - 'openjdk-19-jdk'
+      uses: eProsima/Fast-DDS-Gen/.github/workflows/reusable-ubuntu-ci.yml@4.1.x
+      with:
+        os-version: 'ubuntu-22.04'
+        java-version: ${{ matrix.java-version }}
+        label: 'nightly-ubuntu-ci-4.1.x'
+        fastddsgen-branch: '4.1.x'
+        fastdds-branch: '3.2.x'
+        fastcdr-branch: '2.3.x'
+        fastdds-python-branch: '2.2.x'
+        discovery-server-branch: 'v2.0.0'
+        run-build: true
+        run-tests: true
+        use-ccache: false
+
   nightly-ubuntu-ci-3_3_x:
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR does the following:
- Removes 4.0.x backport
- Removes 2.5.x backport
- Adds a new nightly for Fast DDS 3.2.x using Fast DDS Gen 4.1.x.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.5.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- N/A New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
