### PR TITLE
[25469] Improve generated header guards

### DIFF
--- a/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastdds/idl/grammar/Context.java
@@ -309,6 +309,12 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     {
         super.addTypeDeclaration(typedecl);
 
+        String scope = typedecl.getScope();
+        if (scope != null && !scope.isEmpty())
+        {
+            last_declaration_scope_ = scope;
+        }
+
         boolean is_nested = typedecl.isAnnotatedAsNested();
 
         if (typedecl.getTypeCode().getKind() == Kind.KIND_STRUCT && typedecl.isInScope() && !is_nested)
@@ -626,15 +632,28 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
 
     public String getHeaderGuardName ()
     {
-        if (m_lastStructure != null)
+        String decl_scope = null;
+        if ((m_lastStructure != null) && m_lastStructure.getHasScope())
         {
-            if (m_lastStructure.getHasScope())
-            {
-                return m_lastStructure.getScope().replaceAll("::", "_").toUpperCase() +
-                       "_" + m_fileNameUpper.replaceAll("\\.", "_");
-            }
+            decl_scope = m_lastStructure.getScope().replaceAll("::", "_");
         }
-        return m_fileNameUpper;
+        else if (last_declaration_scope_ != null && !last_declaration_scope_.isEmpty())
+        {
+            decl_scope = last_declaration_scope_.replaceAll("::", "_");
+        }
+
+        String guard_base = getScopeFile().replaceAll("/", "__").replaceAll("\\\\", "__");
+        if (decl_scope != null && !decl_scope.isEmpty())
+        {
+            guard_base = guard_base + "_" + decl_scope;
+        }
+        return getValidGuardName(guard_base);
+    }
+
+    private String getValidGuardName(
+            String value)
+    {
+        return value.toUpperCase().replaceAll("[^A-Z0-9_]", "_");
     }
 
     public String getM_lastStructureTopicDataTypeName()
@@ -778,4 +797,6 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     protected boolean there_is_at_least_one_struct = false;
 
     protected boolean there_is_at_least_one_union = false;
+
+    protected String last_declaration_scope_ = null;
 }

--- a/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
+++ b/src/test/java/com/eprosima/fastdds/FastDDSGenTest.java
@@ -2,7 +2,9 @@ package test.com.eprosima.fastdds;
 
 import org.junit.jupiter.api.Test;
 
+import com.eprosima.fastdds.idl.grammar.Context;
 import com.eprosima.idl.generator.manager.TemplateManager;
+import com.eprosima.idl.parser.tree.TypeDeclaration;
 
 import com.eprosima.integration.Command;
 
@@ -99,6 +101,82 @@ public class FastDDSGenTest
 
             assertEquals("testing/", ctx.getRelativeDir(absolute_root_dir));
         }
+    }
+
+
+    @Test
+    public void Context_getHeaderGuardName_UsesFilePath_Test()
+    {
+        Context first_ctx = new Context(
+                new TemplateManager(),
+                "idl\\package_one\\common\\status_list.idl",
+                new ArrayList<String>(),
+                false,
+                false,
+                null,
+                false,
+                false,
+                false,
+                false);
+        Context second_ctx = new Context(
+                new TemplateManager(),
+                "idl/package_two/common/status_list.idl",
+                new ArrayList<String>(),
+                false,
+                false,
+                null,
+                false,
+                false,
+                false,
+                false);
+        Context third_ctx = new Context(
+                new TemplateManager(),
+                "idl/package_two/common/status/list.idl",
+                new ArrayList<String>(),
+                false,
+                false,
+                null,
+                false,
+                false,
+                false,
+                false);
+
+        assertEquals(
+                "IDL__PACKAGE_ONE__COMMON__STATUS_LIST_IDL",
+                first_ctx.getHeaderGuardName());
+        assertEquals(
+                "IDL__PACKAGE_TWO__COMMON__STATUS_LIST_IDL",
+                second_ctx.getHeaderGuardName());
+        assertEquals(
+                "IDL__PACKAGE_TWO__COMMON__STATUS__LIST_IDL",
+                third_ctx.getHeaderGuardName());
+    }
+
+    @Test
+    public void Context_getHeaderGuardName_DependsOnDeclarations_Test()
+    {
+        Context ctx = new Context(
+                new TemplateManager(),
+                "dir-one/impl-type.idl",
+                new ArrayList<String>(),
+                false,
+                false,
+                null,
+                false,
+                false,
+                false,
+                false);
+        TypeDeclaration typedecl = new TypeDeclaration(
+                ctx.getScopeFile(),
+                true,
+                "module::scope",
+                "ScopedType",
+                ctx.createAliasTypeCode("module::scope", "ScopedType"),
+                null);
+
+        ctx.addTypeDeclaration(typedecl);
+
+        assertEquals("DIR_ONE__IMPL_TYPE_IDL_MODULE_SCOPE", ctx.getHeaderGuardName());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

* Header guards should not include characters other than capital letters, numbers, and underscores.
* IDL files with the same name in different folders should have different header guards
* For the use case of separate invocations of fastddsgen from different folders, where two different IDL files could have the same relative path, take into account the namespace of the last declared structure, or the namespace of the last declaration.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 4.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
