### PR TITLE
[24345] Set default values before deserialize

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -117,6 +117,18 @@ eProsima_user_DllExport void deserialize(
     using namespace $struct.namespace$;
     $endif$
 
+    $struct.allMembers : { member |
+    $if(member.annotationDefault)$
+    data.$member.name$({$member.annotationDefaultValue$\});
+    $elseif(!member.annotationOptional && !member.annotationExternal)$
+    $if(member.typecode.initialValue)$
+    data.$member.name$({$member.typecode.initialValue$\});
+    $elseif(member.typecode.isStringType || member.typecode.isWStringType)$
+    data.$member.name$({\});
+    $endif$
+    $endif$
+    }; separator="\n"$
+
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             $if(struct.annotationFinal)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2$elseif(struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2$endif$ :
             $if(struct.annotationFinal || struct.annotationAppendable)$eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR$elseif(struct.annotationMutable)$eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR$endif$,

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -120,7 +120,9 @@ eProsima_user_DllExport void deserialize(
     $struct.allMembers : { member |
     $if(member.annotationDefault)$
     data.$member.name$({$member.annotationDefaultValue$\});
-    $elseif(!member.annotationOptional && !member.annotationExternal)$
+    $elseif(member.annotationOptional)$
+    data.$member.name$().reset();
+    $elseif(!member.annotationExternal)$
     $if(member.typecode.initialValue)$
     data.$member.name$({$member.typecode.initialValue$\});
     $elseif(member.typecode.isStringType || member.typecode.isWStringType)$


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

Set default values before deserialize
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 4.2.x 4.0.x 3.3.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
