### PR TITLE
[23702] Remove support for `@feed` annotations

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -59,6 +59,14 @@ on:
         required: false
         type: boolean
         default: false
+      blacklist_idls:
+        description: 'Comma-separated list of tests to be blacklisted'
+        required: false
+        type: string
+        default: 'interfaces,interfaces_2'
+env:
+    blacklist_tests: ${{ inputs.run-tests && inputs.blacklist_idls }}
+    gradle-test-flags: ${{ inputs.blacklist_idls && format('-Dblacklist_tests={0}', inputs.blacklist_idls) }}
 defaults:
   run:
     shell: bash
@@ -220,11 +228,27 @@ jobs:
         run: |
           source ${{ github.workspace }}/install/local_setup.bash
           cd ${{ github.workspace }}/src/fastddsgen
-          ./gradlew test
+          ./gradlew test ${{ env.gradle-test-flags }}
 
       - name: Test fastddsgen with python arg
         if: ${{ inputs.run-tests == true }}
         run: |
           source ${{ github.workspace }}/install/local_setup.bash
           cd ${{ github.workspace }}/src/fastddsgen/thirdparty/dds-types-test/IDL
-          find . -path "*.idl*" -exec fastddsgen -python {} +
+          # Example: blacklist_tests='file1,file1'
+          IFS=',' read -r -a BL <<< "${{ env.blacklist_tests }}"
+          
+          # Build exclusion: ! ( -name file1.idl -o -name file2.idl )
+          EXCL=()
+          for f in "${BL[@]}"; do
+            [[ -n "$f" ]] && EXCL+=(-name "${f}.idl" -o)
+          done
+          # Drop trailing -o if present
+          ((${#EXCL[@]})) && unset 'EXCL[${#EXCL[@]}-1]'
+          
+          # Run find: match *.idl files, exclude blacklist, and batch fastddsgen calls
+          if ((${#EXCL[@]})); then
+            find . -type f -name '*.idl' ! \( "${EXCL[@]}" \) -exec fastddsgen -python {} +
+          else
+            find . -type f -name '*.idl' -exec fastddsgen -python {} +
+          fi

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Interface.java
@@ -17,6 +17,7 @@ package com.eprosima.fastdds.idl.grammar;
 import com.eprosima.fastdds.idl.grammar.Operation;
 import com.eprosima.fastdds.idl.parser.typecode.EnumTypeCode;
 import com.eprosima.fastdds.idl.parser.typecode.StructTypeCode;
+import com.eprosima.idl.parser.exception.ParseException;
 import com.eprosima.idl.parser.typecode.Member;
 import com.eprosima.idl.parser.typecode.EnumMember;
 import com.eprosima.idl.parser.typecode.TypeCode.ExtensibilityKind;
@@ -40,7 +41,7 @@ public class Interface extends com.eprosima.idl.parser.tree.Interface
             Operation op = (Operation)exp;
             if (op.isAnnotationFeed())
             {
-                m_hasOutputFeeds = true;
+                throw new ParseException(null, "Support for result feeds is part of Fast DDS Pro");
             }
 
             if (op.getOutputparam().size() > 0)

--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Operation.java
@@ -84,9 +84,7 @@ public class Operation extends com.eprosima.idl.parser.tree.Operation
             }
             else
             {
-                // Take note that there is at least one input feed
-                m_context.inputFeedAdded(p);
-                m_hasInputFeeds = true;
+                throw new ParseException(null, "Support for input feeds is part of Fast DDS Pro");
             }
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Support for `@feed` will be part of Fast DDS Pro.

Depends on:
* https://github.com/eProsima/dds-types-test/pull/47
* https://github.com/eProsima/Fast-DDS/pull/6052
* https://github.com/eProsima/Fast-DDS-python/pull/256

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/1135
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
