### PR TITLE
Upgrade Gradle wrapper from 7.6 to 8.5 for Java 21 support

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Problem

Building Fast-DDS-Gen on systems where Java 21 is the default JDK fails immediately:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'fastddsgen'.
> Could not open proj generic class cache for build file '.../build.gradle'
  > BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_'
    Unsupported class file major version 65
```

Class file major version 65 corresponds to Java 21. Gradle 7.6 (the current wrapper version) supports Java up to version 19 only.

Java 21 is an LTS release (September 2023) and is now the default JDK on many systems, including those installed via `brew install openjdk`, `apt install default-jdk`, and the current Microsoft/Amazon/Eclipse Temurin distributions.

## Fix

Upgrade the Gradle wrapper to **8.5**, which added official Java 21 support. The `build.gradle` already compiles to Java 8 bytecode (`sourceCompatibility = targetCompatibility = 1.8`), so the produced `fastddsgen.jar` remains compatible with any Java 8+ runtime.

```
# gradle/wrapper/gradle-wrapper.properties
- distributionUrl=...gradle-7.6-bin.zip
+ distributionUrl=...gradle-8.5-bin.zip
```

## Dependency

This PR depends on **eProsima/IDL-Parser#192**, which replaces the deprecated `Jar.classifier` property (removed in Gradle 7.0) with `archiveClassifier`. Without that fix, the IDL-Parser submodule fails to configure under Gradle 7+:

```
Could not set unknown property 'classifier' for task ':idl-parser:sourceJar'
of type org.gradle.api.tasks.bundling.Jar.
```

## Testing

- **Platform:** macOS 15 Sequoia, Apple Silicon (arm64)  
- **Java:** OpenJDK 21 (default), build performed with OpenJDK 17 as intermediate step before this fix was confirmed  
- After both this change and IDL-Parser#192: `./gradlew assemble` completes successfully with Java 21
- `java -jar share/fastddsgen/java/fastddsgen.jar -version` → `fastddsgen version 4.2.0`