### PR TITLE
Fix SWIG syntax error on maps

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg
@@ -206,7 +206,7 @@ $if(member.typecode.isSequenceType)$
 $template_sequence(member.typecode)$
 $elseif(member.typecode.isMapType)$
 %ignore $struct_name$::$member.name$() const;
-%template($member.typecode.keyTypeCode.cppTypename$_$member.typecode.valueTypeCode.noScopedCppTypename$_map) std::map<$if(member.typecode.keyTypeCode.isEnumType)$enum $endif$$member.typecode.keyTypeCode.cppTypename$,$if(member.typecode.valueTypeCode.isEnumType)$enum $endif$$member.typecode.valueTypeCode.cppTypename$>;
+%template($member.typecode.keyTypeCode.noScopedCppTypename$_$member.typecode.valueTypeCode.noScopedCppTypename$_map) std::map<$if(member.typecode.keyTypeCode.isEnumType)$enum $endif$$member.typecode.keyTypeCode.cppTypename$,$if(member.typecode.valueTypeCode.isEnumType)$enum $endif$$member.typecode.valueTypeCode.cppTypename$>;
 $elseif(member.typecode.isType_f)$
 %ignore $struct_name$::$member.name$() const;
 %template($member.typecode.contentTypeCode.noScopedCppTypename$_$member.typecode.evaluatedDimensions$_array) std::array<$if(member.typecode.contentTypeCode.isEnumType)$enum $endif$$member.typecode.contentTypeCode.cppTypename$,$member.typecode.evaluatedDimensions$>;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

When generating Python (SWIG) bindings for an IDL struct member of type `map<K, V>`, `fastddsgen` builds the `%template(...)` instantiation name by concatenating the **key** type's fully-qualified C++ typename with the **value** type's unqualified name. If the key type's C++ name contains a scope-resolution operator (`::`) — which `string` always does, since it maps to `std::string` — the generated identifier is invalid SWIG syntax and SWIG fails to parse the file.

### Root cause

`src/main/java/com/eprosima/fastcdr/idl/templates/TypesSwigInterface.stg`,
rule `member_getters`, map branch:

```stg
$elseif(member.typecode.isMapType)$
%ignore $struct_name$::$member.name$() const;
%template($member.typecode.keyTypeCode.cppTypename$_$member.typecode.valueTypeCode.noScopedCppTypename$_map) std::map<...>;
```

The value type correctly calls .noScopedCppTypename (namespace
stripped). The key type uses plain .cppTypename (fully qualified) —
that's the bug. Every other collection/composite branch in this same file
(sequences, arrays, optionals, fixed strings, the RPC template family)
consistently uses a sanitized name (noScopedCppTypename or
formatedCppTypename); this is the only branch that doesn't.


### Reproduction

Given an IDL like:

```
struct SomeipServiceEntry {
  SomeipServiceAvailability availability;
  uint32 last_changed;
};

typedef map<string, SomeipServiceEntry> SomeipServiceEntryByName;

struct SomeipServiceStatus {
  SomeipServiceEntryByName services;
};
```

fastddsgen -python generates, in the corresponding .i file:

```
%template(std::string_SomeipServiceEntry_map) std::map<std::string,SomeipServiceEntry>;
```

Compiling this with SWIG fails:

```
SomeipServiceStatus.i:185: Error: Syntax error in input(1).
```
SWIG parses :: as C++ scope resolution, so std::string_SomeipServiceEntry_map
is not a valid template-instantiation identifier.

### Fix

Using 

```
%template($member.typecode.keyTypeCode.noScopedCppTypename$_$member.typecode.valueTypeCode.noScopedCppTypename$_map) std::map<...>;
```
instead of 

```
%template($member.typecode.keyTypeCode.cppTypename$_$member.typecode.valueTypeCode.noScopedCppTypename$_map) std::map<...>;
```

produces a clean identifier:

```
%template(string_SomeipServiceEntry_map) std::map<std::string,SomeipServiceEntry>;
```
which SWIG parses without error.

### Why this only affects map, not sequence/array 

Sequences and arrays only ever need a name for their single content type, and both branches already use noScopedCppTypename for it. map is the only collection type with a second, independent type parameter (the key), and it was the one spot where the unqualified variant wasn't used. Any map whose key type has a qualified C++ name — string (→ std::string), or an enum key — triggers this; maps keyed by a plain scalar (int32, etc.) don't hit it, since those types have no :: in their C++ name to begin with.


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport pro/4.3.x -->

<!--
    In case of a bug fix that should be backported to Fast DDS Gen basic, please add the label `move-to-basic`.
-->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a bug fix that needs to be backported to Fast DDS Gen basic, the corresponding label has been added.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.0.x 3.3.x 2.1.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
