### PR TITLE
[24612] Changes after fastcdr branch-out to 2.4.x

### DIFF
--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -20,7 +20,7 @@ jobs:
       label: 'nightly-ubuntu-ci-master'
       fastddsgen-branch: 'master'
       fastdds-branch: 'master'
-      fastcdr-branch: 'master'
+      fastcdr-branch: '2.3.x'
       fastdds-python-branch: 'master'
       discovery-server-branch: 'master'
       run-build: true
@@ -78,7 +78,7 @@ jobs:
           - 'openjdk-17-jdk'
         fastcdr-branch:
           - '1.1.x'
-          - '2.x'
+          - '2.3.x'
     uses: eProsima/Fast-DDS-Gen/.github/workflows/reusable-ubuntu-ci.yml@3.3.x
     with:
       os-version: 'ubuntu-22.04'

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -28,7 +28,7 @@ on:
         description: 'Branch or tag of Fast CDR repository'
         required: false
         type: string
-        default: 'master'
+        default: '2.3.x'
       fastdds-python-branch:
         description: 'Branch or tag of Fast DDS Python repository'
         required: false

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -16,7 +16,7 @@ on:
         description: 'Branch or tag of Fast CDR repository'
         required: false
         type: string
-        default: 'master'
+        default: '2.3.x'
       fastdds-python-branch:
         description: 'Branch or tag of Fast DDS Python repository'
         required: false
@@ -69,7 +69,7 @@ jobs:
       label: 'ubuntu-ci-${{ matrix.java-version }}'
       fastddsgen-branch: ${{ inputs.fastddsgen-branch || github.ref }}
       fastdds-branch: ${{ inputs.fastdds-branch || 'master' }}
-      fastcdr-branch: ${{ inputs.fastcdr-branch || 'master' }}
+      fastcdr-branch: ${{ inputs.fastcdr-branch || '2.3.x' }}
       fastdds-python-branch: ${{ inputs.fastdds-python-branch || 'master' }}
       discovery-server-branch: ${{ inputs.discovery-server-branch || 'master' }}
       run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This performs the necessary changes to fix Fast CDR to 2.3.x.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.2.x 4.0.x 3.3.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
