### PR TITLE
[25536] Fix some warnings in generated code (backport #593)

### DIFF
--- a/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
+++ b/src/main/java/com/eprosima/fastcdr/idl/templates/FastCdrCommon.stg
@@ -62,7 +62,7 @@ member_array_cstring_destructor(ctx, name, loopvar, dims) ::= <<$if(rest(dims))$
 
 member_default_init(member) ::= <%
 $if(member.annotationDefault)$
- {$member.annotationDefaultValue$}
+ {$member.annotationDefaultValue$$if(member.typecode.isType_5)$f$endif$}
 $elseif(!member.annotationOptional && !member.annotationExternal)$
 $if(member.typecode.initialValue)$
  {$member.typecode.initialValue$}

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -124,7 +124,7 @@ eProsima_user_DllExport void deserialize(
     data.$member.name$().reset();
     $elseif(!member.annotationExternal)$
     $if(member.typecode.initialValue)$
-    data.$member.name$({$member.typecode.initialValue$\});
+    data.$member.name$($member.typecode.initialValue$);
     $elseif(member.typecode.isStringType || member.typecode.isWStringType)$
     data.$member.name$({\});
     $endif$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -119,7 +119,7 @@ eProsima_user_DllExport void deserialize(
 
     $struct.allMembers : { member |
     $if(member.annotationDefault)$
-    data.$member.name$({$member.annotationDefaultValue$\});
+    data.$member.name$({$member.annotationDefaultValue$$if(member.typecode.isType_5)$f$endif$\});
     $elseif(member.annotationOptional)$
     data.$member.name$().reset();
     $elseif(!member.annotationExternal)$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -119,7 +119,7 @@ eProsima_user_DllExport void deserialize(
 
     $struct.allMembers : { member |
     $if(member.annotationDefault)$
-    data.$member.name$({$member.annotationDefaultValue$$if(member.typecode.isType_5)$f$endif$\});
+    data.$member.name$($member.annotationDefaultValue$$if(member.typecode.isType_5)$f$endif$);
     $elseif(member.annotationOptional)$
     data.$member.name$().reset();
     $elseif(!member.annotationExternal)$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/TypesCdrAuxHeaderImpl.stg
@@ -124,7 +124,7 @@ eProsima_user_DllExport void deserialize(
     data.$member.name$().reset();
     $elseif(!member.annotationExternal)$
     $if(member.typecode.initialValue)$
-    data.$member.name$($member.typecode.initialValue$);
+    data.$member.name$($with_braces_if_array(member, member.typecode.initialValue)$);
     $elseif(member.typecode.isStringType || member.typecode.isWStringType)$
     data.$member.name$({\});
     $endif$

--- a/src/main/java/com/eprosima/fastdds/idl/templates/eprosima.stg
+++ b/src/main/java/com/eprosima/fastdds/idl/templates/eprosima.stg
@@ -235,3 +235,11 @@ wstring_name(wstring) ::= <<
 anonymous_wstring_$if(wstring.isBounded)$$wstring.evaluatedMaxsize$$else$unbounded$endif$
 >>
 //}
+
+with_braces_if_array(member, value) ::= <%
+$if(member.typecode.isArrayType)$
+{$value$}
+$else$
+$value$
+$endif$
+%>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This is a manual backport of #593. It is basically a rebase of its branch removing the commit that updates the IDL parser submodule.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS-Gen developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Fast-DDS-docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
