### PR TITLE
[24136] Mark 4.2.x as EOL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 4.2.x 4.0.x 3.3.x 2.1.x -->
+<!-- @Mergifyio backport 4.0.x 3.3.x 2.1.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -27,27 +27,6 @@ jobs:
       run-tests: true
       use-ccache: false
 
-  nightly-ubuntu-ci-4_2_x-fast-3_4_x:
-      strategy:
-        fail-fast: false
-        matrix:
-          java-version:
-            - 'openjdk-11-jdk'
-            - 'openjdk-17-jdk'
-      uses: eProsima/Fast-DDS-Gen/.github/workflows/reusable-ubuntu-ci.yml@4.2.x
-      with:
-        os-version: 'ubuntu-22.04'
-        java-version: ${{ matrix.java-version }}
-        label: 'nightly-ubuntu-ci-4.2.x-3.4.x'
-        fastddsgen-branch: '4.2.x'
-        fastdds-branch: '3.4.x'
-        fastcdr-branch: '2.3.x'
-        fastdds-python-branch: '2.4.x'
-        discovery-server-branch: 'v2.0.0'
-        run-build: true
-        run-tests: true
-        use-ccache: false
-
   nightly-ubuntu-ci-4_0_x-fast-3_2_x:
       strategy:
         fail-fast: false

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -1,6 +1,5 @@
 # Release support
 
-
 Please, refer to the [master branch](https://github.com/eProsima/Fast-DDS-Gen/blob/master/RELEASE_SUPPORT.md) for the latest version of this document.
 
 *eProsima Fast DDS-Gen* maintains several releases with different support cycles.
@@ -11,7 +10,6 @@ Please, refer to the [master branch](https://github.com/eProsima/Fast-DDS-Gen/bl
 |Fast DDS Version|Fast DDS-Gen Version|Fast DDS-Gen Version branch|Fast DDS-Gen Latest Release|
 |----------------|--------------------|---------------------------|---------------------------|
 |3.6|4.3|[4.3.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.3.x)|[v4.3.0](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.3.0)|
-|3.4|4.2|[4.2.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.2.x)|[v4.2.0](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.2.0)|
 |3.2|4.0|[4.0.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.0.x)|[v4.0.5](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.0.5)|
 |2.14|3.3|[3.3.x](https://github.com/eProsima/Fast-DDS-Gen/tree/3.3.x)|[v3.3.1](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v3.3.1)|
 |2.6|2.1|[2.1.x](https://github.com/eProsima/Fast-DDS-Gen/tree/2.1.x)|[v2.1.3](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v2.1.3)|
@@ -21,6 +19,7 @@ Please, refer to the [master branch](https://github.com/eProsima/Fast-DDS-Gen/bl
 |Fast DDS Version|Fast DDS-Gen Version|Fast DDS-Gen Version branch|Fast DDS-Gen Latest Release|Release Date|EOL Date|
 |----------------|----------------|-----------------------|-----------------------|------------|--------|
 |3.5|4.3|[4.3.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.3.x)|[v4.3.0](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.3.0)|February 2026|March 2026|
+|3.4|4.2|[4.2.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.2.x)|[v4.2.1](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.2.1)|October 2025|June 2026|
 |3.3|4.1|[4.1.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.1.x)|[v4.1.1](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.1.1)|July 2025|January 2026|
 |3.1|4.0|[4.0.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.0.x)|[v4.0.4](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.0.4)|August 2024|February 2025|
 |3.0|4.0|[4.0.x](https://github.com/eProsima/Fast-DDS-Gen/tree/4.0.x)|[v4.0.3](https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v4.0.3)|August 2024|February 2025|


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

After the EOL of Fast DDS 3.4.x, Fast DDS Gen 4.2.x can go EOL.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.2.x 4.0.x 3.3.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#1273
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: Check CI results: changes do not issue any warning.
- _N/A_: Check CI results: failing tests are unrelated with the changes.
