### PR TITLE
[24377] Set Fast DDS version 3.5 as EOL

### DIFF
--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -10,6 +10,7 @@ Please, refer to the [master branch](https://github.com/eProsima/Fast-DDS-Gen/bl
 
 |Fast DDS Version|Fast DDS-Gen Version|Fast DDS-Gen Version branch|Fast DDS-Gen Latest Release|
 |----------------|--------------------|---------------------------|---------------------------|
+|3.6|4.3|[4.3.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.3.x)|[v4.3.0](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.3.0)|
 |3.4|4.2|[4.2.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.2.x)|[v4.2.0](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.2.0)|
 |3.2|4.0|[4.0.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.0.x)|[v4.0.5](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.0.5)|
 |2.14|3.3|[3.3.x](https://github.com/eProsima/Fast-DDS-Gen/tree/3.3.x)|[v3.3.1](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v3.3.1)|
@@ -19,6 +20,7 @@ Please, refer to the [master branch](https://github.com/eProsima/Fast-DDS-Gen/bl
 
 |Fast DDS Version|Fast DDS-Gen Version|Fast DDS-Gen Version branch|Fast DDS-Gen Latest Release|Release Date|EOL Date|
 |----------------|----------------|-----------------------|-----------------------|------------|--------|
+|3.5|4.3|[4.3.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.3.x)|[v4.3.0](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.3.0)|February 2026|March 2026|
 |3.3|4.1|[4.1.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.1.x)|[v4.1.1](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.1.1)|July 2025|January 2026|
 |3.1|4.0|[4.0.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.0.x)|[v4.0.4](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.0.4)|August 2024|February 2025|
 |3.0|4.0|[4.0.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.0.x)|[v4.0.3](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.0.3)|August 2024|February 2025|


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->


This PR does all the work necessary in the repo to mark version 3.5 as EOL.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.2.x 4.0.x 3.3.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: Check CI results: changes do not issue any warning.
- _N/A_: Check CI results: failing tests are unrelated with the changes.
